### PR TITLE
fix: Fixed EOSFriendsManager.GetDisplayName cached friends dictionary lookup

### DIFF
--- a/Assets/Scripts/EOSFriendsManager.cs
+++ b/Assets/Scripts/EOSFriendsManager.cs
@@ -127,14 +127,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return new EpicAccountId();
         }
 
-        public string GetDisplayName(EpicAccountId targetUserId)
+        public string GetDisplayName(EpicAccountId targetAccountId)
         {
-            foreach (FriendData friendData in CachedFriends.Values)
+            if(CachedFriends.TryGetValue( targetAccountId, out FriendData friend ))
             {
-                if (targetUserId == friendData.UserProductUserId)
-                {
-                    return friendData.Name;
-                }
+                return friend.Name;
             }
 
             return string.Empty;


### PR DESCRIPTION
**EOSFriendsManager.GetDisplayName** currently compares a given user's **EpicAccountId** against each cached friend's **ProductUserId**, meaning the function won't ever find the friend in question. This PR fixes that behavior by using the given user's **EpicAccountId** as the key into the cached friends dictionary (mapped by **EpicAccountId**) to find the friend in question.