### PR TITLE
feat(networking): Change from copying byte arrays to using ArraySegments in EOSTransport SendPacket methods.

### DIFF
--- a/Assets/Scripts/Networking/EOSTransport.cs
+++ b/Assets/Scripts/Networking/EOSTransport.cs
@@ -155,14 +155,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 }
             }
 
-            // Construct our packet to be sent (ie. the payload array segment)
-            byte[] packet = new byte[payload.Count];
-            Array.Copy(payload.Array, payload.Offset, // Source
-                       packet, 0,                     // Destination
-                       payload.Count);                // Length to copy
-
-
-            P2PManager.SendPacket(userId, P2PSocketName, packet, 0, false, reliability);
+            P2PManager.SendPacket(userId, P2PSocketName, payload, 0, false, reliability);
         }
 
         /// <summary>


### PR DESCRIPTION
# Intro 
While looking at the EOSTransport code, I noticed that we do a lot of converting from ArraySegments<bytes> into byte[] types, and also cloning those byte[] to other arrays.

# Overview of changes
These changes are targeted on the `EOSTransportManager.SendPacket` method, and focus only on decreasing the number of copies that occur between arrays to help speed up packet sending.
