### PR TITLE
Fix: add `!EOS_DISABLE_FULL` constraint to Editor asmdef

### DIFF
--- a/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
+++ b/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
@@ -14,7 +14,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "!EOS_DISABLE_FULL"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Added `!EOS_DISABLE_FULL` constraint to Editor assembly definition.

Currently, `EOS_DISABLE_FULL` only disables runtime assemblies, which leads to compiler errors because the Editor assembly depends on the `essential` assembly.

This PR adds the same constraint to the Editor assembly, which fixes the compiler errors, and allows the plugin to be completely disabled on unsupported platforms (e.g. console, mobile).