### PR TITLE
fix(eac,build) : Remove early return that skips copying files fo EAC

### DIFF
--- a/Assets/Plugins/Source/Editor/Build/EACPostBuild.cs
+++ b/Assets/Plugins/Source/Editor/Build/EACPostBuild.cs
@@ -316,9 +316,6 @@ namespace PlayEveryWare.EpicOnlineServices.Build
             string destDir = Path.GetDirectoryName(report.summary.outputPath);
             string pathToInstallFrom = GetPathToPlatformSpecificAssets(report);
 
-            if (!string.IsNullOrEmpty(pathToInstallFrom))
-                return;
-
             List<string> filestoInstall = GetPostBuildFiles(report);
             List<string> directoriesToInstall = GetPostBuildDirectories(report);
 


### PR DESCRIPTION
This line bypasses the whole file copying step for EAC integration.
It is removed to allow normal functionality for Windows