### PR TITLE
fix(regression): Add back code to show how to disable host migration

### DIFF
--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -46,6 +46,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public LobbyPermissionLevel LobbyPermissionLevel = LobbyPermissionLevel.Publicadvertised;
         public uint AvailableSlots = 0;
         public bool AllowInvites = true;
+        public bool? DisableHostMigration;
 
         // Cached copy of the RoomName of the RTC room that our lobby has, if any
         public string RTCRoomName = string.Empty;
@@ -951,6 +952,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             createLobbyOptions.AllowInvites = lobbyProperties.AllowInvites;
             createLobbyOptions.BucketId = lobbyProperties.BucketId;
 
+            if (lobbyProperties.DisableHostMigration != null)
+            {
+                createLobbyOptions.DisableHostMigration = (bool)lobbyProperties.DisableHostMigration;
+            }
             // Voice Chat
             if(lobbyProperties.RTCRoomEnabled)
             {


### PR DESCRIPTION
Restores sample code in the EOSLobbyManager that shows how to disable host migration.
I noticed the issue after reading this discussion that was reopened [here](https://github.com/PlayEveryWare/eos_plugin_for_unity/discussions/34).