### PR TITLE
Fixed bug where files over 4096 bytes would fail to download.

### DIFF
--- a/Assets/Scripts/EOSPlayerDataStorageManager.cs
+++ b/Assets/Scripts/EOSPlayerDataStorageManager.cs
@@ -29,6 +29,8 @@ using UnityEngine;
 
 using Epic.OnlineServices;
 using Epic.OnlineServices.PlayerDataStorage;
+using static Codice.Client.Common.WebApi.WebApiEndpoints;
+using static UnityEditor.PlayerSettings;
 
 namespace PlayEveryWare.EpicOnlineServices.Samples
 {
@@ -384,19 +386,21 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     }
                 }
 
-                if (isLastChunk)//transfer.TotalSize - transfer.CurrentIndex >= numBytes)
+                // If more data has been received than was anticipated, fail the request
+                if (transfer.TotalSize < transfer.CurrentIndex + data.Count)
                 {
-                    data.Array.CopyTo(transfer.Data, transfer.CurrentIndex);
-
-                    transfer.CurrentIndex = transfer.TotalSize; // Done
-
-                    return ReadResult.ContinueReading;
-                }
-                else
-                {
-                    Debug.LogError("[EOS SDK] Player data storage: could not receive data: too much of it.");
+                    Debug.LogError("[EOS SDK] Player data storage: could not receive data: too much.");
                     return ReadResult.FailRequest;
                 }
+
+                // Copy the data 
+                data.Array?.CopyTo(transfer.Data, transfer.CurrentIndex);
+
+                // Advance the index by the amount of data received.
+                transfer.CurrentIndex += (uint)data.Count;
+
+                // Keep reading
+                return ReadResult.ContinueReading;
             }
 
             return ReadResult.CancelRequest;

--- a/Assets/Scripts/EOSPlayerDataStorageManager.cs
+++ b/Assets/Scripts/EOSPlayerDataStorageManager.cs
@@ -29,8 +29,6 @@ using UnityEngine;
 
 using Epic.OnlineServices;
 using Epic.OnlineServices.PlayerDataStorage;
-using static Codice.Client.Common.WebApi.WebApiEndpoints;
-using static UnityEditor.PlayerSettings;
 
 namespace PlayEveryWare.EpicOnlineServices.Samples
 {

--- a/Assets/Scripts/EOSTransferInProgress.cs
+++ b/Assets/Scripts/EOSTransferInProgress.cs
@@ -32,7 +32,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
     public class EOSTransferInProgress
     {
-        public const int FileMaxSizeBytes = (64 * 1024 * 1024);
+        // per EOS SDK documentation, the maximum size for a file is 200MB, or this many bytes.
+        public const int FileMaxSizeBytes = 200000000;
 
         public bool Download = true;
         public uint CurrentIndex = 0;

--- a/Assets/Scripts/UI/UIPlayerDataStorageMenu.cs
+++ b/Assets/Scripts/UI/UIPlayerDataStorageMenu.cs
@@ -154,7 +154,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 return;
             }
 
+            // This is to test a typical use case
             string newFileContents = JsonUtility.ToJson(new PlayerDataInventory(), true);
+
+            // TODO: Add this as a test case.
+            // Un-comment the following lines to test a large file
+            // newFileContents = new string('*', 20000);
 
             PlayerDataStorageManager.AddFile(NewFileNameTextBox.InputField.text, newFileContents, UpdateFileListUI);
 


### PR DESCRIPTION
This PR fixes a bug in the player storage implementation where any file over the `MAX_CHUNK_SIZE` (4096) bytes would fail to download. The logic of the code was faulty. It has since been updated. I also changed the maximum file size to reflect the usage restrictions dictated by the EOS SDK documentation (files are allowed to be up to 200MB in size). 

This resolves issue #480 