### PR TITLE
feat(rtc) : allow custom rtc options

### DIFF
--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -47,6 +47,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public uint AvailableSlots = 0;
         public bool AllowInvites = true;
         public bool? DisableHostMigration;
+        public LocalRTCOptions? localRTCOptions;
 
         // Cached copy of the RoomName of the RTC room that our lobby has, if any
         public string RTCRoomName = string.Empty;
@@ -979,16 +980,19 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // Voice Chat
             if(lobbyProperties.RTCRoomEnabled)
             {
-                LocalRTCOptions rtcOptions = new LocalRTCOptions()
+                if (lobbyProperties.localRTCOptions == null)
                 {
-                    Flags = 0, //EOS_RTC_JOINROOMFLAGS_ENABLE_ECHO;
-                    UseManualAudioInput = false,
-                    UseManualAudioOutput = false,
-                    LocalAudioDeviceInputStartsMuted = false
-                };
+                    lobbyProperties.localRTCOptions = new LocalRTCOptions()
+                    {
+                        Flags = 0, //EOS_RTC_JOINROOMFLAGS_ENABLE_ECHO;
+                        UseManualAudioInput = false,
+                        UseManualAudioOutput = false,
+                        LocalAudioDeviceInputStartsMuted = false
+                    };
+                }
 
                 createLobbyOptions.EnableRTCRoom = true;
-                createLobbyOptions.LocalRTCOptions = rtcOptions;
+                createLobbyOptions.LocalRTCOptions = lobbyProperties.localRTCOptions;
             }
             else
             {

--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -47,7 +47,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public uint AvailableSlots = 0;
         public bool AllowInvites = true;
         public bool? DisableHostMigration;
-        public LocalRTCOptions? localRTCOptions;
 
         // Cached copy of the RoomName of the RTC room that our lobby has, if any
         public string RTCRoomName = string.Empty;
@@ -471,9 +470,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private List<Action> LobbyUpdateCallbacks;
 
         private EOSUserInfoManager UserInfoManager;
+        
+        public LocalRTCOptions? customLocalRTCOptions;
 
         // Init
-
         public EOSLobbyManager()
         {
             UserInfoManager = EOSManager.Instance.GetOrCreateManager<EOSUserInfoManager>();
@@ -980,24 +980,16 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // Voice Chat
             if(lobbyProperties.RTCRoomEnabled)
             {
-                if (lobbyProperties.localRTCOptions == null)
+                if (customLocalRTCOptions != null)
                 {
-                    lobbyProperties.localRTCOptions = new LocalRTCOptions()
-                    {
-                        Flags = 0, //EOS_RTC_JOINROOMFLAGS_ENABLE_ECHO;
-                        UseManualAudioInput = false,
-                        UseManualAudioOutput = false,
-                        LocalAudioDeviceInputStartsMuted = false
-                    };
+                    createLobbyOptions.LocalRTCOptions = customLocalRTCOptions;
                 }
 
-                createLobbyOptions.EnableRTCRoom = true;
-                createLobbyOptions.LocalRTCOptions = lobbyProperties.localRTCOptions;
+                createLobbyOptions.EnableRTCRoom = true;      
             }
             else
             {
                 createLobbyOptions.EnableRTCRoom = false;
-                createLobbyOptions.LocalRTCOptions = null;
             }
 
             EOSManager.Instance.GetEOSLobbyInterface().CreateLobby(ref createLobbyOptions, CreateLobbyCompleted, OnCreateLobbyCompleted);
@@ -2333,7 +2325,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             joinOptions.LobbyDetailsHandle = lobbyDetails;
             joinOptions.LocalUserId = EOSManager.Instance.GetProductUserId();
             joinOptions.PresenceEnabled = presenceEnabled;
-
+            if (customLocalRTCOptions != null)
+            {
+                joinOptions.LocalRTCOptions = customLocalRTCOptions;
+            }
             EOSManager.Instance.GetEOSLobbyInterface().JoinLobby(ref joinOptions, JoinLobbyCompleted, OnJoinLobbyCompleted);
         }
 


### PR DESCRIPTION
This PR creates a `localRTCOptions` variable in the `Lobby` class, that should allow the user to set the options to meet their needs.
The thing I am not so sure about is whether this variable should really exist in this class, or even if it needs to be held beyond the scope of a function/method