### PR TITLE
fix(P2PNetcodeSample) Fixed the errors when hosting

### DIFF
--- a/Assets/Scripts/UI/UILoginMenu.cs
+++ b/Assets/Scripts/UI/UILoginMenu.cs
@@ -272,7 +272,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 {
                     EventSystem.current.SetSelectedGameObject(UIFirstSelected);
                 }
-                else if (UIFindSelectable.activeSelf == true)
+                else if (UIFindSelectable && UIFindSelectable.activeSelf == true)
                 {
                     EventSystem.current.SetSelectedGameObject(UIFindSelectable);
                 }


### PR DESCRIPTION
Fixed the error by checking if the missing object existed before referencing it. 
From what I can tell it was the arrow keys being used both for the game and menu navigation taking over.