### PR TITLE
Fixed usings to prevent warnings.

### DIFF
--- a/Assets/Plugins/Source/Core/IEOSManagerPlatformSpecifics.cs
+++ b/Assets/Plugins/Source/Core/IEOSManagerPlatformSpecifics.cs
@@ -21,13 +21,9 @@
 */
 
 using System;
-
 using UnityEngine;
-using Epic.OnlineServices;
-using Epic.OnlineServices.Platform;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 
 #if !EOS_DISABLE
 using Epic.OnlineServices;


### PR DESCRIPTION
Removed duplicate using statements which caused warnings in Unity.