### PR TITLE
Fix: Dismissal of README upon "Logout"

### DIFF
--- a/Assets/Scripts/UI/UILoginMenu.cs
+++ b/Assets/Scripts/UI/UILoginMenu.cs
@@ -869,7 +869,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             // if the readme is open, then close it.
             UIReadme readme = UIReadme.FindObjectOfType<UIReadme>();
-            readme.CloseReadme();
+            readme?.CloseReadme();
 
             if (EOSManager.Instance.GetLocalUserId() == null)
             {

--- a/Assets/Scripts/UI/UILoginMenu.cs
+++ b/Assets/Scripts/UI/UILoginMenu.cs
@@ -867,6 +867,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void OnLogoutButtonClick()
         {
+            // if the readme is open, then close it.
+            UIReadme readme = UIReadme.FindObjectOfType<UIReadme>();
+            readme.CloseReadme();
+
             if (EOSManager.Instance.GetLocalUserId() == null)
             {
                 EOSManager.Instance.ClearConnectId(EOSManager.Instance.GetProductUserId());

--- a/Assets/Scripts/UI/UIReadme.cs
+++ b/Assets/Scripts/UI/UIReadme.cs
@@ -53,4 +53,13 @@ public class UIReadme : MonoBehaviour
             ReadmeScrollRect.verticalNormalizedPosition = 1;
         }
     }
+
+    public void CloseReadme()
+    {
+        if (ReadmePanel.activeSelf)
+        {
+            ReadmePanel.SetActive(false);
+            ReadmeScrollRect.verticalNormalizedPosition = 1;
+        }
+    }
 }


### PR DESCRIPTION
Fix adds line(s) of code to dismiss the readme after the "Logout" button is pressed. 

Closes issue #375 