### PR TITLE
Feat: Shutdown callbacks added to EOS Manager

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -320,6 +320,11 @@ namespace PlayEveryWare.EpicOnlineServices
                 s_onAuthLogoutCallbacks.Add(authLogout.OnAuthLogout);
             }
 
+            public void AddApplicationCloseListener(Action listener)
+            {
+                s_onApplicationShutdownCallbacks.Add(listener);
+            }
+
             public void RemoveConnectLoginListener(IEOSOnConnectLogin connectLogin)
             {
                 s_onConnectLoginCallbacks.Remove(connectLogin.OnConnectLogin);
@@ -333,11 +338,6 @@ namespace PlayEveryWare.EpicOnlineServices
             public void RemoveAuthLogoutListener(IEOSOnAuthLogout authLogout)
             {
                 s_onAuthLogoutCallbacks.Remove(authLogout.OnAuthLogout);
-            }
-
-            public void AddApplicationCloseListener(Action listener)
-            {
-                s_onApplicationShutdownCallbacks.Add(listener);
             }
 
             //-------------------------------------------------------------------------

--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -109,6 +109,9 @@ namespace PlayEveryWare.EpicOnlineServices
 
         /// <value>List of Auth Logout callbacks</value>
         private static List<OnAuthLogoutCallback> s_onAuthLogoutCallbacks = new List<OnAuthLogoutCallback>();
+        
+        /// <value>List of application shutdown callbacks</value>
+        private static List<Action> s_onApplicationShutdownCallbacks = new List<Action>();
 
         /// <value>True if EOS Overlay is visible and has exclusive input.</value>
         private static bool s_isOverlayVisible = false;
@@ -330,6 +333,11 @@ namespace PlayEveryWare.EpicOnlineServices
             public void RemoveAuthLogoutListener(IEOSOnAuthLogout authLogout)
             {
                 s_onAuthLogoutCallbacks.Remove(authLogout.OnAuthLogout);
+            }
+
+            public void AddApplicationCloseListener(Action listener)
+            {
+                s_onApplicationShutdownCallbacks.Add(listener);
             }
 
             //-------------------------------------------------------------------------
@@ -1461,6 +1469,13 @@ namespace PlayEveryWare.EpicOnlineServices
             public void OnShutdown()
             {
                 print("Shutting down");
+
+                foreach(Action callback in s_onApplicationShutdownCallbacks)
+                {
+                    callback();
+                }
+
+
                 var PlatformInterface = GetEOSPlatformInterface();
                 if(PlatformInterface != null)
                 {

--- a/Assets/Scripts/Networking/EOSTransportManager.cs
+++ b/Assets/Scripts/Networking/EOSTransportManager.cs
@@ -399,6 +399,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 }
                 Connections = new Dictionary<ProductUserId, List<Connection>>();
                 InProgressPackets = new Dictionary<ushort, SortedList<ushort, byte[]>>();
+
+                EOSManager.Instance.AddApplicationCloseListener(Shutdown);
             }
 
             if (P2PHandle == null)


### PR DESCRIPTION
Adds a list of callbacks that individual managers can add to to make sure they have specific code run before the main manager shuts down. This Fixes the P2P crash on close bug