### PR TITLE
fix(iOS) : IOS Login Options Refactor

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -1228,7 +1228,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 print("StartLoginWithLoginTypeAndToken");
 
 #if UNITY_IOS && !UNITY_EDITOR
-                IOSLoginOptions modifiedLoginOptions = (EOSManagerPlatformSpecifics.Instance as EOSPlatformSpecificsiOS).MakeIOSLoginOptionsFromDefualt(loginOptions);
+                IOSLoginOptions modifiedLoginOptions = new EOS_iOSLoginOptionsHelper().MakeIOSLoginOptionsFromDefualt(loginOptions);
                 EOSAuthInterface.Login(ref modifiedLoginOptions, null, (Epic.OnlineServices.Auth.OnLoginCallback)((ref Epic.OnlineServices.Auth.LoginCallbackInfo data) => {
 #else
                 EOSAuthInterface.Login(ref loginOptions, null, (Epic.OnlineServices.Auth.OnLoginCallback)((ref Epic.OnlineServices.Auth.LoginCallbackInfo data) => {

--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -1228,7 +1228,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 print("StartLoginWithLoginTypeAndToken");
 
 #if UNITY_IOS && !UNITY_EDITOR
-                IOSLoginOptions modifiedLoginOptions = new EOS_iOSLoginOptionsHelper().MakeIOSLoginOptionsFromDefualt(loginOptions);
+                IOSLoginOptions modifiedLoginOptions = EOS_iOSLoginOptionsHelper.MakeIOSLoginOptionsFromDefualt(loginOptions);
                 EOSAuthInterface.Login(ref modifiedLoginOptions, null, (Epic.OnlineServices.Auth.OnLoginCallback)((ref Epic.OnlineServices.Auth.LoginCallbackInfo data) => {
 #else
                 EOSAuthInterface.Login(ref loginOptions, null, (Epic.OnlineServices.Auth.OnLoginCallback)((ref Epic.OnlineServices.Auth.LoginCallbackInfo data) => {

--- a/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs
+++ b/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs
@@ -1,0 +1,43 @@
+using System;
+using Epic.OnlineServices.Auth;
+using System.Runtime.InteropServices;
+
+#if UNITY_IOS && !UNITY_EDITOR
+public class EOS_iOSLoginOptionsHelper
+{
+    public EOS_iOSLoginOptionsHelper() { }
+
+    //-------------------------------------------------------------------------
+    /// <summary>
+    /// Create App Controller necessary for iOS login options
+    /// </summary>
+    [DllImport("__Internal")]
+    static private extern IntPtr LoginUtility_get_app_controller();
+
+    //-------------------------------------------------------------------------
+    /// <summary>
+    /// Make Login Options for iOS Specific
+    /// </summary>
+    public IOSLoginOptions MakeIOSLoginOptionsFromDefualt(Epic.OnlineServices.Auth.LoginOptions loginOptions)
+    {
+        IOSLoginOptions modifiedLoginOptions = new IOSLoginOptions();
+        modifiedLoginOptions.ScopeFlags = loginOptions.ScopeFlags;
+
+        var credentials = new IOSCredentials();
+
+        credentials.Token = loginOptions.Credentials.Value.Token;
+        credentials.Id = loginOptions.Credentials.Value.Id;
+        credentials.Type = loginOptions.Credentials.Value.Type;
+        credentials.ExternalType = loginOptions.Credentials.Value.ExternalType;
+
+        var systemAuthCredentialsOptions = new IOSCredentialsSystemAuthCredentialsOptions();
+
+        systemAuthCredentialsOptions.PresentationContextProviding = LoginUtility_get_app_controller();
+        credentials.SystemAuthCredentialsOptions = systemAuthCredentialsOptions;
+
+        modifiedLoginOptions.Credentials = credentials;
+
+        return modifiedLoginOptions;
+    }
+}
+#endif

--- a/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs
+++ b/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs
@@ -3,10 +3,8 @@ using Epic.OnlineServices.Auth;
 using System.Runtime.InteropServices;
 
 #if UNITY_IOS && !UNITY_EDITOR
-public class EOS_iOSLoginOptionsHelper
+public static class EOS_iOSLoginOptionsHelper
 {
-    public EOS_iOSLoginOptionsHelper() { }
-
     //-------------------------------------------------------------------------
     /// <summary>
     /// Create App Controller necessary for iOS login options
@@ -18,7 +16,7 @@ public class EOS_iOSLoginOptionsHelper
     /// <summary>
     /// Make Login Options for iOS Specific
     /// </summary>
-    public IOSLoginOptions MakeIOSLoginOptionsFromDefualt(Epic.OnlineServices.Auth.LoginOptions loginOptions)
+    public static IOSLoginOptions MakeIOSLoginOptionsFromDefualt(Epic.OnlineServices.Auth.LoginOptions loginOptions)
     {
         IOSLoginOptions modifiedLoginOptions = new IOSLoginOptions();
         modifiedLoginOptions.ScopeFlags = loginOptions.ScopeFlags;

--- a/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs
+++ b/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs
@@ -1,3 +1,27 @@
+/*
+* Copyright (c) 2023 PlayEveryWare
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+
+
 using System;
 using Epic.OnlineServices.Auth;
 using System.Runtime.InteropServices;

--- a/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs.meta
+++ b/Assets/Plugins/iOS/Core/EOS_iOSLoginOptionsHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6e73e82bdf734f39ae29af9b013b14b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/EOSManager_iOS.cs
+++ b/Assets/Plugins/iOS/EOSManager_iOS.cs
@@ -211,39 +211,6 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         /// <summary>
-        /// Create App Controller necessary for iOS login options
-        /// </summary>
-        [DllImport("__Internal")]
-        static private extern IntPtr LoginUtility_get_app_controller();
-
-        //-------------------------------------------------------------------------
-        /// <summary>
-        /// Make Login Options for iOS Specific
-        /// </summary>
-        public IOSLoginOptions MakeIOSLoginOptionsFromDefualt(Epic.OnlineServices.Auth.LoginOptions loginOptions)
-        {
-            IOSLoginOptions modifiedLoginOptions = new IOSLoginOptions();
-            modifiedLoginOptions.ScopeFlags = loginOptions.ScopeFlags;
-
-            var credentials = new IOSCredentials();
-
-            credentials.Token = loginOptions.Credentials.Value.Token;
-            credentials.Id = loginOptions.Credentials.Value.Id;
-            credentials.Type = loginOptions.Credentials.Value.Type;
-            credentials.ExternalType = loginOptions.Credentials.Value.ExternalType;
-
-            var systemAuthCredentialsOptions = new IOSCredentialsSystemAuthCredentialsOptions();
-
-            systemAuthCredentialsOptions.PresentationContextProviding = LoginUtility_get_app_controller();
-            credentials.SystemAuthCredentialsOptions = systemAuthCredentialsOptions;
-
-            modifiedLoginOptions.Credentials = credentials;
-
-            return modifiedLoginOptions;
-        }
-
-        //-------------------------------------------------------------------------
-        /// <summary>
         /// Set Default Audio Session for iOS (Category to AVAudioSessionCategoryPlayAndRecord)
         /// </summary>
         [DllImport("__Internal")]


### PR DESCRIPTION
Moves MakeIOSLoginOptions from EOSManager_iOS to a new helper script in iOS/Core to fit the core assembly structure.