### PR TITLE
Fix platform native lib output path

### DIFF
--- a/lib/NativeCode/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.vcxproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.vcxproj
@@ -72,20 +72,20 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
     <TargetName>$(ProjectName)-x86</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
     <TargetName>$(ProjectName)-x64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -144,7 +144,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(SolutionDir)$(ProjectName)-x86.dll.meta $(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
+      <Command>copy $(SolutionDir)$(ProjectName)-x86.dll.meta $(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -168,7 +168,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(SolutionDir)$(ProjectName)-x64.dll.meta $(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
+      <Command>copy $(SolutionDir)$(ProjectName)-x64.dll.meta $(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/NativeRender.vcxproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/NativeRender.vcxproj
@@ -73,22 +73,22 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
     <TargetName>$(ProjectName)-x64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
     <TargetName>$(ProjectName)-x86</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
     <TargetName>$(ProjectName)-x86</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</OutDir>
     <TargetName>$(ProjectName)-x64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -150,7 +150,7 @@
       <EnableUAC>false</EnableUAC>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(SolutionDir)$(ProjectName)-x86.dll.meta $(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
+      <Command>copy $(SolutionDir)$(ProjectName)-x86.dll.meta $(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -175,7 +175,7 @@
       <EnableUAC>false</EnableUAC>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(SolutionDir)$(ProjectName)-x64.dll.meta $(SolutionDir)..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
+      <Command>copy $(SolutionDir)$(ProjectName)-x64.dll.meta $(SolutionDir)..\..\..\Assets\Plugins\Windows\$(PlatformTarget)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/Makefile
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/Makefile
@@ -10,8 +10,8 @@ UNITY_META_FILES = libDynamicLibraryLoaderHelper.so.meta
 all : $(SOLIBS)
 
 install : all
-	cp $(SOLIBS) ../../Assets/Plugins/Linux/
-	cp $(UNITY_META_FILES) ../../Assets/Plugins/Linux/
+	cp $(SOLIBS) ../../../Assets/Plugins/Linux/
+	cp $(UNITY_META_FILES) ../../../Assets/Plugins/Linux/
 
 clean : DynamicLibraryLoaderHelper_clean
 #-----------------------------------------------------------------------

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/Makefile
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/Makefile
@@ -12,8 +12,8 @@ UNITY_META_FILES = libDynamicLibraryLoaderHelper.dylib.meta
 all : $(DYLIBS)
 
 install : all
-	cp $(DYLIBS) ../../Assets/Plugins/macOS/
-	cp $(UNITY_META_FILES) ../../Assets/Plugins/macOS/
+	cp $(DYLIBS) ../../../Assets/Plugins/macOS/
+	cp $(UNITY_META_FILES) ../../../Assets/Plugins/macOS/
 
 clean : DynamicLibraryLoaderHelper_clean MicrophoneUtility_macos_clean
 #-----------------------------------------------------------------------


### PR DESCRIPTION
Following the folder rearrangements, native libraries that used to be built directly in place went rouge, this PR fixes that.  