### PR TITLE
Use MacOS code paths when running in editor on mac

### DIFF
--- a/Assets/Plugins/Source/EOSManager.cs
+++ b/Assets/Plugins/Source/EOSManager.cs
@@ -527,7 +527,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 string configDataAsString = "";
 
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
 
                 configDataAsString = AndroidFileIOHelper.ReadAllText(eosFinalConfigPath);
 #else

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -33,7 +33,7 @@ using Epic.OnlineServices.Auth;
 using Epic.OnlineServices.Logging;
 using System.Runtime.InteropServices;
 
-#if UNITY_STANDALONE_OSX && EOS_PREVIEW_PLATFORM
+#if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && EOS_PREVIEW_PLATFORM
 namespace PlayEveryWare.EpicOnlineServices 
 {
     //-------------------------------------------------------------------------


### PR DESCRIPTION
Use MacOS code paths when running in editor on mac, even when Unity platform is set to Android.