### PR TITLE
fix: Don't check for valid EOS config files when the build target has

### DIFF
--- a/Assets/Plugins/Android/Editor/EOSOnPreprocessBuild_android.cs
+++ b/Assets/Plugins/Android/Editor/EOSOnPreprocessBuild_android.cs
@@ -46,6 +46,11 @@ public class EOSOnPreprocessBuild_android : IPreprocessBuildWithReport
     //-------------------------------------------------------------------------
     public void OnPreprocessBuild(BuildReport report)
     {
+        if (EOSPreprocessUtilities.isEOSDisableScriptingDefineEnabled(report))
+        {
+            return;
+        }
+
         if (report.summary.platform == BuildTarget.Android)
         {
             InstallEOSDependentLibrary();

--- a/Assets/Plugins/Source/Editor/EOSOnPreprocessBuild.cs
+++ b/Assets/Plugins/Source/Editor/EOSOnPreprocessBuild.cs
@@ -11,6 +11,10 @@ public class EOSOnPreprocessBuild : IPreprocessBuildWithReport
     public void OnPreprocessBuild(BuildReport report)
     {
         //if (report.summary.platform == BuildTarget.StandaloneWindows || report.summary.platform == BuildTarget.StandaloneWindows64)
+        if (EOSPreprocessUtilities.isEOSDisableScriptingDefineEnabled(report))
+        {
+            return;
+        }
 
         Debug.Log("MyCustomBuildProcessor.OnPreprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
 

--- a/Assets/Plugins/Source/Editor/EOSPreprocessUtilities.cs
+++ b/Assets/Plugins/Source/Editor/EOSPreprocessUtilities.cs
@@ -1,0 +1,53 @@
+/*
+* Copyright (c) 2023 PlayEveryWare
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+
+public class EOSPreprocessUtilities
+{
+    //-------------------------------------------------------------------------
+    public static bool isScriptingDefineEnabled(BuildReport report, string defineAsString)
+    {
+#if UNITY_2021_2_OR_NEWER
+        var namedBuildTarget = UnityEditor.Build.NamedBuildTarget.FromBuildTargetGroup(report.summary.platformGroup);
+        var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget);
+#else
+        // Ensure that we don't do checks for config files if the current platform group has EOS disabled
+        var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbolsForGroup(report.summary.platformGroup);
+#endif
+        foreach(string define in defineSymbolsForGroup.Split(';'))
+        {
+            if (define == defineAsString)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //-------------------------------------------------------------------------
+    public static bool isEOSDisableScriptingDefineEnabled(BuildReport report)
+    {
+        return EOSPreprocessUtilities.isScriptingDefineEnabled(report, "EOS_DISABLE");
+    }
+}

--- a/Assets/Plugins/Source/Editor/EOSPreprocessUtilities.cs.meta
+++ b/Assets/Plugins/Source/Editor/EOSPreprocessUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 013d27af820af2a4cbb5eefec8bcefb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
+++ b/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
@@ -32,6 +32,13 @@ class PreProcessConfigConfirmation : IPreprocessBuildWithReport
     public int callbackOrder { get { return 0; } }
     public void OnPreprocessBuild(BuildReport report)
     {
+        // Ensure that we don't do checks for config files if the current platform group has EOS disabled
+        var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbolsForGroup(report.summary.platformGroup);
+        if (defineSymbolsForGroup.Contains("EOS_DISABLE"))
+        {
+            return;
+        }
+
         Debug.Log("PreProcessConfigConfirmation.OnPreprocessBuild for target: " + report.summary.platform);
         BuildTarget target = report.summary.platform;
 

--- a/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
+++ b/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
@@ -29,7 +29,7 @@ using System.Collections.Generic;
 
 class PreProcessConfigConfirmation : IPreprocessBuildWithReport
 {
-    public int callbackOrder { get { return 0; } }
+    public int callbackOrder { get { return int.MaxValue; } }
     public void OnPreprocessBuild(BuildReport report)
     {
 

--- a/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
+++ b/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
@@ -32,15 +32,7 @@ class PreProcessConfigConfirmation : IPreprocessBuildWithReport
     public int callbackOrder { get { return int.MaxValue; } }
     public void OnPreprocessBuild(BuildReport report)
     {
-
-#if UNITY_2021_2_OR_NEWER
-        var namedBuildTarget = UnityEditor.Build.NamedBuildTarget.FromBuildTargetGroup(report.summary.platformGroup);
-        var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget);
-#else
-        // Ensure that we don't do checks for config files if the current platform group has EOS disabled
-        var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbolsForGroup(report.summary.platformGroup);
-#endif
-        if (defineSymbolsForGroup.Contains("EOS_DISABLE"))
+        if (EOSPreprocessUtilities.isEOSDisableScriptingDefineEnabled(report))
         {
             return;
         }

--- a/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
+++ b/Assets/Plugins/Source/Editor/PreProcessConfigConfirmation.cs
@@ -32,8 +32,14 @@ class PreProcessConfigConfirmation : IPreprocessBuildWithReport
     public int callbackOrder { get { return 0; } }
     public void OnPreprocessBuild(BuildReport report)
     {
+
+#if UNITY_2021_2_OR_NEWER
+        var namedBuildTarget = UnityEditor.Build.NamedBuildTarget.FromBuildTargetGroup(report.summary.platformGroup);
+        var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget);
+#else
         // Ensure that we don't do checks for config files if the current platform group has EOS disabled
         var defineSymbolsForGroup = PlayerSettings.GetScriptingDefineSymbolsForGroup(report.summary.platformGroup);
+#endif
         if (defineSymbolsForGroup.Contains("EOS_DISABLE"))
         {
             return;

--- a/Assets/Plugins/iOS/Editor/EOSOnPostProcessBuild.cs
+++ b/Assets/Plugins/iOS/Editor/EOSOnPostProcessBuild.cs
@@ -21,6 +21,11 @@ public class iOS_BuildPostProcess
     public static void OnPostprocessBuild(BuildTarget buildTarget, string path)
     {
 
+        if (EOSPreprocessUtilities.isEOSDisableScriptingDefineEnabled(report))
+        {
+            return;
+        }
+
         if (buildTarget == BuildTarget.iOS)
         {
             string projPath = path + "/Unity-iPhone.xcodeproj/project.pbxproj";


### PR DESCRIPTION
Small fix related to #237 . This change checks the defines for the for the build, and if it includes EOS_DISABLED, it won't check if the files exist on disk.

One edge case with this, is that if another prebuild script is run that adds EOS_DISABLED later, this script might not pick it up.

