### PR TITLE
Generate C File only when ALLOW_CREATION_OF_EOS_CONFIG_AS_C_FILE is enabled

### DIFF
--- a/Assets/Plugins/Source/Editor/EpicOnlineServicesConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/EpicOnlineServicesConfigEditor.cs
@@ -151,7 +151,9 @@ extern ""C"" __declspec(dllexport) char*  __stdcall GetConfigAsJSONString()
         string generatedCFile = GenerateEOSGeneratedFile(currentEOSConfig);
 
         File.WriteAllText(GetConfigPath(), configDataAsJSON);
+#if ALLOW_CREATION_OF_EOS_CONFIG_AS_C_FILE
         File.WriteAllText(Path.Combine(eosGeneratedCFilePath, "EOSGenerated.c"), generatedCFile);
+#endif
         AssetDatabase.SaveAssets();
         AssetDatabase.Refresh();
     }


### PR DESCRIPTION
Currently, if you do not enable `ALLOW_CREATION_OF_EOS_CONFIG_AS_C_FILE`, the C file will be created directly under current directory path.