### PR TITLE
Set log levels during application startup with config.

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -578,6 +578,8 @@ namespace PlayEveryWare.EpicOnlineServices
                     loadedEOSConfig = LoadEOSConfigFileFromPath(eosFinalConfigPath);
                 }
 
+                var logLevelList = LogLevelHelper.LogLevelList;
+
                 if (GetEOSPlatformInterface() != null)
                 {
                     print("Init completed with existing EOS PlatformInterface");
@@ -587,11 +589,11 @@ namespace PlayEveryWare.EpicOnlineServices
                         LoggingInterface.SetCallback(SimplePrintCallback);
                         hasSetLoggingCallback = true;
                     }
-#if UNITY_EDITOR
-                    SetLogLevel(LogCategory.AllCategories, LogLevel.VeryVerbose);
-#else
-                    SetLogLevel(LogCategory.AllCategories, LogLevel.Warning);
-#endif
+
+                    for (int logCategoryIndex = 0; logCategoryIndex < logLevelList.Count; logCategoryIndex++)
+                    {
+                        SetLogLevel((LogCategory)logCategoryIndex, logLevelList[logCategoryIndex]);
+                    }
 
                     InitializeOverlay(coroutineOwner);
                     return;
@@ -675,12 +677,10 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 InitializeOverlay(coroutineOwner);
 
-                // Default back to quiet logs
-#if UNITY_EDITOR
-                SetLogLevel(LogCategory.AllCategories, LogLevel.VeryVerbose);
-#else
-                SetLogLevel(LogCategory.AllCategories, LogLevel.Warning);
-#endif
+                for (int logCategoryIndex = 0; logCategoryIndex < logLevelList.Count; logCategoryIndex++)
+                {
+                    SetLogLevel((LogCategory)logCategoryIndex, logLevelList[logCategoryIndex]);
+                }
 
                 print("EOS loaded");
             }

--- a/Assets/Plugins/Source/Core/LogLevelConfig.cs
+++ b/Assets/Plugins/Source/Core/LogLevelConfig.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PlayEveryWare.EpicOnlineServices
+{
+    [Serializable]
+    public class LogCategoryLevelPair
+    {
+        public string category;
+        public string level;
+
+        public LogCategoryLevelPair(string _category, string _level)
+        {
+            category = _category;
+            level = _level;
+        }
+    }
+
+    [Serializable]
+    public class LogLevelConfig : Config
+    {
+        public List<LogCategoryLevelPair> logCategoryLevelPairs;
+    }
+}

--- a/Assets/Plugins/Source/Core/LogLevelConfig.cs.meta
+++ b/Assets/Plugins/Source/Core/LogLevelConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40eb8a388984ef440bd1139596fb7366
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Source/Core/LogLevelHelper.cs
+++ b/Assets/Plugins/Source/Core/LogLevelHelper.cs
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using UnityEngine;
+using Epic.OnlineServices.Logging;
+
+
+namespace PlayEveryWare.EpicOnlineServices
+{
+    public static class LogLevelHelper
+    {
+        public static string[] LogCategoryStringArray
+        {
+            get { return Enum.GetNames(typeof(LogCategory)); }
+        }
+        public static string[] LogLevelStringArray
+        {
+            get { return Enum.GetNames(typeof(LogLevel)); }
+        }
+
+        public static LogLevelConfig LoadLogLevelConfigFileFromPath(string logLevelConfigPath)
+        {
+            string configDataAsString = "";
+#if UNITY_ANDROID && !UNITY_EDITOR
+            configDataAsString = AndroidFileIOHelper.ReadAllText(logLevelConfigPath);
+#else
+
+            if (!File.Exists(logLevelConfigPath))
+            {
+                throw new Exception("Couldn't find Log Level Config file: Please ensure log_level_config.json exists and is a valid config");
+            }
+
+            configDataAsString = File.ReadAllText(logLevelConfigPath);
+#endif
+            var configData = JsonUtility.FromJson<LogLevelConfig>(configDataAsString);
+
+            Debug.Log("Loaded log level config file: " + configDataAsString);
+            return configData;
+        }
+
+        public static List<LogLevel> LogLevelList
+        {
+            get
+            {
+                LogLevelConfig logLevelConfig = LoadLogLevelConfigFileFromPath(Path.Combine(Application.streamingAssetsPath, "EOS", "log_level_config.json"));
+                
+                var logLevels = new List<LogLevel>();
+                for (int i = 0; i < LogCategoryStringArray.Length - 1; i++)
+                {
+                    if (Enum.TryParse(logLevelConfig.logCategoryLevelPairs[i].level, out LogLevel parsedLogLevel))
+                    {
+                        logLevels.Add(parsedLogLevel);
+                    }
+                    else
+                    {
+                        logLevels.Add(LogLevel.Info);
+                        Debug.Log("Failed to Parse Log Level");
+                    }
+                }
+                return logLevels;
+            }
+        }
+    }
+}

