### PR TITLE
fix: resolve error caused by some code accidently not being between EOS_DISABLE blocks

### DIFF
--- a/Assets/Plugins/Source/Core/EOSCreateOptions.cs
+++ b/Assets/Plugins/Source/Core/EOSCreateOptions.cs
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;
@@ -63,3 +64,5 @@ namespace PlayEveryWare.EpicOnlineServices
         uint IEOSCreateOptions.TickBudgetInMilliseconds { get => options.TickBudgetInMilliseconds; set => options.TickBudgetInMilliseconds = value; }
     }
 }
+
+#endif //EOS_DISABLED

--- a/Assets/Plugins/Source/Core/EOSInitializeOptions.cs
+++ b/Assets/Plugins/Source/Core/EOSInitializeOptions.cs
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;
@@ -54,3 +55,5 @@ namespace PlayEveryWare.EpicOnlineServices
         public InitializeThreadAffinity? OverrideThreadAffinity { get => options.OverrideThreadAffinity; set => options.OverrideThreadAffinity = value; }
     }
 }
+
+#endif // EOS_DISABLED

--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -48,6 +48,11 @@
 #define USE_EOS_DYNAMIC_BINDINGS
 #endif
 
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+using System.Collections;
+
 #if !EOS_DISABLE
 using Epic.OnlineServices.Platform;
 using Epic.OnlineServices;
@@ -59,14 +64,13 @@ using Epic.OnlineServices.UI;
 
 namespace PlayEveryWare.EpicOnlineServices
 {
+
+#if !EOS_DISABLE
     using Epic.OnlineServices.Presence;
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
+
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
-    using UnityEngine;
     using UnityEngine.Assertions;
     using AddNotifyLoginStatusChangedOptions = Epic.OnlineServices.Auth.AddNotifyLoginStatusChangedOptions;
     using Credentials = Epic.OnlineServices.Auth.Credentials;
@@ -76,6 +80,7 @@ namespace PlayEveryWare.EpicOnlineServices
     using LoginCallbackInfo = Epic.OnlineServices.Auth.LoginCallbackInfo;
     using LoginOptions = Epic.OnlineServices.Auth.LoginOptions;
     using LoginStatusChangedCallbackInfo = Epic.OnlineServices.Auth.LoginStatusChangedCallbackInfo;
+#endif
 
     /// <summary>
     /// One of the responsibilities of this class is to manage the lifetime of

--- a/Assets/Plugins/Source/Core/PlatformSpecifics.cs
+++ b/Assets/Plugins/Source/Core/PlatformSpecifics.cs
@@ -19,6 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices
 {
     using System;
@@ -137,3 +139,4 @@ namespace PlayEveryWare.EpicOnlineServices
         #endregion
     }
 }
+#endif //!EOS_DISABLE


### PR DESCRIPTION
# Intro 
There is a define called `EOS_DISABLE` that allows the user to define that conditional so that some platforms won't have the EOS SDK/plugin included, but others still may have it included.

# Overview of changes
Add conditional compile blocks between `EOS_DISABLE` so that users of the plugin may disable the plugin when needed.