### PR TITLE
[Fix] EOSConfig.sandboxDeploymentOverrides nullref

### DIFF
--- a/Assets/Plugins/Source/Core/EOSConfig.cs
+++ b/Assets/Plugins/Source/Core/EOSConfig.cs
@@ -63,7 +63,7 @@ namespace PlayEveryWare.EpicOnlineServices
         public string deploymentID;
 
         /// <value><c>SandboxDeploymentOverride</c> pairs used to override Deployment ID when a given Sandbox ID is used</value>
-        public List<SandboxDeploymentOverride> sandboxDeploymentOverrides;
+        public List<SandboxDeploymentOverride> sandboxDeploymentOverrides = new();
 
         /// <value><c>Client Secret</c> defined in the [Development Portal](https://dev.epicgames.com/portal/)</value>
         public string clientSecret;


### PR DESCRIPTION
Nullref happened when opening EpicOnlineServicesConfigEditor with no config file to load from disk.
Newing the list on the default object construction fixes the problem and doesn't impact subsequent deserializations of the object.