--- a/Assets/Plugins/Source/Core/LogLevelHelper.cs.meta
+++ b/Assets/Plugins/Source/Core/LogLevelHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21eec1919f433054da16fba1ef13e81b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Source/Editor/Windows/LogLevelWindow.cs
+++ b/Assets/Plugins/Source/Editor/Windows/LogLevelWindow.cs
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using UnityEngine;
+using UnityEditor;
+using System;
+using System.Collections.Generic;
+
+
+namespace PlayEveryWare.EpicOnlineServices.Editor
+{
+    public class LogLevelWindow : EOSEditorWindow
+    {
+        ConfigHandler<LogLevelConfig> logLevelConfigFile;
+        LogLevelConfig currentLogLevelConfig;
+
+        string[] categories = LogLevelHelper.LogCategoryStringArray;
+        string[] levels = LogLevelHelper.LogLevelStringArray;
+
+        int selectedCategoryIndex = 0;
+        bool showAllCategories = false;
+        string previousAllCategoryLogLevel;
+
+        [MenuItem("Tools/EOS Plugin/Log Level")]
+        public static void ShowWindow()
+        {
+            GetWindow<LogLevelWindow>("Log Level");
+        }
+        protected override void Setup()
+        {
+            logLevelConfigFile = new ConfigHandler<LogLevelConfig>(Application.streamingAssetsPath + "/EOS/log_level_config.json");
+            logLevelConfigFile.Read();
+
+            currentLogLevelConfig = logLevelConfigFile.Data;
+            if (currentLogLevelConfig.logCategoryLevelPairs == null) 
+            {
+                currentLogLevelConfig.logCategoryLevelPairs = new List<LogCategoryLevelPair>();
+            }
+
+            if (currentLogLevelConfig.logCategoryLevelPairs.Count != categories.Length)
+            {
+                currentLogLevelConfig.logCategoryLevelPairs.Clear();
+
+                foreach (var category in categories)
+                {
+                    currentLogLevelConfig.logCategoryLevelPairs.Add(new LogCategoryLevelPair(category, "Info"));
+                }
+
+                SaveToJSONConfig(true);
+            }
+        }
+        protected override void RenderWindow()
+        {
+            // Last element in the list is All Categories
+            previousAllCategoryLogLevel = currentLogLevelConfig.logCategoryLevelPairs[categories.Length - 1].level;
+
+            showAllCategories = EditorGUILayout.Toggle("Show All Log Settings", showAllCategories);
+            EditorGUILayout.LabelField("Category", "Level", GUILayout.Width(200));
+
+            if (showAllCategories)
+            {
+                foreach (var pair in currentLogLevelConfig.logCategoryLevelPairs)
+                {
+                    int selectedLevelIndex = EditorGUILayout.Popup(pair.category, Array.IndexOf(levels, pair.level), levels);
+                    pair.level = LogLevelHelper.LogLevelStringArray[selectedLevelIndex];
+                }
+            }
+            else
+            {
+                EditorGUILayout.BeginHorizontal();
+                selectedCategoryIndex = EditorGUILayout.Popup(selectedCategoryIndex, categories);
+
+                var selectedPair = logLevelConfigFile.Data.logCategoryLevelPairs[selectedCategoryIndex];
+                int selectedLevelIndex = EditorGUILayout.Popup(Array.IndexOf(levels, selectedPair.level), levels);
+                selectedPair.level = LogLevelHelper.LogLevelStringArray[selectedLevelIndex];           
+                EditorGUILayout.EndHorizontal();
+            }
+
+            // If Level for All Category is "dirty", then update every category
+            var newAllCategoryLogLevel = currentLogLevelConfig.logCategoryLevelPairs[categories.Length - 1].level;
+            if (newAllCategoryLogLevel != previousAllCategoryLogLevel) 
+            {
+                foreach (var pair in currentLogLevelConfig.logCategoryLevelPairs)
+                {
+                    pair.level = newAllCategoryLogLevel;
+                }
+            }
+
+
+
+            if (GUILayout.Button("Save All Changes"))
+            {
+                SaveToJSONConfig(true);
+            }
+        }
+
+        private void SaveToJSONConfig(bool prettyPrint)
+        {
+            logLevelConfigFile.Write(prettyPrint);
+        }
+    }
+}

