### PR TITLE
fix: EOSPluginEditorConfiguration/eos_plugin_packaging_config.json not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ test-results/
 
 *IL2CPPCache/*
 *IL2CPPStats/*
+EOSPluginEditorConfiguration/

--- a/Assets/Plugins/Source/Editor/EOSConfigFile.cs
+++ b/Assets/Plugins/Source/Editor/EOSConfigFile.cs
@@ -68,6 +68,11 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 var configDataAsJSON = JsonUtility.ToJson(currentEOSConfig, prettyPrint);
 
+                // If this is the first time we are saving the config, we need to create the directory
+                // If the directory already exists this will do nothing
+                System.IO.FileInfo file = new System.IO.FileInfo(configFilenamePath);
+                file.Directory.Create();
+                
                 File.WriteAllText(configFilenamePath, configDataAsJSON);
             }
             AssetDatabase.SaveAssets();


### PR DESCRIPTION
- Fix directory not found when using a fresh copy of the project and attempting to build the upm package
- gitignore EOSPluginEditorConfiguration

Fixes #145 