### PR TITLE
Dev/flag fix

### DIFF
--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -142,6 +142,7 @@ static string SteamDllName = "steam_api.dll";
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()
         {
+            UnityEngine.Log.Warning("Linux platform is currently in preview.");
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsLinux());
         }
 

--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -142,7 +142,7 @@ static string SteamDllName = "steam_api.dll";
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()
         {
-            UnityEngine.Log.Warning("Linux platform is currently in preview.");
+            UnityEngine.Debug.LogWarning("Linux platform is currently in preview.");
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsLinux());
         }
 

--- a/Assets/Plugins/Linux/EOSManager_Linux.cs
+++ b/Assets/Plugins/Linux/EOSManager_Linux.cs
@@ -22,7 +22,7 @@
 
 #if UNITY_64 || UNITY_EDITOR_64
 #define PLATFORM_64BITS
-#elif (UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX) && EOS_PREVIEW_PLATFORM
+#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
 #define PLATFORM_32BITS
 #endif
 
@@ -47,7 +47,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Epic.OnlineServices.IntegratedPlatform;
 
-#if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM
+#if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX)
 [assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -462,7 +462,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 platformOptions.ClientCredentials = clientCredentials;
 
 
-#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || (UNITY_STANDALONE_LINUX && EOS_PREVIEW_PLATFORM) || (UNITY_EDITOR_LINUX && EOS_PREVIEW_PLATFORM))
+#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX)
                 var createIntegratedPlatformOptionsContainerOptions = new Epic.OnlineServices.IntegratedPlatform.CreateIntegratedPlatformOptionsContainerOptions();
                 //TODO: handle errors
                 var integratedPlatformOptionsContainer = new Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformOptionsContainer();
@@ -600,7 +600,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     UnityEngine.Debug.LogWarning($"EOSManager::Init: InitializePlatformInterface: initResult = {secondTryResult}");
                     if (secondTryResult != Result.Success)
 #endif
-#if (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM
+#if (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)
                     if (secondTryResult != Result.AlreadyConfigured)
 #endif
                     {

--- a/Assets/Plugins/Source/Core/EOSManager_DynamicLoading.cs
+++ b/Assets/Plugins/Source/Core/EOSManager_DynamicLoading.cs
@@ -67,34 +67,30 @@ namespace PlayEveryWare.EpicOnlineServices
 
             public const string EOSBinaryName = Epic.OnlineServices.Config.LibraryName;
 
+
 #if USE_EOS_GFX_PLUGIN_NATIVE_RENDER
-//#if UNITY_WSA
-                        //delegate void UnloadEOS_delegate();
-                        //delegate IntPtr EOS_GetPlatformInterface_delegate();
-                        //static UnloadEOS_delegate UnloadEOS;
-                        //static EOS_GetPlatformInterface_delegate EOS_GetPlatformInterface;
-                        public const string GfxPluginNativeRenderPath =
-#if UNITY_STANDALONE_OSX && EOS_PREVIEW_PLATFORM
-                            "GfxPluginNativeRender-macOS";
+            public const string GfxPluginNativeRenderPath =
+#if UNITY_STANDALONE_OSX 
+                "GfxPluginNativeRender-macOS";
 #elif (UNITY_STANDALONE_WIN || UNITY_WSA) && PLATFORM_64BITS
-                        "GfxPluginNativeRender-x64";
+                "GfxPluginNativeRender-x64";
 #elif (UNITY_STANDALONE_WIN) && PLATFORM_32BITS
-                        "GfxPluginNativeRender-x86";
+                "GfxPluginNativeRender-x86";
 #else
 #error Unknown platform
-                        "GfxPluginNativeRender-unknown";
+                "GfxPluginNativeRender-unknown";
 #endif
 
-                        [DllImport(GfxPluginNativeRenderPath)]
-                        static extern void UnloadEOS();
+            [DllImport(GfxPluginNativeRenderPath)]
+            static extern void UnloadEOS();
 
-                        [DllImport(GfxPluginNativeRenderPath,CallingConvention = CallingConvention.StdCall)]
-                        static extern IntPtr EOS_GetPlatformInterface();
+            [DllImport(GfxPluginNativeRenderPath,CallingConvention = CallingConvention.StdCall)]
+            static extern IntPtr EOS_GetPlatformInterface();
 
-                        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                        delegate void PrintDelegateType(string str);
-                        [DllImport(GfxPluginNativeRenderPath,CallingConvention = CallingConvention.StdCall)]
-                        static extern void global_log_flush_with_function(IntPtr ptr);
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            delegate void PrintDelegateType(string str);
+            [DllImport(GfxPluginNativeRenderPath,CallingConvention = CallingConvention.StdCall)]
+            static extern void global_log_flush_with_function(IntPtr ptr);
 #endif
 
             static void NativeCallToUnloadEOS()
@@ -220,7 +216,8 @@ namespace PlayEveryWare.EpicOnlineServices
                 var eosLibraryHandle = LoadDynamicLibrary(EOSBinaryName);
 
                 Epic.OnlineServices.Bindings.Hook<DLLHandle>(eosLibraryHandle, (DLLHandle handle, string functionName) => {
-#if UNITY_EDITOR_OSX && EOS_PREVIEW_PLATFORM
+                // TODO: Add conditions for all flags (unless OSX is the only one that's weird?)
+#if UNITY_EDITOR_OSX
                     return handle.LoadFunctionAsIntPtr(functionName.Trim('_'));
 #else
                     return handle.LoadFunctionAsIntPtr(functionName);

--- a/Assets/Plugins/Source/Core/IEOSManagerPlatformSpecifics.cs
+++ b/Assets/Plugins/Source/Core/IEOSManagerPlatformSpecifics.cs
@@ -79,7 +79,7 @@ namespace PlayEveryWare.EpicOnlineServices
         Utf8String CacheDirectory { get; set; }
         uint TickBudgetInMilliseconds { get; set; }
 
-#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || (UNITY_STANDALONE_LINUX && EOS_PREVIEW_PLATFORM) || (UNITY_EDITOR_LINUX && EOS_PREVIEW_PLATFORM))
+#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX|| UNITY_EDITOR_LINUX)
         Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformOptionsContainer IntegratedPlatformOptionsContainerHandle { get; set; }
 #endif
 

--- a/Assets/Plugins/Source/Core/SystemDynamicLibrary.cs
+++ b/Assets/Plugins/Source/Core/SystemDynamicLibrary.cs
@@ -61,7 +61,7 @@ public partial class SystemDynamicLibrary
 
     [DllImport(Kernel32BinaryName, SetLastError = true, CharSet = CharSet.Ansi, ExactSpelling = true)]
     private static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
-#elif UNITY_EDITOR_OSX && EOS_PREVIEW_PLATFORM
+#elif UNITY_EDITOR_OSX
     private const string DynamicLinkLibrary = "libDynamicLibraryLoaderHelper";
     [DllImport(DynamicLinkLibrary)]
     public static extern bool FreeLibrary(IntPtr hModule);
@@ -74,7 +74,7 @@ public partial class SystemDynamicLibrary
 
     [DllImport(DynamicLinkLibrary)]
     private static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
-#elif UNITY_EDITOR_LINUX && EOS_PREVIEW_PLATFORM
+#elif UNITY_EDITOR_LINUX
     private const string DynamicLinkLibrary = "libDynamicLibraryLoaderHelper";
     [DllImport(DynamicLinkLibrary)]
     public static extern bool FreeLibrary(IntPtr hModule);
@@ -149,18 +149,18 @@ public partial class SystemDynamicLibrary
 
     static public IntPtr GetHandleForModule(string moduleName)
     {
-#if (UNITY_EDITOR_WIN || ((UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM)) && !EOS_DISABLE
+#if (UNITY_EDITOR_WIN || (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)) && !EOS_DISABLE
         return GetModuleHandle(moduleName);
 #else
         return IntPtr.Zero;
 #endif
     }
 
-#if UNITY_EDITOR || (UNITY_STANDALONE_OSX && EOS_PREVIEW_PLATFORM)
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX
     //-------------------------------------------------------------------------
     static public bool UnloadLibraryInEditor(IntPtr libraryHandle)
     {
-#if (UNITY_EDITOR_WIN || ((UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM)) && !EOS_DISABLE
+#if (UNITY_EDITOR_WIN || (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)) && !EOS_DISABLE
         return FreeLibrary(libraryHandle);
 #else
         return true;
@@ -174,7 +174,7 @@ public partial class SystemDynamicLibrary
     {
 #if EOS_DISABLE
         return IntPtr.Zero;
-#elif  UNITY_EDITOR_WIN || ((UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM)
+#elif  UNITY_EDITOR_WIN || (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)
         return LoadLibrary(libraryPath);
 #else
         return DLLH_load_library_at_path(DLLHContex, libraryPath);
@@ -187,7 +187,7 @@ public partial class SystemDynamicLibrary
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_ANDROID || UNITY_IOS || ((UNITY_STANDALONE_OSX || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM )
 #if EOS_DISABLE
         return true;
-#elif (UNITY_EDITOR_WIN || ((UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM)) && !UNITY_ANDROID
+#elif (UNITY_EDITOR_WIN || (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)) && !UNITY_ANDROID
         return FreeLibrary(libraryHandle);
 #else
         return DLLH_unload_library_at_path(DLLHContex, libraryHandle);
@@ -206,7 +206,7 @@ public partial class SystemDynamicLibrary
     {
 #if EOS_DISABLE
         return IntPtr.Zero;
-#elif UNITY_EDITOR_WIN || ((UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX) && EOS_PREVIEW_PLATFORM)
+#elif UNITY_EDITOR_WIN || (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)
         return GetProcAddress(libraryHandle, functionName);
 #else
         return DLLH_load_function_with_name(DLLHContex, libraryHandle, functionName);

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -34,7 +34,7 @@ using Epic.OnlineServices.Auth;
 using Epic.OnlineServices.Logging;
 using System.Runtime.InteropServices;
 
-#if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && EOS_PREVIEW_PLATFORM
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
 [assembly: AlwaysLinkAssembly]
 namespace PlayEveryWare.EpicOnlineServices 
 {

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -79,7 +79,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()
         {
-            UnityEngine.Log.Warning("macOS platform is currently in preview.");
+            UnityEngine.Debug.LogWarning("macOS platform is currently in preview.");
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsmacOS());
         }
 

--- a/Assets/Plugins/macOS/EOSManager_macOS.cs
+++ b/Assets/Plugins/macOS/EOSManager_macOS.cs
@@ -79,6 +79,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()
         {
+            UnityEngine.Log.Warning("macOS platform is currently in preview.");
             EOSManagerPlatformSpecifics.SetEOSManagerPlatformSpecificsInterface(new EOSPlatformSpecificsmacOS());
         }
 

--- a/Assets/Scripts/UI/UILoginMenu.cs
+++ b/Assets/Scripts/UI/UILoginMenu.cs
@@ -102,7 +102,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             loginType = LoginCredentialType.AccountPortal; // Default on other platforms
 #endif
 
-#if UNITY_EDITOR || (UNITY_STANDALONE_OSX && EOS_PREVIEW_PLATFORM) || UNITY_STANDALONE_WIN || (UNITY_STANDALONE_LINUX && EOS_PREVIEW_PLATFORM)
+        // TODO: This will fail on anything that is mac, windows, or linux, or is an editor version of any of the above
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX
             idInputField.InputField.text = "localhost:7777"; //default on pc
 #endif
 

--- a/Assets/Scripts/UI/UIMemberEntry.cs
+++ b/Assets/Scripts/UI/UIMemberEntry.cs
@@ -244,7 +244,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
         }
 
-    #if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && EOS_PREVIEW_PLATFORM
+    // TODO: Add conditions for all flags
+    #if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)
         [System.Runtime.InteropServices.DllImport("MicrophoneUtility_macos.dylib")]
         public static extern bool MicrophoneUtility_get_mic_permission();
     #elif UNITY_IOS
@@ -254,7 +255,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
     
         private bool HasPlatformMicrophonePermission()
         {
-#if UNITY_IOS || ((UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && EOS_PREVIEW_PLATFORM)
+            // TODO: Add conditions for all flags
+#if UNITY_IOS || (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)
             return MicrophoneUtility_get_mic_permission();
 #elif UNITY_ANDROID
             return UnityEngine.Android.Permission.HasUserAuthorizedPermission(UnityEngine.Android.Permission.Microphone);

--- a/Assets/Scripts/UI/UITitleStorageMenu.cs
+++ b/Assets/Scripts/UI/UITitleStorageMenu.cs
@@ -113,9 +113,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
 #if UNITY_STANDALONE_WIN
             string platformTag = "PLATFORM_WINDOWS";
-#elif UNITY_STANDALONE_OSX && EOS_PREVIEW_PLATFORM
+#elif UNITY_STANDALONE_OSX
             string platformTag = "PLATFORM_MAC";
-#elif UNITY_STANDALONE_LINUX && EOS_PREVIEW_PLATFORM
+#elif UNITY_STANDALONE_LINUX
             string platformTag = "PLATFORM_LINUX";
 #elif UNITY_IOS
             string platformTag = "PLATFORM_IOS";

--- a/docs/linux/linux_supported_versions.md
+++ b/docs/linux/linux_supported_versions.md
@@ -1,6 +1,3 @@
-## Preview Platform
-To access Preview platforms, enable `EOS_PREVIEW_PLATFORM`
-
 ## Supported Linux Versions
 
 ### Tested Configurations

--- a/docs/macOS/readme_macOS.md
+++ b/docs/macOS/readme_macOS.md
@@ -1,10 +1,5 @@
 # macOS 
 
-## Preview Platform
-
-To access Preview platforms, apply `EOS_PREVIEW_PLATFORM` in   
-`Player Settings -> Other Settings -> Scripting Define Symbols`
-
 ---------------------------------------
 ## Building Standalone with Unity.
 

--- a/docs/upm_readme.md
+++ b/docs/upm_readme.md
@@ -33,8 +33,6 @@ The follow target platforms are supported in Unity for the current release of th
 | Universal Windows Platform x86 | Not Supported |
 | Unity Web Player | Not Supported |
 
-To access Preview platforms, enable `EOS_PREVIEW_PLATFORM`.
-
 
 ## Supported EOS SDK Features
 As the EOS SDK continues releasing new features and functionality, the EOS Unity Plugin will be updated over time to support the new functionality. Here's the current list of EOS SDK features and their level of support in the EOS Unity Plugin:

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,6 @@ The support level of each target platform in Unity as of the current release of 
 | Universal Windows Platform x64 | | |
 | [Android](/docs/android/readme_android.md) (No Social Overlay Yet) | | |
 | [iOS](/docs/iOS/readme_iOS.md) (No Social Overlay Yet) | | |
-> :heavy_exclamation_mark: Enable `EOS_PREVIEW_PLATFORM` to access Preview platforms.
 
 <br />
 


### PR DESCRIPTION
Refactoring the way `EOS_PREVIEW_PLATFORM` is managed to improve the developer experience on unsupported platforms. Previously, adding this script symbol in the player settings was cumbersome and affected version-controlled files.

After analyzing its usage, it became clear that the flag was intended to make sure developers are aware they're on a preview platform. However, this approach led to silent build failures, offering no hints to set the flag.

To maintain user awareness without causing disruptive issues, I've added warning log statements for both macOS and Linux platforms to indicate the platform's preview status.