### PR TITLE
Fix Added Preserve tags to platform specific code

### DIFF
--- a/Assets/Plugins/Android/EOSManager_Android.cs
+++ b/Assets/Plugins/Android/EOSManager_Android.cs
@@ -23,6 +23,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Scripting;
 
 using Epic.OnlineServices.Platform;
 using Epic.OnlineServices;

--- a/Assets/Plugins/Android/EOSManager_Android.cs
+++ b/Assets/Plugins/Android/EOSManager_Android.cs
@@ -88,6 +88,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsAndroid());

--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -138,6 +138,7 @@ static string SteamDllName = "steam_api.dll";
 
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsLinux());

--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -36,6 +36,7 @@ using System.Collections;
 using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Scripting;
 using System;
 
 using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/Windows/EOSManager_Windows.cs
+++ b/Assets/Plugins/Windows/EOSManager_Windows.cs
@@ -139,6 +139,7 @@ static string SteamDllName = "steam_api.dll";
 
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsWindows());

--- a/Assets/Plugins/Windows/EOSManager_Windows.cs
+++ b/Assets/Plugins/Windows/EOSManager_Windows.cs
@@ -36,6 +36,7 @@ using System.Collections;
 using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Scripting;
 using System;
 
 using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/iOS/EOSManager_iOS.cs
+++ b/Assets/Plugins/iOS/EOSManager_iOS.cs
@@ -25,6 +25,7 @@ using System.Collections;
 using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Scripting;
 using System;
 
 using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/iOS/EOSManager_iOS.cs
+++ b/Assets/Plugins/iOS/EOSManager_iOS.cs
@@ -75,6 +75,7 @@ namespace PlayEveryWare.EpicOnlineServices
         EOS_iOSConfig iOSConfig;
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsiOS());

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -75,6 +75,7 @@ namespace PlayEveryWare.EpicOnlineServices
         EOS_macOSConfig macOSConfig;
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsmacOS());

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -25,6 +25,7 @@ using System.Collections;
 using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Scripting;
 using System;
 
 using Epic.OnlineServices.Platform;


### PR DESCRIPTION
Added the [Preserve} tag to each platform's EOSManager to ensure it does not get stripped during IL2CPP compilation