### PR TITLE
fix: resolve errors where types only availabe in the Unity Editor were

### DIFF
--- a/Assets/Plugins/Source/Core/Config.cs
+++ b/Assets/Plugins/Source/Core/Config.cs
@@ -50,6 +50,9 @@ namespace PlayEveryWare.EpicOnlineServices
             return IsDefault(this);
         }
 
+#endif
+
+
         /// <summary>
         /// Returns member-wise clone of configuration data
         /// (copies the values).
@@ -60,6 +63,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return this.MemberwiseClone();
         }
 
+#if UNITY_EDITOR
         #region Functions to help determine if a config has default values
 
         /// <summary>

--- a/Assets/Plugins/Source/Core/EOSCreateOptions.cs
+++ b/Assets/Plugins/Source/Core/EOSCreateOptions.cs
@@ -43,7 +43,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         #region Platform-Specific properties
 
-#if UNITY_PS5 || UNITY_GAMECORE || UNITY_SWITCH
+#if UNITY_PS5 || UNITY_GAMECORE || UNITY_SWITCH || UNITY_ANDROID || UNITY_IOS
         public IntegratedPlatformOptionsContainer IntegratedPlatformOptionsContainerHandle { get => options.IntegratedPlatformOptionsContainerHandle; set => options.IntegratedPlatformOptionsContainerHandle = value; }
 #endif
 

--- a/Assets/Plugins/Source/Core/PlatformManager.cs
+++ b/Assets/Plugins/Source/Core/PlatformManager.cs
@@ -115,6 +115,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }));
         }
 
+#if UNITY_EDITOR
         /// <summary>
         /// Maps Unity BuildTarget to Platform
         /// </summary>
@@ -143,6 +144,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return PlatformInformation[platform].ConfigType;
         }
 
+#endif
         /// <summary>
         /// Return a string that represents the file extension used by the indicated platform for dynamic library files.
         /// </summary>
@@ -153,6 +155,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return PlatformInformation[platform].DynamicLibraryExtension;
         }
 
+
         /// <summary>
         /// Get the file extension used by the current platform for dynamic library files.
         /// </summary>
@@ -162,6 +165,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return GetDynamicLibraryExtension(CurrentPlatform);
         }
 
+#if UNITY_EDITOR
         /// <summary>
         /// Returns the type of the PlatformConfig that holds configuration values for the indicated BuildTarget
         /// </summary>
@@ -183,7 +187,7 @@ namespace PlayEveryWare.EpicOnlineServices
             var platform = TargetToPlatformsMap[target];
             return GetConfigFilePath(platform);
         }
-
+#endif
         /// <summary>
         /// Return the fully qualified path to the configuration file for the current platform.
         /// </summary>
@@ -226,6 +230,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return false;
         }
 
+#if UNITY_EDITOR
         /// <summary>
         /// Try to retrieve the config file path for the indicated BuildTarget.
         /// </summary>
@@ -237,6 +242,7 @@ namespace PlayEveryWare.EpicOnlineServices
             var platform = TargetToPlatformsMap[target];
             return TryGetConfigFilePath(platform, out configFilePath);
         }
+#endif
 
         /// <summary>
         /// Returns the name of the JSON file that contains configuration values for the given platform.

--- a/Assets/Plugins/Windows/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/WindowsPlatformSpecifics.cs
@@ -38,6 +38,7 @@ using UnityEngine;
 
 using Epic.OnlineServices.Platform;
 using System.Runtime.InteropServices;
+using UnityEngine.Scripting;
 
 #if (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA_10_0)
 


### PR DESCRIPTION
# Intro 
While doing a quick audit of the state of the code in the development branch, I noticed that the standalone builds were not building.

# Overview of changes
Single commit with the changes needed to resolve the build errors, allowing standalone builds to work.
