### PR TITLE
fix: invalid IntPtr Null check

### DIFF
--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -91,7 +91,7 @@ namespace PlayEveryWare.EpicOnlineServices
         {
             set
             {
-                if(m_OverrideLibraryPath != null)
+                if(m_OverrideLibraryPath != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(m_OverrideLibraryPath);
                 }
@@ -114,7 +114,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public void Dispose()
         {
-            if (m_OverrideLibraryPath != null)
+            if (m_OverrideLibraryPath != IntPtr.Zero)
             {
                 Marshal.FreeHGlobal(m_OverrideLibraryPath);
             }
@@ -294,7 +294,7 @@ static string SteamDllName = "steam_api.dll";
 
                 string SteamDllVersion = DLLHandle.GetVersionForLibrary(SteamDllName);
 
-                if (steamIntegratedPlatform.m_OverrideLibraryPath != null)
+                if (steamIntegratedPlatform.m_OverrideLibraryPath != IntPtr.Zero)
                 {
                     SteamOptionsGCHandle = GCHandle.Alloc(steamIntegratedPlatform, GCHandleType.Pinned);
                     integratedPlatforms[0].InitOptions = SteamOptionsGCHandle.AddrOfPinnedObject();

--- a/Assets/Plugins/Windows/EOSManager_Windows.cs
+++ b/Assets/Plugins/Windows/EOSManager_Windows.cs
@@ -91,7 +91,7 @@ namespace PlayEveryWare.EpicOnlineServices
         {
             set
             {
-                if(m_OverrideLibraryPath != null)
+                if(m_OverrideLibraryPath != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(m_OverrideLibraryPath);
                 }
@@ -114,7 +114,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public void Dispose()
         {
-            if (m_OverrideLibraryPath != null)
+            if (m_OverrideLibraryPath != IntPtr.Zero)
             {
                 Marshal.FreeHGlobal(m_OverrideLibraryPath);
             }

--- a/Assets/Plugins/Windows/EOSManager_Windows.cs
+++ b/Assets/Plugins/Windows/EOSManager_Windows.cs
@@ -293,7 +293,7 @@ static string SteamDllName = "steam_api.dll";
 
                     string SteamDllVersion = DLLHandle.GetVersionForLibrary(SteamDllName);
 
-                    if (steamIntegratedPlatform.m_OverrideLibraryPath != null)
+                    if (steamIntegratedPlatform.m_OverrideLibraryPath != IntPtr.Zero)
                     {
                         SteamOptionsGCHandle = GCHandle.Alloc(steamIntegratedPlatform, GCHandleType.Pinned);
                         integratedPlatforms[0].InitOptions = SteamOptionsGCHandle.AddrOfPinnedObject();


### PR DESCRIPTION
fix: invalid IntPtr Null check

`m_OverrideLibraryPath != null` was casuing the following error using warning level 5 and warnaserrors enabled:
```
error CS8073: The result of the expression is always 'true' since a value of type 'IntPtr' is never equal to 'null' of type 'IntPtr?'
```