### PR TITLE
fix: Use the char version of String.Split for compatibility with .NET Standard 2.0

### DIFF
--- a/Assets/Plugins/Source/Editor/EpicOnlineServicesConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/EpicOnlineServicesConfigEditor.cs
@@ -618,7 +618,7 @@ _WIN32 || _WIN64
             if (GUILayout.Button("Update from Steamworks.NET", GUILayout.MaxWidth(200)))
             {
                 var steamworksVersion = Steamworks_Utility.GetSteamworksVersion();
-                var versionParts = steamworksVersion.Split(".");
+                var versionParts = steamworksVersion.Split('.');
                 bool success = false;
                 if (versionParts.Length >= 2)
                 {


### PR DESCRIPTION
The overload for String.Split() that takes a single String parameter was added in .NET Standard 2.1.
This change brings compatibility for Unity 2020 which uses .NET Standard 2.0.