### PR TITLE
fix: Rectified regression concerning the EOSBootstrapper and the EOS overlay.

### DIFF
--- a/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
@@ -126,11 +126,8 @@ namespace PlayEveryWare.EpicOnlineServices.Build
                 return;
             }
 
-            // perform the post-build task for the platform using it's builder.
+            // Perform the post-build task for the platform using it's builder.
             GetBuilder()?.PostBuild(report);
-
-            // Configure EAC (Note that this only happens on "standalone" builds.
-            EACPostBuild.ConfigureEAC(report);
         }
 
         /// <summary>

--- a/Assets/Plugins/Source/Editor/Build/EACPostBuild.cs
+++ b/Assets/Plugins/Source/Editor/Build/EACPostBuild.cs
@@ -43,7 +43,10 @@ namespace PlayEveryWare.EpicOnlineServices.Build
         private static readonly HashSet<string> postBuildFilesWithVars =
             new HashSet<string>() { "EasyAntiCheat/Settings.json" };
 
-        private static string GetPathToEOSBin()
+        // TODO: From an organizational perspective - this function ought to be implemented
+        //       somewhere other than EACPostBuild, as it's functionality is used in several
+        //       places in the build process that have little to do with EAC.
+        public static string GetPathToEOSBin()
         {
             string projectPathToBin = Path.Combine(Application.dataPath, "../tools/bin/");
             string packagePathToBin = Path.GetFullPath("Packages/" + EOSPackageInfo.GetPackageName() + "/bin~/");
@@ -96,52 +99,6 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
             return pathToInstallFrom;
         }
-
-
-#if UNITY_EDITOR_WIN
-        private static void InstallBootStrapper(string appFilenameExe, string installDirectory,
-            string pathToEOSBootStrapperTool, string bootstrapperFileName)
-        {
-            string installPathForEOSBootStrapper = Path.Combine(installDirectory, bootstrapperFileName);
-            string workingDirectory = GetPathToEOSBin();
-            string bootStrapperArgs = ""
-                                      + " --output-path " + "\"" + installPathForEOSBootStrapper + "\""
-                                      + " --app-path " + "\"" + appFilenameExe + "\""
-                ;
-
-            var procInfo = new System.Diagnostics.ProcessStartInfo();
-            procInfo.FileName = pathToEOSBootStrapperTool;
-            procInfo.Arguments = bootStrapperArgs;
-            procInfo.UseShellExecute = false;
-            procInfo.WorkingDirectory = workingDirectory;
-            procInfo.RedirectStandardOutput = true;
-            procInfo.RedirectStandardError = true;
-
-            var process = new System.Diagnostics.Process { StartInfo = procInfo };
-            process.OutputDataReceived += new System.Diagnostics.DataReceivedEventHandler((sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    Debug.Log(e.Data);
-                }
-            });
-
-            process.ErrorDataReceived += new System.Diagnostics.DataReceivedEventHandler((sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    Debug.LogError(e.Data);
-                }
-            });
-
-            bool didStart = process.Start();
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-            process.WaitForExit();
-            process.Close();
-
-        }
-#endif
 
         private static string GetDefaultIntegrityToolPath()
         {
@@ -468,38 +425,6 @@ namespace PlayEveryWare.EpicOnlineServices.Build
                 {
                     CopySplashImage(report, editorToolConfig.pathToEACSplashImage);
                 }
-
-#if UNITY_EDITOR_WIN
-                if (report.summary.platform == BuildTarget.StandaloneWindows ||
-                    report.summary.platform == BuildTarget.StandaloneWindows64)
-                {
-                    string bootstrapperName = null;
-                    if (editorToolConfig != null)
-                    {
-                        bootstrapperName = editorToolConfig.bootstrapperNameOverride;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(bootstrapperName))
-                    {
-                        bootstrapperName = "EOSBootstrapper.exe";
-                    }
-
-                    if (!bootstrapperName.EndsWith(".exe"))
-                    {
-                        bootstrapperName += ".exe";
-                    }
-
-                    string pathToEOSBootStrapperTool = Path.Combine(GetPathToEOSBin(), "EOSBootstrapperTool.exe");
-
-                    string installDirectory = Path.GetDirectoryName(report.summary.outputPath);
-
-                    string bootstrapperTarget =
-                        useEAC ? "EACLauncher.exe" : Path.GetFileName(report.summary.outputPath);
-
-                    InstallBootStrapper(bootstrapperTarget, installDirectory, pathToEOSBootStrapperTool,
-                        bootstrapperName);
-                }
-#endif
 
                 if (!string.IsNullOrWhiteSpace(editorToolConfig.pathToEACPrivateKey) &&
                     !string.IsNullOrWhiteSpace(editorToolConfig.pathToEACCertificate))

--- a/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
@@ -176,5 +176,18 @@ namespace PlayEveryWare.EpicOnlineServices.Build
         {
             return string.Empty;
         }
+
+        /// <summary>
+        /// Determines if the build is a standalone build.
+        /// </summary>
+        /// <returns>True if the build is standalone, false otherwise.</returns>
+        protected bool IsStandalone()
+        {
+#if UNITY_STANDALONE
+            return true;
+#else
+            return false;
+#endif
+        }
     }
 }