--- a/Assets/Plugins/Source/Editor/Windows/LogLevelWindow.cs.meta
+++ b/Assets/Plugins/Source/Editor/Windows/LogLevelWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3575c243343830428f6760ff76b8e6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/EOS/log_level_config.json
+++ b/Assets/StreamingAssets/EOS/log_level_config.json
@@ -1,0 +1,136 @@
+{
+    "logCategoryLevelPairs": [
+        {
+            "category": "Core",
+            "level": "Warning"
+        },
+        {
+            "category": "Auth",
+            "level": "Warning"
+        },
+        {
+            "category": "Friends",
+            "level": "Warning"
+        },
+        {
+            "category": "Presence",
+            "level": "Warning"
+        },
+        {
+            "category": "UserInfo",
+            "level": "Warning"
+        },
+        {
+            "category": "HttpSerialization",
+            "level": "Warning"
+        },
+        {
+            "category": "Ecom",
+            "level": "Warning"
+        },
+        {
+            "category": "P2P",
+            "level": "Warning"
+        },
+        {
+            "category": "Sessions",
+            "level": "Warning"
+        },
+        {
+            "category": "RateLimiter",
+            "level": "Warning"
+        },
+        {
+            "category": "PlayerDataStorage",
+            "level": "Warning"
+        },
+        {
+            "category": "Analytics",
+            "level": "Warning"
+        },
+        {
+            "category": "Messaging",
+            "level": "Warning"
+        },
+        {
+            "category": "Connect",
+            "level": "Warning"
+        },
+        {
+            "category": "Overlay",
+            "level": "Warning"
+        },
+        {
+            "category": "Achievements",
+            "level": "Warning"
+        },
+        {
+            "category": "Stats",
+            "level": "Warning"
+        },
+        {
+            "category": "Ui",
+            "level": "Warning"
+        },
+        {
+            "category": "Lobby",
+            "level": "Warning"
+        },
+        {
+            "category": "Leaderboards",
+            "level": "Warning"
+        },
+        {
+            "category": "Keychain",
+            "level": "Warning"
+        },
+        {
+            "category": "IntegratedPlatform",
+            "level": "Warning"
+        },
+        {
+            "category": "TitleStorage",
+            "level": "Warning"
+        },
+        {
+            "category": "Mods",
+            "level": "Warning"
+        },
+        {
+            "category": "AntiCheat",
+            "level": "Warning"
+        },
+        {
+            "category": "Reports",
+            "level": "Warning"
+        },
+        {
+            "category": "Sanctions",
+            "level": "Warning"
+        },
+        {
+            "category": "ProgressionSnapshots",
+            "level": "Warning"
+        },
+        {
+            "category": "Kws",
+            "level": "Warning"
+        },
+        {
+            "category": "Rtc",
+            "level": "Warning"
+        },
+        {
+            "category": "RTCAdmin",
+            "level": "Warning"
+        },
+        {
+            "category": "CustomInvites",
+            "level": "Warning"
+        },
+        {
+            "category": "AllCategories",
+            "level": "Warning"
+        }
+    ]
+}

--- a/Assets/StreamingAssets/EOS/log_level_config.json.meta
+++ b/Assets/StreamingAssets/EOS/log_level_config.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 544cabbb2273773408330f363370321a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The log levels on startup used to be hard coded.
Now it is loaded from a config file to allow flexibility when debugging with logs.
![eos_plugin_for_unity - Lobbies - Windows, Mac, Linux - Unity 2021 3 8f1 _DX11_ 3_15_2024 4_07_36 PM](https://github.com/PlayEveryWare/eos_plugin_for_unity/assets/36757173/7840b0e4-206d-4d47-8fb4-f2ae517bb55f)
![eos_plugin_for_unity - Lobbies - Windows, Mac, Linux - Unity 2021 3 8f1 _DX11_ 3_15_2024 4_07_41 PM](https://github.com/PlayEveryWare/eos_plugin_for_unity/assets/36757173/e68767e5-8485-4a1b-aefd-fcccbce18a11)
