### PR TITLE
fix: set LibraryName when using EOS_DISABLE directive

### DIFF
--- a/Assets/Plugins/Source/EOS_SDK/Core/Config.cs
+++ b/Assets/Plugins/Source/EOS_SDK/Core/Config.cs
@@ -88,6 +88,7 @@ namespace Epic.OnlineServices
 
 		#elif EOS_DISABLE
 			#warning Disabling EOS
+            "EOSSDK-Disabled"
 
 		#else
 			#error Unable to determine the name of the EOSSDK library. Ensure you have set the correct EOS compilation symbol for the current platform, such as EOS_PLATFORM_WINDOWS_32 or EOS_PLATFORM_WINDOWS_64, so that the correct EOSSDK library can be targeted.


### PR DESCRIPTION
LibraryName wasn't being set when EOS_DISABLE was active, resulting in a syntax error.