### PR TITLE
Fix IL2CPP stripping platform-specific initialization code

### DIFF
--- a/Assets/Plugins/Android/EOSManager_Android.cs
+++ b/Assets/Plugins/Android/EOSManager_Android.cs
@@ -41,6 +41,7 @@ using System.Diagnostics;
 
 
 #if UNITY_ANDROID && !UNITY_EDITOR
+[assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices
 {
     //-------------------------------------------------------------------------
@@ -89,7 +90,6 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsAndroid());

--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -48,6 +48,7 @@ using System.Text;
 using Epic.OnlineServices.IntegratedPlatform;
 
 #if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM
+[assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices
 {
     //-------------------------------------------------------------------------
@@ -139,7 +140,6 @@ static string SteamDllName = "steam_api.dll";
 
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsLinux());

--- a/Assets/Plugins/Windows/EOSManager_Windows.cs
+++ b/Assets/Plugins/Windows/EOSManager_Windows.cs
@@ -47,6 +47,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 
 #if (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA_10_0)
+[assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices
 {
     //-------------------------------------------------------------------------
@@ -140,7 +141,6 @@ static string SteamDllName = "steam_api.dll";
 
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsWindows());

--- a/Assets/Plugins/iOS/EOSManager_iOS.cs
+++ b/Assets/Plugins/iOS/EOSManager_iOS.cs
@@ -35,6 +35,7 @@ using Epic.OnlineServices.Logging;
 using System.Runtime.InteropServices;
 
 #if UNITY_IOS && !UNITY_EDITOR
+[assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices
 {
     //-------------------------------------------------------------------------
@@ -76,7 +77,6 @@ namespace PlayEveryWare.EpicOnlineServices
         EOS_iOSConfig iOSConfig;
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsiOS());

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -35,6 +35,7 @@ using Epic.OnlineServices.Logging;
 using System.Runtime.InteropServices;
 
 #if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && EOS_PREVIEW_PLATFORM
+[assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices 
 {
     //-------------------------------------------------------------------------
@@ -76,7 +77,6 @@ namespace PlayEveryWare.EpicOnlineServices
         EOS_macOSConfig macOSConfig;
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        [Preserve]
         static public void Register()
         {
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsmacOS());


### PR DESCRIPTION
This fixes IL2CPP stripping the platform-specific `EOSManager_*` classes by adding the [`[assembly: AlwaysLinkAssembly]`](https://docs.unity3d.com/ScriptReference/Scripting.AlwaysLinkAssemblyAttribute.html) attribute.

Without this attribute, the entire `com.playeveryware.eos` assembly is stripped, because none of the classes are referenced by any other assembly. This means all of the `[RuntimeInitializeOnLoadMethod]` Register methods are stripped, so the plugin is not initialized properly.

I've also removed the `[Preserve]` attributes added in #319 as they are no longer necessary with this fix.