### PR TITLE
fix(config) : Load platform config from streaming asset path

### DIFF
--- a/Assets/Plugins/Source/Core/PlatformManager.cs
+++ b/Assets/Plugins/Source/Core/PlatformManager.cs
@@ -213,8 +213,7 @@ namespace PlayEveryWare.EpicOnlineServices
         public static string GetConfigFilePath(Platform platform)
         {
             return Path.Combine(
-                Application.dataPath,
-                "StreamingAssets",
+                Application.streamingAssetsPath,
                 "EOS",
                 GetPlatformConfigFileName(platform)
                 );


### PR DESCRIPTION
The mac player streaming asset file is different than dataPath/StreamingAssets. It is easier to access directly with streaming assets path