### PR TITLE
Fix: Do not receive a packet of size 0

### DIFF
--- a/Assets/Scripts/EOSPeer2PeerManager.cs
+++ b/Assets/Scripts/EOSPeer2PeerManager.cs
@@ -306,6 +306,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 RequestedChannel = null
             };
             P2PHandle.GetNextReceivedPacketSize(ref getNextReceivedPacketSizeOptions, out uint nextPacketSizeBytes);
+            
+            if (nextPacketSizeBytes == 0)
+            {
+                return null;
+            }
 
             byte[] data = new byte[nextPacketSizeBytes];
             var dataSegment = new ArraySegment<byte>(data);

--- a/Assets/Scripts/Networking/EOSTransportManager.cs
+++ b/Assets/Scripts/Networking/EOSTransportManager.cs
@@ -1112,6 +1112,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             };
             P2PHandle.GetNextReceivedPacketSize(ref getNextReceivedPacketSizeOptions, out uint nextPacketSizeBytes);
 
+            if (nextPacketSizeBytes == 0)
+            {
+                remoteUserId = null;
+                socketName = null;
+                channel = 0;
+                packet = null;
+                return false;
+            }
+            
             packet = new byte[nextPacketSizeBytes];
             var dataSegment = new ArraySegment<byte>(packet);
 


### PR DESCRIPTION
This fixes a rare crash that happened when `GetNextReceivedPacketSize` returned a size of 0 but `ReceivePacket` would write some number of bytes to a 0 byte buffer.