### PR TITLE
EOSConfig -> ScriptableObject & fix Windows Standalone build

### DIFF
--- a/Assets/Plugins/EOSConfig.cs
+++ b/Assets/Plugins/EOSConfig.cs
@@ -29,8 +29,8 @@ namespace PlayEveryWare.EpicOnlineServices
     /// <summary>
     /// Represents the EOS Configuration used for initializing EOS SDK.
     /// </summary>
-    [Serializable]
-    public class EOSConfig
+    [CreateAssetMenu(fileName = "EOS Config File", menuName = "Epic Online Services/Create Config File")]
+    public class EOSConfig : ScriptableObject
     {
         /// <value><c>Product Name</c> defined in the [Development Portal](https://dev.epicgames.com/portal/)</value>
         public string productName;


### PR DESCRIPTION
Please use this.

EOSConfig turns to Scriptable Object mean the config now can be created and placed anywhere in the project, not just Streaming Asset Folder, and do not need to be found by path. Just create one and put in the EOSManager.

Also add a fix so that Window Standalone Build can now create Platform.