--- a/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
@@ -80,6 +80,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
         /// <summary>
         /// Implement this function on a per-platform basis to provide custom logic for the platform being compiled.
+        /// Any overriding implementations should first call the base implementation.
         /// </summary>
         /// <param name="report"></param>
         public virtual void PreBuild(BuildReport report)
@@ -89,11 +90,17 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
         /// <summary>
         /// Implement this function on a per-platform basis to provide custom logic for the platform being compiled.
+        /// Any overriding implementations should first call the base implementation.
         /// </summary>
         /// <param name="report"></param>
         public virtual void PostBuild(BuildReport report)
         {
-            // Default post-build behavior is empty for the time being.
+            // The only standalone platforms that are supported are WIN/OSX/Linux
+            if (IsStandalone())
+            {
+                // Configure easy-anti-cheat.
+                EACPostBuild.ConfigureEAC(report);
+            }
         }
 
         /// <summary>
@@ -183,7 +190,12 @@ namespace PlayEveryWare.EpicOnlineServices.Build
         /// <returns>True if the build is standalone, false otherwise.</returns>
         protected bool IsStandalone()
         {
-#if UNITY_STANDALONE
+            // It is unclear from the Unity documentation what the meaning of "UNITY_STANDALONE" is,
+            // although it can be reasonably inferred from context that it will be defined if any
+            // of the following specific standalone scripting defines exist, for the sake of future-
+            // proofing the scenario where a new standalone platform is introduced, each of the three
+            // standalone platforms that the EOS Plugin current supports are explicitly checked here.
+#if UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN
             return true;
 #else
             return false;

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -22,8 +22,17 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
+    using PlayEveryWare.EpicOnlineServices.Editor.Config;
+    using PlayEveryWare.EpicOnlineServices.Editor;
+    using UnityEditor.Build.Reporting;
+    using System.IO;
+    using UnityEngine;
+    using Utility;
+
     public class WindowsBuilder : PlatformSpecificBuilder
     {
+        private const string ProjectPathToEOSBootstrapperTool = "tools/bin/EOSBootstrapperTool.exe";
+
         public WindowsBuilder() : base("Plugins/Windows")
         {
             // TODO/NOTE: Add support for 32-bit project to binary file mapping?
@@ -31,6 +40,123 @@ namespace PlayEveryWare.EpicOnlineServices.Build
                 "DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.sln",
                 "x64/DynamicLibraryLoaderHelper-x64.dll",
                 "x64/GfxPluginNativeRender-x64.dll");
+        }
+
+        public override void PostBuild(BuildReport report)
+        {
+            base.PostBuild(report);
+
+            ConfigureAndInstallBootstrapper(report);
+        }
+
+        private static void ConfigureAndInstallBootstrapper(BuildReport report)
+        {
+            /*
+             * NOTE:
+             *
+             * The following code functions properly, but exposes some poor design with
+             * respect to the build process. For starters, in order to determine whether
+             * EAC is installed, this function must instantiate a config editor. It would
+             * be nice if there was a way to query the config values via a static property
+             * like this:
+             *
+             * if (ToolsConfig.UseEAC) { ... }
+             *
+             * However, that does not actually answer the question that needs answering
+             * in the context of installing the bootstrapper. This answers the question
+             * "Is EAC supposed to be configured?" Because if the answer is yes, then
+             * the bootstrapper tool needs to use EACLauncher.exe as the target.
+             *
+             * The reason it is insufficient to answer the question "Is EAC supposed to be
+             * configured?" for this purpose is that it doesn't determine if EAC *IS*
+             * configured. This current solution relies on the fact that the steps happen
+             * to be in-order.
+             *
+             * Rectifying these design flaws is beyond the scope of what needs to be done
+             * right now, but this note remains for the sake of future Build engineers
+             * wishing to improve the system, and future developers who may encounter
+             * build issues surrounding the Bootstrapper and/or the Easy Anti-Cheat system
+             * that are difficult to diagnose.
+             */
+
+            // Determine whether or not to install EAC
+            var editorToolsConfigSection = new ToolsConfigEditor();
+            bool useEAC = false;
+
+            editorToolsConfigSection.Load();
+
+            ToolsConfig editorToolConfig = editorToolsConfigSection.GetConfig().Data;
+            if (editorToolConfig != null)
+            {
+                useEAC = editorToolConfig.useEAC;
+            }
+
+            string bootstrapperName = null;
+            if (editorToolConfig != null)
+            {
+                bootstrapperName = editorToolConfig.bootstrapperNameOverride;
+            }
+
+            if (string.IsNullOrWhiteSpace(bootstrapperName))
+            {
+                bootstrapperName = "EOSBootstrapper.exe";
+            }
+
+            if (!bootstrapperName.EndsWith(".exe"))
+            {
+                bootstrapperName += ".exe";
+            }
+
+            string pathToEOSBootStrapperTool = Path.Combine(PackageFileUtility.GetProjectPath(), ProjectPathToEOSBootstrapperTool);
+
+            string installDirectory = Path.GetDirectoryName(report.summary.outputPath);
+
+            string bootstrapperTarget =
+                useEAC ? "EACLauncher.exe" : Path.GetFileName(report.summary.outputPath);
+
+            InstallBootStrapper(bootstrapperTarget, installDirectory, pathToEOSBootStrapperTool,
+                bootstrapperName);
+        }
+
+        private static void InstallBootStrapper(string appFilenameExe, string installDirectory,
+            string pathToEOSBootStrapperTool, string bootstrapperFileName)
+        {
+            string installPathForEOSBootStrapper = Path.Combine(installDirectory, bootstrapperFileName);
+            string workingDirectory = EACPostBuild.GetPathToEOSBin();
+            string bootStrapperArgs = ""
+                                      + $" --output-path \"{installPathForEOSBootStrapper}\""
+                                      + $" --app-path \"{appFilenameExe}\"";
+
+            var procInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = pathToEOSBootStrapperTool, Arguments = bootStrapperArgs,
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            var process = new System.Diagnostics.Process { StartInfo = procInfo };
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Debug.Log(e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Debug.LogError(e.Data);
+                }
+            };
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
+            process.Close();
         }
     }
 }

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -26,6 +26,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     using PlayEveryWare.EpicOnlineServices.Editor;
     using UnityEditor.Build.Reporting;
     using System.IO;
+    using UnityEditor.Build;
     using UnityEngine;
     using Utility;
 
@@ -152,6 +153,11 @@ namespace PlayEveryWare.EpicOnlineServices.Build
                     Debug.LogError(e.Data);
                 }
             };
+
+            if (false == process.Start())
+            {
+                throw new BuildFailedException($"Failed to run the BootstrapperTool \"{pathToEOSBootStrapperTool}\".");
+            }
 
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();


### PR DESCRIPTION
This PR fixes a regression that was introduced at some point during the recent changes to the build system.

Those changes errantly coupled the configuration and execution of Easy-Anti-Cheat and the Bootstrapper. 

The regression was such that if EAC was not configured, then the bootstrapper tool would not be utilized, which would prevent the friends overlay from displaying on Windows.