### PR TITLE
fix(android,login) : fix for login not returning to the application

### DIFF
--- a/Assets/Plugins/Android/Editor/EOSOnPreprocessBuild_android.cs
+++ b/Assets/Plugins/Android/Editor/EOSOnPreprocessBuild_android.cs
@@ -394,10 +394,20 @@ public class EOSOnPreprocessBuild_android : IPreprocessBuildWithReport
         currentEOSValuesConfigAsXML.Load(pathToEOSValuesConfig);
 
         var node = currentEOSValuesConfigAsXML.DocumentElement.SelectSingleNode("/resources");
-        if (node == null) { return; }
+        if (node == null) 
+        {
+            Directory.Delete("../Temp/", true); 
+            Debug.LogError("aar fix failed"); 
+            return; 
+        }
 
         var node2 = node.SelectSingleNode("string[@name=\"eos_login_protocol_scheme\"]");
-        if (node2 == null) { return; }
+        if (node2 == null) 
+        { 
+            Directory.Delete("../Temp/", true); 
+            Debug.LogError("aar fix failed"); 
+            return; 
+        }
 
         string eosProtocolScheme = node2.InnerText;
         string storedClientID = eosProtocolScheme.Split('.').Last();
@@ -410,7 +420,6 @@ public class EOSOnPreprocessBuild_android : IPreprocessBuildWithReport
 
         ZipFile.CreateFromDirectory("../Temp/Android/eos-sdk", "../eos-sdk.aar", System.IO.Compression.CompressionLevel.Optimal, false);
         File.Copy("../eos-sdk.aar", "Assets/Plugins/Android/eos-sdk.aar", true);
-
 
         Directory.Delete("../Temp/", true);
         File.Delete("../eos-sdk.aar");

--- a/Assets/Plugins/Android/Editor/EOSOnPreprocessBuild_android.cs
+++ b/Assets/Plugins/Android/Editor/EOSOnPreprocessBuild_android.cs
@@ -31,6 +31,8 @@ using PlayEveryWare.EpicOnlineServices;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
+using System.IO.Compression;
+
 #if UNITY_ANDROID
 public class EOSOnPreprocessBuild_android : IPreprocessBuildWithReport
 {
@@ -375,6 +377,47 @@ public class EOSOnPreprocessBuild_android : IPreprocessBuildWithReport
 
         CopyFromSourceToPluginFolder_Android(sourcePath, "eos-sdk.aar", destPath);
         CopyFromSourceToPluginFolder_Android(sourcePath, "eos-sdk.aar.meta", destPath);
+
+        //////////////////////////////
+        // Temp fix pre EOS SDK 1.16//
+        ////////////////////////////// 
+
+        ZipFile.ExtractToDirectory("Assets/Plugins/Android/eos-sdk.aar", "../Temp/Android/eos-sdk", true);
+
+        string configFilePath = Path.Combine(Application.streamingAssetsPath, "EOS", EOSPackageInfo.ConfigFileName);
+        var eosConfigFile = new EOSConfigFile<EOSConfig>(configFilePath);
+        eosConfigFile.LoadConfigFromDisk();
+        string clientIDAsLower = eosConfigFile.currentEOSConfig.clientID.ToLower();
+
+        var pathToEOSValuesConfig = "../Temp/Android/eos-sdk/res/values/values.xml";
+        var currentEOSValuesConfigAsXML = new System.Xml.XmlDocument();
+        currentEOSValuesConfigAsXML.Load(pathToEOSValuesConfig);
+
+        var node = currentEOSValuesConfigAsXML.DocumentElement.SelectSingleNode("/resources");
+        if (node == null) { return; }
+
+        var node2 = node.SelectSingleNode("string[@name=\"eos_login_protocol_scheme\"]");
+        if (node2 == null) { return; }
+
+        string eosProtocolScheme = node2.InnerText;
+        string storedClientID = eosProtocolScheme.Split('.').Last();
+
+        if (storedClientID != clientIDAsLower)
+        {
+            node2.InnerText = $"eos.{clientIDAsLower}";
+            currentEOSValuesConfigAsXML.Save(pathToEOSValuesConfig);
+        }
+
+        ZipFile.CreateFromDirectory("../Temp/Android/eos-sdk", "../eos-sdk.aar", System.IO.Compression.CompressionLevel.Optimal, false);
+        File.Copy("../eos-sdk.aar", "Assets/Plugins/Android/eos-sdk.aar", true);
+
+
+        Directory.Delete("../Temp/", true);
+        File.Delete("../eos-sdk.aar");
+
+        //////////////////////////////////
+        ///        End temp fix        ///
+        //////////////////////////////////
     }
 
     private void CopyFromSourceToPluginFolder_Android(string sourcePath, string filename, string destPath)


### PR DESCRIPTION
The reason was because the eos_login_protocol_scheme was overwritten by an empty entry. This fix assigns the correct string to the empty entry to avoid this problem