### PR TITLE
fix: EOSbootstrapper and EAC binary install when building from plugin

### DIFF
--- a/Assets/Plugins/Source/Editor/EOSPluginEditorConfig.cs
+++ b/Assets/Plugins/Source/Editor/EOSPluginEditorConfig.cs
@@ -91,11 +91,25 @@ namespace PlayEveryWare.EpicOnlineServices
         void IEOSPluginEditorConfigurationSection.OnGUI()
         {
             string pathToSigntool = EmptyPredicates.NewIfNull(configFile.currentEOSConfig.pathToSignTool);
+            string pathToEACCertificate = EmptyPredicates.NewIfNull(configFile.currentEOSConfig.pathToEACCertificate);
+            string pathToEACPublicKey = EmptyPredicates.NewIfNull(configFile.currentEOSConfig.pathToEACPublicKey);
             EpicOnlineServicesConfigEditor.AssigningTextField("Path to signtool", ref pathToSigntool);
+            EpicOnlineServicesConfigEditor.AssigningTextField("Path to EAC public key", ref pathToEACPublicKey);
+            EpicOnlineServicesConfigEditor.AssigningTextField("Path to EAC Certificate", ref pathToEACCertificate);
 
             if (pathToSigntool.Length != 0)
             {
                 configFile.currentEOSConfig.pathToSignTool = pathToSigntool;
+            }
+
+            if (pathToEACPublicKey.Length != 0)
+            {
+                configFile.currentEOSConfig.pathToEACPublicKey = pathToEACPublicKey;
+            }
+
+            if (pathToEACCertificate.Length != 0)
+            {
+                configFile.currentEOSConfig.pathToEACCertificate = pathToEACCertificate;
             }
         }
 
@@ -419,6 +433,8 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <value><c>Path To signtool</c> The path to find the tool used for signing binaries</value>
         public string pathToSignTool;
         public string pathToDefaultCertificate;
+        public string pathToEACPublicKey;
+        public string pathToEACCertificate;
 
         public EOSPluginEditorToolsConfig Clone()
         {

--- a/Assets/Plugins/Windows/Editor/EOSOnPostprocessBuild_Windows.cs
+++ b/Assets/Plugins/Windows/Editor/EOSOnPostprocessBuild_Windows.cs
@@ -107,7 +107,7 @@ public class EOSOnPostprocessBuild_Windows:  IPostprocessBuildWithReport
         string appFilenameExe = Path.GetFileName(report.summary.outputPath);
         string installDirectory = Path.GetDirectoryName(report.summary.outputPath);
         string installPathForEOSBootStrapper = Path.Combine(installDirectory, "EOSBootStrapper.exe");
-        string workingDirectory = Path.Combine(Application.dataPath, "../bin/");
+        string workingDirectory = GetPathToEOSBin();
         string bootStrapperArgs = ""
            + " --output-path " + "\"" + installPathForEOSBootStrapper + "\""
            + " --app-path "  + "\"" + appFilenameExe + "\""
@@ -304,11 +304,24 @@ public class EOSOnPostprocessBuild_Windows:  IPostprocessBuildWithReport
 
             InstallFiles(report);
             
-            string pathToEOSBootStrapperTool = GetPathToEOSBin() + "/EOSBootstrapperTool.exe";
-            string pathToEOSBootStrapper = GetPathToEOSBin() + "/EOSBootStrapper.exe";
-            string pathToEACIntegrityTool = GetPathToEOSBin() + "/EAC/anticheat_integritytool.exe";
+            string pathToEOSBootStrapperTool = Path.Combine(GetPathToEOSBin(), "EOSBootstrapperTool.exe");
+            string pathToEOSBootStrapper = Path.Combine(GetPathToEOSBin(), "EOSBootStrapper.exe");
+            string pathToEACIntegrityTool = Path.Combine(GetPathToEOSBin(), "EAC/anticheat_integritytool.exe");
             InstallBootStrapper(report, pathToEOSBootStrapperTool, pathToEOSBootStrapper);
-            GenerateIntegrityCert(report, pathToEACIntegrityTool, GetEOSConfig().productID, "base_private.key", "base_public.cer");
+
+            //TODO: Actually use the editor tool config
+            var editorToolsConfigSection = EOSPluginEditorConfigEditor.GetConfigurationSectionEditor<EOSPluginEditorToolsConfigSection>();
+
+            if (editorToolsConfigSection != null)
+            {
+                editorToolsConfigSection.Awake();
+                editorToolsConfigSection.LoadConfigFromDisk();
+                var editorToolConfig = editorToolsConfigSection.GetCurrentConfig();
+                if (editorToolConfig != null && editorToolConfig.pathToEACPublicKey != null)
+                {
+                    GenerateIntegrityCert(report, pathToEACIntegrityTool, GetEOSConfig().productID, "base_private.key", "base_public.cer");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This work does two things:
1) Fix some path issues that can occur when the code is run from the plugin directory
2) Adds some of the work for allowing a user specified path to find the EAC cert and public key.