### PR TITLE
Fix .unitypackage creation bug

### DIFF
--- a/Assets/Plugins/Source/Editor/Internal/BuildPackage.cs
+++ b/Assets/Plugins/Source/Editor/Internal/BuildPackage.cs
@@ -26,7 +26,7 @@ using UnityEditor.Build;
 
 public static class BuildPackage
 {
-    private enum PackageType
+    public enum PackageType
     {
         /// <summary>
         /// Un-compressed directory of UPM contents.
@@ -202,8 +202,7 @@ public static class BuildPackage
                 break;
             case PackageType.UPMDirectory:
             default:
-                UnityPackageCreationUtility.customOutputDirectory = OutputDirectory;
-                UnityPackageCreationUtility.CreateUPM(jsonFile);
+                UnityPackageCreationUtility.CreateUPM(OutputDirectory, jsonFile);
                 break;
 
         }

--- a/Assets/Plugins/Source/Editor/Internal/PackageDescription.cs
+++ b/Assets/Plugins/Source/Editor/Internal/PackageDescription.cs
@@ -79,7 +79,9 @@ namespace Playeveryware.Editor
 
         public bool IsCommentOnly()
         {
-            return EmptyPredicates.IsEmptyOrNull(src) && EmptyPredicates.IsEmptyOrNull(dest) && EmptyPredicates.IsEmptyOrNull(ignore_regex);
+            return (EmptyPredicates.IsEmptyOrNull(src) && 
+                EmptyPredicates.IsEmptyOrNull(dest) && 
+                EmptyPredicates.IsEmptyOrNull(ignore_regex)) || (null != comment && comment.StartsWith("//"));
         }
     }
 

--- a/Assets/Plugins/Source/Editor/Internal/PackageFileUtils.cs
+++ b/Assets/Plugins/Source/Editor/Internal/PackageFileUtils.cs
@@ -98,7 +98,7 @@ namespace Playeveryware.Editor
             var filepaths = new List<string>();
             foreach(var srcToDestKeyValues in packageDescription.source_to_dest)
             {
-                if (srcToDestKeyValues.IsCommentOnly() || srcToDestKeyValues.comment.StartsWith("//"))
+                if (srcToDestKeyValues.IsCommentOnly() || null == srcToDestKeyValues.src)
                 {
                     continue;
                 }

--- a/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationTool.cs
+++ b/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationTool.cs
@@ -81,6 +81,7 @@ public class UnityPackageCreationTool : EditorWindow
             if (SaveConfiguration())
             {
                 UPCUtil.CreateUPMTarball(UPCUtil.pathToOutput, UPCUtil.jsonPackageFile);
+                OnPackageCreated(UPCUtil.pathToOutput);
             }
         }
 
@@ -88,7 +89,10 @@ public class UnityPackageCreationTool : EditorWindow
         {
             if (SaveConfiguration())
             {
+                // Creating the dot unity package file is asynchronous, so don't display a popup
                 UPCUtil.CreateDotUnityPackage(UPCUtil.pathToOutput, UPCUtil.jsonPackageFile);
+
+                //OnPackageCreated(UPCUtil.pathToOutput);
             }
         }
 
@@ -96,9 +100,18 @@ public class UnityPackageCreationTool : EditorWindow
         {
             if (SaveConfiguration())
             {
-                CopyFilesInPackageDescriptionToBuildDir(UPCUtil.jsonPackageFile);
+                UPCUtil.CreateUPM(UPCUtil.pathToOutput, UPCUtil.jsonPackageFile);
+                OnPackageCreated(UPCUtil.pathToOutput);
             }
         }
+    }
+
+    private void OnPackageCreated(string outputPath)
+    {
+        EditorUtility.DisplayDialog(
+            "Package created",
+            $"Package was successfully created at \"{outputPath}\"",
+            "Ok");
     }
 
     private bool SaveConfiguration()
@@ -125,15 +138,5 @@ public class UnityPackageCreationTool : EditorWindow
         }
 
         return false;
-    }
-
-    //-------------------------------------------------------------------------
-    private void CopyFilesInPackageDescriptionToBuildDir(string pathToJSONPackageDescription)
-    {
-        EditorUtility.DisplayProgressBar("PEW Package Tool", "Copying files...", 0.5f);
-
-        UPCUtil.CreateUPM(UPCUtil.pathToOutput, UPCUtil.jsonPackageFile);
-
-        EditorUtility.ClearProgressBar();
     }
 }

