### PR TITLE
Exempt issues labeled "pending" from becoming marked stale and subsequently removed

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,5 +1,6 @@
 name: Close inactive issues
 on:
+  workflow_dispatch:
   schedule:
     # Everyday at 1:30PM GMT+7
     - cron: "30 1 * * *"

--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,9 +1,8 @@
 name: Close inactive issues
 on:
-  workflow_dispatch:
-  #schedule:
-    # Everyday at 1:30PM GMT+7
-  #  - cron: "30 1 * * *"
+  schedule:
+    # Everyday at 1:30PM
+    - cron: "30 1 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,9 +1,9 @@
 name: Close inactive issues
 on:
   workflow_dispatch:
-  schedule:
+  #schedule:
     # Everyday at 1:30PM GMT+7
-    - cron: "30 1 * * *"
+  #  - cron: "30 1 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     env:
       # Number of days before an issue with no activity gets marked as stale.
       DAYS_TO_STALE: 14

--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,6 +1,7 @@
 name: Close inactive issues
 on:
   schedule:
+    # Everyday at 1:30PM GMT+7
     - cron: "30 1 * * *"
 
 jobs:
@@ -9,18 +10,41 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    env:
+      # Number of days before an issue with no activity gets marked as stale.
+      DAYS_TO_STALE: 14
+      # Number of days after being marked stale the issue is closed 
+      # automatically.
+      DAYS_AFTER_STALE_TO_CLOSE: 7
     steps:
       - uses: actions/stale@v5
         with:
-          # Mark stale if not resonse after 7 days, and close after 14
-          days-before-issue-stale: 7
-          days-before-issue-close: 7
+          # Any issues marked "pending" or "bug" are exempt from the close 
+          # inactive issues logic.
+          #
+          # NOTE: This will require some oversight - if something isn't
+          # really a bug, then the label should be removed so it can be later
+          # marked stale by this workflow.
+          exempt-issue-labels: "pending, bug"
 
+          # Mark stale if there is no activity after DAYS_TO_STALE days.
+          days-before-issue-stale: $DAYS_TO_STALE
+
+          # *After* issue has been stale for DAYS_AFTER_STALE_TO_CLOSE days.
+          days-before-issue-close: $DAYS_AFTER_STALE_TO_CLOSE
+
+          # Define the name of the label to use for marking issues as "stale".
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 7 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
 
-          # Never close a PR
+          # Messages for each action.
+          stale-issue-message: "This issue is stale because it has been open for $DAYS_TO_STALE days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for $DAYS_AFTER_STALE_TO_CLOSE days since being marked as stale."
+
+          # When an issue is closed via this workflow, add a label so auto-
+          # closed issues can be searched.
+          close-issue-label: "auto-closed"
+          
+          # Never mark a PR as either stale or closed
           days-before-pr-stale: -1
           days-before-pr-close: -1
 


### PR DESCRIPTION
# Nuanced Automated Issue Closure Workflow:
Currently, when an issue has no activity on it after 7 days, it gets marked as "stale." If, after an additional 7 days there is still no activity, the issue is closed.

## Changes Made to Workflow:
- If the issue is marked `pending` or `bug` it will neither be labeled `stale`, nor will it be automatically closed.
- The number of days after which to mark an inactive issue has been increased from 7 to 14.
- _When_ an issue is closed automatically by this workflow, a new label `auto-closed` will be added to the issue

## Things to Consider:
- Because issues labeled `bug` are now exempt from being auto-marked stale and subsequently closed, it will be important for maintainers to carefully consider whether an issue truly is a bug, and removing the label if the issue doesn't truly meet the threshold of being a "bug" vs being a feature request.

### Flowchart of Auto-Close Logic:
<img width="929" alt="image" src="https://github.com/PlayEveryWare/eos_plugin_for_unity/assets/1439891/fec2bed7-0fa3-4147-abc0-7e72acda045b">



