### PR TITLE
fix: Package Description Fix

### DIFF
--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -50,6 +50,20 @@
         {"src":"Assets/Plugins/Source/Editor/Utility/*.cs", "dest": "Editor/Utility/"},
         {"src":"Assets/Plugins/Source/Editor/Utility/*.cs.meta", "dest": "Editor/Utility/"},
         
+        {"src":"Assets/Plugins/Source/Editor/Build.meta", "dest": "Editor/"},
+        {"src":"Assets/Plugins/Source/Editor/Build/*.cs", "dest": "Editor/Build/"},
+        {"src":"Assets/Plugins/Source/Editor/Build/*.cs.meta", "dest": "Editor/Build/"},
+
+        {"src":"Assets/Plugins/Source/Editor/ConfigEditors.meta", "dest": "Editor/"},
+        {"src":"Assets/Plugins/Source/Editor/ConfigEditors/*.cs", "dest": "Editor/ConfigEditors/"},
+        {"src":"Assets/Plugins/Source/Editor/ConfigEditors/*.cs.meta", "dest": "Editor/ConfigEditors/"},
+
+        {"src":"Assets/Plugins/Source/Editor/Configs.meta", "dest": "Editor/"},
+        {"src":"Assets/Plugins/Source/Editor/Configs/*.cs", "dest": "Editor/Configs/"},
+        {"src":"Assets/Plugins/Source/Editor/Configs/*.cs.meta", "dest": "Editor/Configs/"},
+        
+
+
         {"comment": "----------------------------Standalone---------------------------------------------"},
         {"src":"Assets/Plugins/Standalone/Editor.meta", "dest": "Editor/Standalone.meta"},
         {"src":"Assets/Plugins/Standalone/Editor/*", "dest": "Editor/Standalone/"},
@@ -73,6 +87,10 @@
         {"src":"Assets/Plugins/Windows/x86/license.txt.meta", "dest": "Runtime/windows/x86/"},
         {"src":"Assets/Plugins/Windows/x86/ThirdPartySoftwareNotice.txt", "dest": "Runtime/windows/x86/"},
         {"src":"Assets/Plugins/Windows/x86/ThirdPartySoftwareNotice.txt.meta", "dest": "Runtime/windows/x86/"},
+
+        {"src":"Assets/Plugins/Windows/Core.meta", "dest": "Runtime/Windows/"},
+        {"src":"Assets/Plugins/Windows/Core/*.cs", "dest": "Runtime/Windows/Core/"},
+        {"src":"Assets/Plugins/Windows/Core/*.cs.meta", "dest": "Runtime/Windows/Core/"},
 
         {"src":"Assets/Plugins/Windows/*.cs", "dest": "Runtime/Windows/"},
         {"src":"Assets/Plugins/Windows/*.cs.meta", "dest": "Runtime/Windows/"},

--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -91,6 +91,9 @@
         {"src":"Assets/Plugins/Windows/Core.meta", "dest": "Runtime/Windows/"},
         {"src":"Assets/Plugins/Windows/Core/*.cs", "dest": "Runtime/Windows/Core/"},
         {"src":"Assets/Plugins/Windows/Core/*.cs.meta", "dest": "Runtime/Windows/Core/"},
+        {"src":"Assets/Plugins/Windows/Editor.meta", "dest": "Editor/Windows.meta"},
+        {"src":"Assets/Plugins/Windows/Editor/*.cs", "dest": "Editor/Windows/"},
+        {"src":"Assets/Plugins/Windows/Editor/*.cs.meta", "dest": "Editor/Windows/"},
 
         {"src":"Assets/Plugins/Windows/*.cs", "dest": "Runtime/Windows/"},
         {"src":"Assets/Plugins/Windows/*.cs.meta", "dest": "Runtime/Windows/"},


### PR DESCRIPTION
Some recent changes to the plugin invalidated the JSON package description file we use to create the package. This resolves those issues so that the UPM can be imported properly.