--- a/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationTool.cs
+++ b/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationTool.cs
@@ -30,6 +30,8 @@ using ConfigEditor = PlayEveryWare.EpicOnlineServices.EpicOnlineServicesConfigEd
 //-------------------------------------------------------------------------
 public class UnityPackageCreationTool : EditorWindow
 {
+    const string DEFAULT_OUTPUT_DIRECTORY = "Build";
+
     //-------------------------------------------------------------------------
     [MenuItem("Tools/EOS Plugin/Create Package")]
     public static void ShowWindow()
@@ -68,24 +70,12 @@ public class UnityPackageCreationTool : EditorWindow
         }
         GUILayout.EndHorizontal();
 
-        GUILayout.BeginHorizontal();
-        ConfigEditor.AssigningTextField("Custom Build Directory", ref UPCUtil.customOutputDirectory);
-        if (GUILayout.Button("Select", GUILayout.MaxWidth(100)))
-        {
-            var buildDir = EditorUtility.OpenFolderPanel("Pick Custom Build Directory", "", "");
-            if (!string.IsNullOrWhiteSpace(buildDir))
-            {
-                UPCUtil.customOutputDirectory = buildDir;
-                UPCUtil.packageConfig.GetCurrentConfig().customBuildDirectoryPath = buildDir;
-            }
-        }
-        GUILayout.EndHorizontal();
-
         GUILayout.Space(20f);
 
         if (GUILayout.Button("Create UPM Package", GUILayout.MaxWidth(200)))
         {
-            if (string.IsNullOrWhiteSpace(UPCUtil.pathToOutput))
+            if (string.IsNullOrWhiteSpace(UPCUtil.pathToOutput) &&
+                false == OnEmptyOutputPath(ref UPCUtil.pathToOutput))
             {
                 return;
             }
@@ -95,7 +85,8 @@ public class UnityPackageCreationTool : EditorWindow
 
         if (GUILayout.Button("Create .unitypackage", GUILayout.MaxWidth(200)))
         {
-            if (string.IsNullOrWhiteSpace(UPCUtil.pathToOutput))
+            if (string.IsNullOrWhiteSpace(UPCUtil.pathToOutput) &&
+                false == OnEmptyOutputPath(ref UPCUtil.pathToOutput))
             {
                 return;
             }
@@ -105,13 +96,29 @@ public class UnityPackageCreationTool : EditorWindow
 
         if (GUILayout.Button("Export to Custom Build Directory", GUILayout.MaxWidth(200)))
         {
-            if (string.IsNullOrWhiteSpace(UPCUtil.customOutputDirectory))
+            if (string.IsNullOrWhiteSpace(UPCUtil.pathToOutput) && 
+                false == OnEmptyOutputPath(ref UPCUtil.pathToOutput))
             {
                 return;
             }
             UPCUtil.packageConfig.SaveToJSONConfig(true);
             CopyFilesInPackageDescriptionToBuildDir(UPCUtil.jsonPackageFile);
         }
+    }
+
+    private bool OnEmptyOutputPath(ref string output)
+    {
+        // Display dialog saying no output path was provided, and offering to default to the 'Build' directory.
+        if (EditorUtility.DisplayDialog(
+            "Empty output path",
+            $"No output path was provided, do you want to use {DEFAULT_OUTPUT_DIRECTORY}?",
+            "Yes", "Cancel"))
+        {
+            output = DEFAULT_OUTPUT_DIRECTORY;
+            return true;
+        }
+
+        return false;
     }
 
     //-------------------------------------------------------------------------

--- a/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationTool.cs
+++ b/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationTool.cs
@@ -44,7 +44,10 @@ public class UnityPackageCreationTool : EditorWindow
     //-------------------------------------------------------------------------
     private void OnGUI()
     {
+        GUILayout.Space(10f);
+
         GUILayout.BeginHorizontal();
+        GUILayout.Space(10f);
         ConfigEditor.AssigningTextField("Output Path", ref UPCUtil.pathToOutput);
         if (GUILayout.Button("Select", GUILayout.MaxWidth(100)))
         {
@@ -55,12 +58,14 @@ public class UnityPackageCreationTool : EditorWindow
                 UPCUtil.packageConfig.GetCurrentConfig().pathToOutput = UPCUtil.pathToOutput;
             }
         }
+        GUILayout.Space(10f);
         GUILayout.EndHorizontal();
 
         showJSON = EditorGUILayout.Foldout(showJSON, "Advanced");
         if (showJSON)
         {
             GUILayout.BeginHorizontal();
+            GUILayout.Space(10f);
             ConfigEditor.AssigningTextField("JSON Description Path", ref UPCUtil.jsonPackageFile);
             if (GUILayout.Button("Select", GUILayout.MaxWidth(100)))
             {
@@ -71,11 +76,15 @@ public class UnityPackageCreationTool : EditorWindow
                     UPCUtil.packageConfig.GetCurrentConfig().pathToJSONPackageDescription = UPCUtil.jsonPackageFile;
                 }
             }
+            GUILayout.Space(10f);
             GUILayout.EndHorizontal();
         }
         
         GUILayout.Space(20f);
 
