### PR TITLE
Removed LaTeX formatted headers.

### DIFF
--- a/docs/android/link_eos_library_settings.md
+++ b/docs/android/link_eos_library_settings.md
@@ -7,7 +7,7 @@
 
 
 
-# <div align="center">$\textcolor{deeppink}{\textsf{Linking EOS Library on Android Settings}}$</div> <a name="linking-eos-library-on-android-settings" />
+# <div align="center">Linking EOS Library on Android Settings</div> <a name="linking-eos-library-on-android-settings" />
 ---
 
 ## What is the Difference Between Linking the EOS Library Dynamically and Statically?

--- a/docs/android/readme_android.md
+++ b/docs/android/readme_android.md
@@ -7,7 +7,7 @@
 
 
 
-# <div align="center">$\textcolor{deeppink}{\textsf{Android Getting Started}}$</div> <a name="getting-started" />
+# <div align="center">Android Getting Started</div> <a name="getting-started" />
 ---
 
 ## Prerequisites
@@ -76,7 +76,7 @@ You can follow the standard <a href="/readme.md#configuring-the-plugin">Configur
 
 
 
-# <div align="center">$\textcolor{deeppink}{\textsf{FAQ}}$</div> <a name="faq" />
+# <div align="center">FAQ</div> <a name="faq" />
 ---
 
 See [docs/frequently_asked_questions.md](/docs/frequently_asked_questions.md).

--- a/docs/iOS/readme_iOS.md
+++ b/docs/iOS/readme_iOS.md
@@ -7,7 +7,7 @@
 
 
 
-# <div align="center">$\textcolor{deeppink}{\textsf{iOS Getting Started}}$</div> <a name="getting-started" />
+# <div align="center">iOS Getting Started</div> <a name="getting-started" />
 ---
 
 ## Prerequisites
@@ -65,7 +65,7 @@ You can follow the standard <a href="/readme.md#configuring-the-plugin">Configur
 
 
 
-# <div align="center">$\textcolor{deeppink}{\textsf{FAQ}}$</div> <a name="faq" />
+# <div align="center">FAQ</div> <a name="faq" />
 ---
 
 See [docs/frequently_asked_questions.md](/docs/frequently_asked_questions.md).

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@
   </ol>
 
 
-# <div align="center">$\textcolor{deeppink}{\textsf{Overview}}$</div> <a name="overview" />
+# <div align="center">Overview</div> <a name="overview" />
 ---
 
 The PlayEveryWare EOS Plugin for Unity is a software development kit (SDK) used for integrating EOS into a Unity project. Bringing the free services that connect players across all platforms and all stores, to Unity in an easy to use package. Find more information on EOS [here](https://dev.epicgames.com/en-US/services) and Epic docs [here](https://dev.epicgames.com/docs/epic-online-services).
@@ -157,7 +157,7 @@ The support level of each EOS SDK features as of the current release of the plug
 
 <br />
 
-# <div align="center">$\textcolor{deeppink}{\textsf{Getting Started}}$</div> <a name="getting-started" />
+# <div align="center">Getting Started</div> <a name="getting-started" />
 ---
 
 ## Prerequisites
@@ -360,7 +360,7 @@ See [docs/disable_plugin_per_platform.md](docs/disable_plugin_per_platform.md) f
 
 <br />
 
-# <div align="center">$\textcolor{deeppink}{\textsf{Plugin Support}}$</div> <a name="plugin-support" />
+# <div align="center">Plugin Support</div> <a name="plugin-support" />
 ---
 
 PlayEveryWare EOS Plugin for Unity API Documentation can be found at https://eospluginforunity.playeveryware.com.
@@ -373,7 +373,7 @@ Detailed descriptions and usage for EOS SDK Interfaces, can be found at [EOS Dev
 
 <br />
 
-# <div align="center">$\textcolor{deeppink}{\textsf{Source Code Contributor Notes}}$</div> <a name="source-code-contributor-notes" />
+# <div align="center">Source Code Contributor Notes</div> <a name="source-code-contributor-notes" />
 ---
 
 The following are guidelines for helping contribute to this open source project.
@@ -407,7 +407,7 @@ See [docs/class_description.md](docs/class_description.md).
 
 <br />
 
-# <div align="center">$\textcolor{deeppink}{\textsf{FAQ}}$</div> <a name="faq" />
+# <div align="center">FAQ</div> <a name="faq" />
 ---
 
 See [docs/frequently_asked_questions.md](docs/frequently_asked_questions.md).


### PR DESCRIPTION
Ran the following script to remove our usage of LaTeX formatting to color the headers:

```powershell
$docs = Get-ChildItem -file -Recurse ./docs/* | Where-Object { $_.Extension -eq '.md' }
$docs += Get-Item -Path "readme.md"

$docs | ForEach-Object { 
    
    # Create temporary file
    $tempFile = New-TemporaryFile;

    $titleWasReplaced = $false;

    # For each line of the file
    Get-Content $_.FullName | ForEach-Object { 
        # if it uses LaTeX formatting for color
        if ($_ -imatch '\$\\textcolor') {
            # regex away the LaTeX
            $_ -ireplace '\$\\textcolor.+{' -ireplace '}}\$' | Add-Content $tempFile;
            $titleWasReplaced = $true;
        } else {
            # if not, then just add the line as usual
            $_ | Add-Content $tempFile;
        }
    }

    if ($titleWasReplaced -eq $true) {
        # Set the content of the file to the content of the temp file.
        Get-Content $tempFile | Set-Content $_.FullName;
    }
}
```