### PR TITLE
fix(config,steam): compile errors on platforms that don't support steamworks

### DIFF
--- a/Assets/Plugins/Source/Editor/EpicOnlineServicesConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/EpicOnlineServicesConfigEditor.cs
@@ -27,7 +27,6 @@ using System.IO;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
-using PlayEveryWare.EpicOnlineServices;
 using System.Collections.Generic;
 
 namespace PlayEveryWare.EpicOnlineServices
@@ -616,10 +615,10 @@ _WIN32 || _WIN64
             AssigningTextField("Override Library path", ref steamEOSConfigFile.currentEOSConfig.overrideLibraryPath);
             AssigningUintField("Steamworks SDK major version", ref steamEOSConfigFile.currentEOSConfig.steamSDKMajorVersion, 190);
             AssigningUintField("Steamworks SDK minor version", ref steamEOSConfigFile.currentEOSConfig.steamSDKMinorVersion, 190);
-#if STEAMWORKS_MODULE && !DISABLESTEAMWORKS
+
             if (GUILayout.Button("Update from Steamworks.NET", GUILayout.MaxWidth(200)))
             {
-                var steamworksVersion = Steamworks.Version.SteamworksSDKVersion;
+                var steamworksVersion = Steamworks_Utility.GetSteamworksVersion();
                 var versionParts = steamworksVersion.Split(".");
                 bool success = false;
                 if (versionParts.Length >= 2)
@@ -637,7 +636,6 @@ _WIN32 || _WIN64
                     Debug.LogError("Failed to retrive Steamworks SDK version from Steamworks.NET");
                 }
             }
-#endif
         }
 
         // TODO: create way to hook up new platforms dynamically 

--- a/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
+++ b/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
@@ -5,7 +5,7 @@
         "GUID:2ced8f3cc58f63843bc26c7591a35628",
         "GUID:478a2357cc57436488a56e564b08d223",
         "GUID:3a63500f0eef43a438c0553491f7c5da",
-        "GUID:68bd7fdb68ef2684e982e8a9825b18a5"
+        "GUID:4a3cd13b0378c984c9688988d6a41c57"
     ],
     "includePlatforms": [
         "Editor"
@@ -16,12 +16,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.rlabrecque.steamworks.net",
-            "expression": "",
-            "define": "STEAMWORKS_MODULE"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Assets/Scripts/Steam/Utility.meta
+++ b/Assets/Scripts/Steam/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45a9e158d6f67dd44a932ce60be1619b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Steam/Utility/Steamworks_Utility.cs
+++ b/Assets/Scripts/Steam/Utility/Steamworks_Utility.cs
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) 2021 PlayEveryWare
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#if !STEAMWORKS_MODULE || !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
+using UnityEngine;
+
+#if !DISABLESTEAMWORKS
+using Steamworks;
+#endif
+
+public class Steamworks_Utility : MonoBehaviour
+{
+    public static string GetSteamworksVersion()
+    {
+#if DISABLESTEAMWORKS
+        return "Steamworks not imported or not supported on platform";
+#else
+        return Steamworks.Version.SteamworksSDKVersion;
+#endif
+    }
+}

--- a/Assets/Scripts/Steam/Utility/Steamworks_Utility.cs.meta
+++ b/Assets/Scripts/Steam/Utility/Steamworks_Utility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbb77447f414dea43bc0a8cfa36c29de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Steam/Utility/com.playeveryware.eos.samples.steam.utility.asmdef
+++ b/Assets/Scripts/Steam/Utility/com.playeveryware.eos.samples.steam.utility.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "com.playeveryware.eos.samples.steam.utility",
+    "rootNamespace": "",
+    "references": [
+        "GUID:68bd7fdb68ef2684e982e8a9825b18a5"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.rlabrecque.steamworks.net",
+            "expression": "",
+            "define": "STEAMWORKS_MODULE"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Steam/Utility/com.playeveryware.eos.samples.steam.utility.asmdef.meta
+++ b/Assets/Scripts/Steam/Utility/com.playeveryware.eos.samples.steam.utility.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a3cd13b0378c984c9688988d6a41c57
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This commit fixes an error happening in the Steam config tool.

This is likely an overkill with the refactor however.

The easier fix is to just add the whole line of platform define for DISABLESTEAMWORKS into EpicOnlineServicesConfigEditor.cs This is efficient if a small number of scripts uses steamworks. If the number grows the same define would need to be added into all the scripts using steamworks.