+        GUILayout.BeginHorizontal();
+        GUILayout.Space(20f);
+        GUILayout.FlexibleSpace();
         if (GUILayout.Button("Create UPM Package", GUILayout.MaxWidth(200)))
         {
             if (SaveConfiguration())
@@ -96,7 +105,7 @@ public class UnityPackageCreationTool : EditorWindow
             }
         }
 
-        if (GUILayout.Button("Export to Custom Build Directory", GUILayout.MaxWidth(200)))
+        if (GUILayout.Button("Export Directory", GUILayout.MaxWidth(200)))
         {
             if (SaveConfiguration())
             {
@@ -104,6 +113,9 @@ public class UnityPackageCreationTool : EditorWindow
                 OnPackageCreated(UPCUtil.pathToOutput);
             }
         }
+        GUILayout.FlexibleSpace();
+        GUILayout.Space(20f);
+        GUILayout.EndHorizontal();
     }
 
     private void OnPackageCreated(string outputPath)

--- a/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationUtility.cs
+++ b/Assets/Plugins/Source/Editor/Internal/UnityPackageCreationUtility.cs
@@ -217,13 +217,13 @@ public static class UnityPackageCreationUtility
         AssetDatabase.ExportPackage(toExport, gzipFilePathName, options);        
     }
 
-    public static void CreateUPM(string json_file)
+    public static void CreateUPM(string outputPath, string json_file)
     {
         var packageDescription = ReadPackageDescription(json_file);
 
         var filesToCopy = PackageFileUtils.GetFileInfoMatchingPackageDescription("./", packageDescription);
 
-        CopyFilesToPackageDirectory(UnityPackageCreationUtility.customOutputDirectory, filesToCopy);
+        CopyFilesToPackageDirectory(outputPath, filesToCopy);
     }
 
     //-------------------------------------------------------------------------

--- a/docs/creating_the_upm_package.md
+++ b/docs/creating_the_upm_package.md
@@ -14,12 +14,13 @@ generate versions of the package which include "Restricted" parts as well.
 This should by default be defined as `${WHATEVER_THE_GIT_REPO_IS_CALLED}/Assets/../PackageDescriptionConfigs/eos_package_description.json`.
 This file defines what will be exported into the final UPM package, the documentation of which currently reside in the same directory as the package files.
 
-4) Fill out "Output path".
+3) Fill out "Output path".
 This is where the generated UPM package will be saved to. 
 
-5) Custom Build Directory.
-This lets one define where the files will be copied to before the final UPM is created. If left blank, a temp directory will be used.
-This setting is useful, allowing the user to export the project to another directory, using the same filtering specification as
-the package itself. In fact, this is how the GitHub project for the UPM package is setup. 
+4) Select button for the package you want to create:
+  - "Create UPM Package" will create a tarball `.tgz` file in the output directory indicated that contains the plugin.
+  - "Create .unitypackage" will create a `.unitypackage` file containing the plugin.
+  - "Export to Directory" will do the same as "Create UPM Package," but will not compress the output, so you'll get a directory of the exported files.
 
-6) Hit the "Create UPM package" to create a UPM package.
+*Advanced:*
+If you are familiar with the structure of the package `.json` file format, you can expand the advanced carrot and use a different `.json` for the package creation.


### PR DESCRIPTION
Prior to these changes, creating the package via `Tools -> EOS Plugin -> Create Package` and selecting `Create .unitypackage` button would result in a `NullReferenceException`.

These changes fix that and simplify the `Create Package` window by removing the custom build output directory field, and using instead just the output directory, and "hid" the package JSON file selection under an "Advanced" carrot. 

This is what the new window looks like:

<img width="491" alt="image" src="https://github.com/PlayEveryWare/eos_plugin_for_unity/assets/1439891/0f4d6795-9c9b-47e2-ae7a-42419cba8b0f">

This is what it used to look like:

<img width="505" alt="image" src="https://github.com/PlayEveryWare/eos_plugin_for_unity/assets/1439891/87f0aa98-5dd6-4a6c-abfe-04898fe1a805">
