### PR TITLE
fix: Update documentation links & Support Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Once imported into your project, be sure to [Configure the Plugin](/docs/configu
 
 # Support / Contact
 
-PlayEveryWare EOS Plugin for Unity documentation can be found right here on GitHub.
+PlayEveryWare EOS Plugin for Unity documentation can be found here on GitHub.
 
 For issues related to integration or usage of the EOS Unity plugin, please create a `New Issue` under the [Issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) tab.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Overview
 
-The PlayEveryWare EOS Plugin for Unity brings the free services from Epic that connect players across all platforms and all stores to Unity in an easy-to-use package. Find more information on EOS [here](https://dev.epicgames.com/en-US/services) and read the Epic docs on the services [here](https://dev.epicgames.com/docs/epic-online-services).
+The PlayEveryWare EOS Plugin for Unity brings the free services from Epic that connect players across all platforms and all stores to Unity in an easy-to-use package. Find more information on what services Epic Online Services encompasses, see here: [https://dev.epicgames.com/en-US/services](https://dev.epicgames.com/en-US/services) and to read the developer documentation on those services, see here: [https://dev.epicgames.com/docs/epic-online-services](https://dev.epicgames.com/docs/epic-online-services).
 
 This repository contains the source code for development and serves as a destination for support for the [PlayEveryWare EOS Plugin for Unity (UPM Package)](https://github.com/PlayEveryWare/eos_plugin_for_unity_upm).
 
@@ -12,7 +12,7 @@ Out of the box, this project demonstrates (through a collection of sample scenes
 
 See [this](/docs/plugin_advantages.md) for a more complete overview of the advantages of using EOS with Unity.
 
-[^1]: See [here](#supported-eos-sdk-features) for which SDK features specifically are demonstrated.
+[^1]: See the [supported-eos-sdk-features](#supported-eos-sdk-features) section for which SDK features specifically are demonstrated.
 
 > [!NOTE]
 > If you are **not** interested in the _development_ of the EOS Plugin project (and instead just want to get to using it) you can follow our guide on [Importing the Plugin Package](#importing-the-plugin-package) to start using the most recently released version of the EOS Plugin.
@@ -97,13 +97,17 @@ Once imported into your project, be sure to [Configure the Plugin](/docs/configu
 
 # Support / Contact
 
-PlayEveryWare EOS Plugin for Unity API Documentation can be found at [here](https://eospluginforunity.playeveryware.com).
+PlayEveryWare EOS Plugin for Unity documentation can be found right here on GitHub.
 
 For issues related to integration or usage of the EOS Unity plugin, please create a `New Issue` under the [Issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) tab.
 
-For issues related to Epic Online Services SDK, Epic Dev Portal or for general EOS SDK information, please go to [Epic Online Services Community Support](https://eoshelp.epicgames.com/).
+For issues related to Epic Online Services SDK, Epic Dev Portal or for general EOS SDK information, see the [Epic Online Services Community Support](https://eoshelp.epicgames.com/).
 
-Detailed descriptions and usage for EOS SDK Interfaces can be found at [here](https://dev.epicgames.com/docs/services/en-US/GameServices/index.html).
+Detailed descriptions and usage for EOS SDK Interfaces can be found on [Epic's documentation for Game Services](https://dev.epicgames.com/docs/services/en-US/GameServices/index.html).
+
+For issues of a confidential nature (for instance for support using this Plugin on restricted console platforms), please reach out to us directly at [eos-support@playeveryware.com](mailto:playeos-support@playeveryware.com).
+
+If it is _at all_ unclear to you where to go for support - do not hesitate to open a `New Issue` under the [Issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) tab, and we will make certain that you are properly (and promptly) assisted :)
 
 # Contributor Notes
 
@@ -113,10 +117,10 @@ This is an open source project! We welcome you to make contributions. See our [C
 
 To disable the plugin for specific platforms, see [this](/docs/disable_plugin_per_platform.md) (which also explains why you might want to do this).
 
-See [here](/docs/command_line_export.md) for a guide on how to export the plugin from the command line. 
+See [our guide](/docs/command_line_export.md) on how to export the plugin from the command line. 
 
 For issues of API Level compatibility, please read our [document](/docs/dotnet_quirks.md) on .NET Quirks and Unity compatibility.
 
-For more FAQs see [here](/docs/frequently_asked_questions.md).
+For more FAQs see [Frequently Asked Questions](/docs/frequently_asked_questions.md).
 
 If you have any outstanding questions, please bring them up in the [Discussions](https://github.com/PlayEveryWare/eos_plugin_for_unity/discussions) tab.

--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -30,7 +30,7 @@ There is a standard sample pack, and several extra packs in the EOS Unity Plugin
 ## Login Page
 The login menu allows the user to select which login method they would like to use through the dropdown in the center of the window. After logging in the user will be put into the selected demo scene.
 The login options are as follows:
-- ``Dev Auth``: Uses Epic Games’ Developer Authentication tool, documentation can be found [here](https://dev.epicgames.com/docs/epic-account-services/developer-authentication-tool).
+- ``Dev Auth``: Uses Epic Games’ [Developer Authentication Tool](https://dev.epicgames.com/docs/epic-account-services/developer-authentication-tool).
     1. Launch the [Developer Authentication Tool](https://dev.epicgames.com/docs/services/en-US/EpicAccountServices/DeveloperAuthenticationTool/index.html).
 
     ![Dev Auth Tool](/docs/images/dev_auth_tool.gif)
@@ -47,18 +47,16 @@ The login options are as follows:
     - A Nintendo Account
     - A Steam Account
     - An Apple ID
-- ``Persistent Auth``: Uses Epic Game's Persisting User Login. More documentation on this can be found [here](https://dev.epicgames.com/docs/epic-account-services/auth/auth-interface#persisting-user-login-to-epic-account-outside-epic-games-launcher).
+- ``Persistent Auth``: Uses Epic Game's [Persisting User Login](https://dev.epicgames.com/docs/epic-account-services/auth/auth-interface#persisting-user-login-to-epic-account-outside-epic-games-launcher).
 - ``External Auth``: Uses a web browser to login through an online account portal similar to the Account Portal option.
-- ``Connect``: Uses the connect interface to login through one of the supported options. More documentation on this can be found [here](https://dev.epicgames.com/docs/game-services/eos-connect-interface?sessionInvalidated=true).
+- ``Connect``: Uses the [Connect Interface](https://dev.epicgames.com/docs/game-services/eos-connect-interface) to login through one of the supported options.
     - Device Access Token: Uses a persistent access token based on the device, unattached to an account.
     - Steam Session Ticket
     - Steam App Ticket
     - Discord Access Token  
     - Openid Access Token
 
-
-For details on supported login methods per platform, see [here](/docs/login_type_by_platform.md).
-
+For information about login methods per platform, see our documentation: [Login Type by Platform](/docs/login_type_by_platform.md).
 
 ## Individual Scene Walkthroughs
 - [Achievements](/docs/scene_walkthrough/achievements_walkthrough.md)
@@ -76,4 +74,4 @@ For details on supported login methods per platform, see [here](/docs/login_type
 - [P2PNetcode](/docs/scene_walkthrough/P2P_netcode_walkthrough.md)
 
 > [!NOTE]
-> More information on the EOS interfaces can be found [here](https://dev.epicgames.com/docs)
+> For more information about Epic Online Services (and information about other resources) checkout the [Epic Developer Resources Documentation](https://dev.epicgames.com/docs).

--- a/docs/add_plugin.md
+++ b/docs/add_plugin.md
@@ -21,11 +21,11 @@ The following document outlines the two methods with which you can add the plugi
 8. Finally, [Configure the Plugin](/docs/configure_plugin.md).
 
 > [!NOTE]
-> The Unity doc for adding a git url can be found [here](https://docs.unity3d.com/2021.3/Documentation/Manual/upm-ui-giturl.html).
+> For additional details, see the [Unity Documentation for adding a UPM via Git URL](https://docs.unity3d.com/2021.3/Documentation/Manual/upm-ui-giturl.html).
 
 ## Adding the package from a tarball
 
-1. Download the latest release UPM tarball, `"com.playeveryware.eos-[version].tgz"` [here](https://github.com/PlayEveryWare/eos_plugin_for_unity/releases).
+1. Download the latest release UPM tarball, `"com.playeveryware.eos-[version].tgz"` ([Releases](https://github.com/PlayEveryWare/eos_plugin_for_unity/releases)).
 
     > [!WARNING]
     > Do *not* attempt to create a tarball yourself from the source, unless you know what you are doing with respect to [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/configuring-git-large-file-storage).
@@ -46,5 +46,5 @@ The following document outlines the two methods with which you can add the plugi
 8. Finally, <a href="#configuring-the-plugin">configure the plugin</a>.
 
 > [!NOTE]
-> The Unity doc for adding a tarball can be found [here](https://docs.unity3d.com/2021.3/Documentation/Manual/upm-ui-tarball.html).
+> For additional details, see the [Unity Documentation for adding a UPM via Tarball](https://docs.unity3d.com/2021.3/Documentation/Manual/upm-ui-tarball.html).
 

--- a/docs/apple_signin.md
+++ b/docs/apple_signin.md
@@ -40,7 +40,7 @@ Take EOS-Unity-Plugin as example, add this code block in `EOSOnPostProcessBuild.
 
 ### PostProcess Build Settings for Xcode project (macOS)
 
-The automated method could be found [here](https://github.com/lupidan/apple-signin-unity/blob/master/docs/macOS_NOTES.md). 
+Documentation regarding automated method could be found in the [macOS_NOTES.md](https://github.com/lupidan/apple-signin-unity/blob/master/docs/macOS_NOTES.md) file within the [Apple-Signing-Unity](https://github.com/lupidan/apple-signin-unity/) repository created by [lupidan](https://github.com/lupidan/).
 
 Here is an alternative that relies on creating an XCode project for the game, make a couple of configurations, then build from the xproject.
 
@@ -56,7 +56,7 @@ Here is an alternative that relies on creating an XCode project for the game, ma
 
 ### Sample Apple Sign In Scripts
 
-Here is a sample script tested in EOS-Unity-Plugin, which is modified from the example Unity's Documents [here](https://docs.unity.com/authentication/en/manual/SettingupAppleSignin)
+Here is a sample script tested in EOS-Unity-Plugin, which is modified from the example [Unity's Document on Setting Up Apple Signin](https://docs.unity.com/authentication/en/manual/SettingupAppleSignin).
 
 ```cs
 using UnityEngine;

--- a/docs/command_line_export.md
+++ b/docs/command_line_export.md
@@ -26,7 +26,7 @@ The following command-line argument is the only one introduced by this project:
 `-EOSPluginOutput` 
 The directory in which the newly created tarball should be placed.
 
-The following command-line arguments are used and defined _by Unity_, and you can read the docs on them in fuller detail [here](https://docs.unity.com/ugs/en-us/manual/ccd/manual/UnityCCDCLI):
+The following command-line arguments are used and defined _by Unity_, and Unity provides fairly [detailed documentation on command-line options](https://docs.unity.com/ugs/en-us/manual/ccd/manual/UnityCCDCLI):
 
 `-batchMode`
 Indicates whether Unity should launch a window or run 'headless'.

--- a/docs/configure_plugin.md
+++ b/docs/configure_plugin.md
@@ -2,7 +2,7 @@
 
 # Configuring the Plugin
 
-To function, the plugin needs some information from your EOS project. Epic Docs on how to set up your project can be found [here](https://dev.epicgames.com/docs/epic-account-services/getting-started?sessionInvalidated=true).
+To function, the plugin needs some information from your EOS project. Be sure to read the Epic Documentation on [getting started](https://dev.epicgames.com/docs/epic-account-services/getting-started?sessionInvalidated=true) with Epic Online Services.
 
 1) Open your Unity project with the integrated EOS Unity Plugin. 
 2) In the Unity editor, Open ```Tools -> EOS Plugin -> Dev Portal Configuration```.
@@ -14,7 +14,7 @@ To function, the plugin needs some information from your EOS project. Epic Docs 
 3) From the [Developer Portal](https://dev.epicgames.com/portal/), copy the configuration values listed below, and paste them into the similarly named fields in the editor tool window pictured above:
 
      > [!NOTE]
-     > Addtional information about configuration settings can be found [here](https://dev.epicgames.com/docs/game-services/eos-platform-interface#creating-the-platform-interface).
+     > For more detailed information, check out Epic's Documentation on [Creating the Platform Interface](https://dev.epicgames.com/docs/game-services/eos-platform-interface#creating-the-platform-interface).
 
     * ProductName
     * ProductVersion

--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -38,9 +38,9 @@ To setup your environment on windows, follow these steps (or you can run the scr
 
 ### macOS
 
-See [here](/docs/macOS/README_macOS.md) to read our guide on setting up your environment on macOS.
+See [Our macOS README](/docs/macOS/README_macOS.md) for a detailed guide on setting up your environment on macOS.
 
-You can run [this](/tools/scripts/setup-macos.sh) script `tools/scripts/setup-macos.sh` from a terminal to accomplish most of the setup steps, or read the aforementioned guide for details.
+You can run the [setup-macos.sh](/tools/scripts/setup-macos.sh) script (located in the `tools/scripts/` directory) from a terminal to accomplish most of the setup steps, or read the aforementioned guide for details.
 
 ## Building Native Libraries
 
@@ -61,7 +61,7 @@ See [standards.md](/docs/standards.md).
 
 ## Core Classes
 
-Descriptions for some of the core classes can be found [here](/docs/class_description.md).
+See our [Class Descriptions document](/docs/class_description.md) for an outline of what some of the core classes do.
 
 ## Create your own UPM
 

--- a/docs/dev_env/HyperV_Linux_Guest_VM.md
+++ b/docs/dev_env/HyperV_Linux_Guest_VM.md
@@ -20,7 +20,7 @@ This document describes how to create a Ubuntu Virtual Machine on Hyper-V suitab
 
     <img src="/docs/images/hyperv_linux_guest_vm/windows-features-on-off.png" width="400" />
 
-    If these options are greyed out, you may need to enter your bios settings to enable virtualization. See [here](https://www.bleepingcomputer.com/tutorials/how-to-enable-cpu-virtualization-in-your-computer-bios/) for general instructions on how to accomplish this.
+    If these options are greyed out, you may need to enter your bios settings to enable virtualization. See the following guide for general instructions on how to accomplish this: [How to Enable CPU Virtualization in Your Computer BIOS](https://www.bleepingcomputer.com/tutorials/how-to-enable-cpu-virtualization-in-your-computer-bios/).
 
     You can also tell if Virtualization is enabled in your BIOS by looking at the CPU Performance tab in Task Manager.
 
@@ -90,7 +90,7 @@ Ubuntu 18.04 is the official version of Linux that is supported by both EOS, the
 
 Set up a shared folder between Linux and Windows. Follow these instructions: [https://linuxhint.com/shared\_folders\_hypver-v\_ubuntu\_guest/](https://linuxhint.com/shared_folders_hypver-v_ubuntu_guest/)
 
-If you would like to increase the Hyper-V display resolution, see [here](https://superuser.com/questions/518484/how-can-i-increase-the-hyper-v-display-resolution#:~:text=1%20Install%20linux-image-extras%20%28hyperv-drivers%29%3A%20sudo%20apt-get%20install%20linux-image-extra-virtual,%28restarting%20Ubuntu%20%28Linux%29%20might%20be%20enough%29%20More%20).
+If you would like to increase the Hyper-V display resolution, see [this helpful thread on SuperUser.com](https://superuser.com/questions/518484/how-can-i-increase-the-hyper-v-display-resolution#:~:text=1%20Install%20linux-image-extras%20%28hyperv-drivers%29%3A%20sudo%20apt-get%20install%20linux-image-extra-virtual,%28restarting%20Ubuntu%20%28Linux%29%20might%20be%20enough%29%20More%20).
 
 ## Next Steps
 

--- a/docs/dev_env/Ubuntu_Development_Environment.md
+++ b/docs/dev_env/Ubuntu_Development_Environment.md
@@ -69,7 +69,7 @@ You'll be prompted to trust the key (type yes and hit enter). This command shoul
 
 ### Step 4: Clone the EOS Plugin Repository
 
-It is important that you have the latest version of `git` installed, so that you can use `git lfs`. See [here](https://itsfoss.com/install-git-ubuntu/) for an excellent guide an installing the latest version of `git`
+It is important that you have the latest version of `git` installed, so that you can use `git lfs`. See the following link for an excellent guide an installing the latest version of `git` on Ubuntu: [Install Git [on] Ubuntu](https://itsfoss.com/install-git-ubuntu/).
 
 > [!NOTE]
 > Simply installing `git` via apt is not sufficient.
@@ -137,4 +137,4 @@ If you are using Hyper-V, and failed to increase the size of the disk before ins
     # Note no space this time!
     ```
 
-10. Now you should have the extra space available to you. If this doesn't work, you can find some other suggestions [here](https://superuser.com/questions/1716141/how-to-expand-ubuntu-20-04-lts-filesystem-volume-on-hyper-v).
+10. Now you should have the extra space available to you. If this doesn't work, you can find some other suggestions [on this SuperUser.com question thread](https://superuser.com/questions/1716141/how-to-expand-ubuntu-20-04-lts-filesystem-volume-on-hyper-v).

--- a/docs/docs_on_docs/doc_style_guide.md
+++ b/docs/docs_on_docs/doc_style_guide.md
@@ -201,7 +201,7 @@ Example markdown linking to a specific section of another document:
 
 For inline code formatting, use single ticks. This is useful to highlight certain words to indicate that they are variables, or to clearly identify things like menu paths to follow.
 
-In order to display code blocks, put the code you wish to display between two lines containing only three ticks. For code blocks, make sure to add to the first set of three ticks the language that the code snippet is in, so that syntax highlighting is accomplished (for instance you can use `cs` to indicate that the block is C#, or `markdown` to indicate that it's a code snippet in markdown). See [here](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md) for a list of all the languages that GitHub Flavored Markdown supports.
+In order to display code blocks, put the code you wish to display between two lines containing only three ticks. For code blocks, make sure to add to the first set of three ticks the language that the code snippet is in, so that syntax highlighting is accomplished (for instance you can use `cs` to indicate that the block is C#, or `markdown` to indicate that it's a code snippet in markdown). See the [SUPPORTED_LANGUAGES.md](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md) document within the [highlightjs](https://github.com/highlightjs) repository on GitHub for a list of all the languages that GitHub Flavored Markdown supports.
 
 > [!IMPORTANT]
 > When you are providing a code example, it may be necessary to break coding standards for the sake of readability. One circumstance where this is particularly true is with code that would normally require horizontal scrolling to fully view. If a line of code within the codeblock exceeds 130 characters, be sure to add line breaks following  [this](https://se-education.org/guides/conventions/csharp.html#2-maximum-line-length-is-130-characters) guide.
@@ -303,7 +303,7 @@ Surprise!
 
 ## Mermaid:
 
-Mermaid is the formatting we use for displaying flowcharts. From the perspective of style guidelines, these flowcharts can be thought of as images, with the added functionality that they are interactive. See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams) for a guide on creating diagrams using Mermaid.
+Mermaid is the formatting we use for displaying flowcharts. From the perspective of style guidelines, these flowcharts can be thought of as images, with the added functionality that they are interactive. See [GitHub's documentation for a guide on creating diagrams using Mermaid](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).
 
 ## Alerts:
 

--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -4,27 +4,32 @@
 ---
 
 ## Questions
-- [Why does the plugin fail to work after changing configuration?](#why-does-the-plugin-fail-to-work-after-changing-configuration)
-- [How do I override sandbox or deployment IDs when publishing on the Epic Games Store?](#how-do-i-override-sandbox-or-deployment-ids-when-publishing-on-the-epic-games-store)
-- [How do I get the Epic Username?](#how-do-i-get-the-epic-username)
-- [Can a title pass a custom device ID? How does one do that?](#can-a-title-pass-a-custom-device-id-how-does-one-do-that)
-- [Are there alternatives to storing the config files in the StreamingAssets directory? Why is the file there?](#are-there-alternatives-to-storing-the-config-files-in-streaming-assets-why-is-the-file-there)
-- [Why does the Demo Scene fail to load?](#why-does-the-demo-scene-fail-to-load)
-- [What is the correct way to log into the Epic Games Store?](#what-is-the-correct-way-to-log-into-the-epic-games-store)
-- [Do I or my players need an Epic Games Account?](#do-i-or-my-players-need-an-epic-games-account)
-- [What does the "DllNotFoundException" error mean?](#what-does-the-dllnotfoundexception-error-mean)
-- [Why am I getting overlay errors?](#why-am-i-getting-overlay-errors)
-- [Missing native libraries?](#missing-native-libraries)
-- [How do I debug the native dll?](#how-do-i-debug-the-native-dll)
+- [ Frequently Asked Questions (FAQ)](#-frequently-asked-questions-faq)
+  - [Questions](#questions)
+  - [Why does the plugin fail to work after changing configuration?](#why-does-the-plugin-fail-to-work-after-changing-configuration)
+  - [How do I override sandbox or deployment IDs when publishing on the Epic Games Store?](#how-do-i-override-sandbox-or-deployment-ids-when-publishing-on-the-epic-games-store)
+  - [How do I get the Epic Username?](#how-do-i-get-the-epic-username)
+  - [Can a title pass a custom device ID? How does one do that?](#can-a-title-pass-a-custom-device-id-how-does-one-do-that)
+  - [Are there alternatives to storing the config files in Streaming Assets? Why is the file there?](#are-there-alternatives-to-storing-the-config-files-in-streaming-assets-why-is-the-file-there)
+  - [Why does the Demo Scene fail to load?](#why-does-the-demo-scene-fail-to-load)
+  - [What is the correct way to log into the Epic Games Store?](#what-is-the-correct-way-to-log-into-the-epic-games-store)
+    - [Exchange Code](#exchange-code)
+  - [Do I or my players need an Epic Games Account?](#do-i-or-my-players-need-an-epic-games-account)
+    - [As a developer](#as-a-developer)
+    - [As a player](#as-a-player)
+  - [What does the "DllNotFoundException" error mean?](#what-does-the-dllnotfoundexception-error-mean)
+  - [Why am I getting Overlay Errors?](#why-am-i-getting-overlay-errors)
+  - [Missing Native Libraries?](#missing-native-libraries)
+  - [How do I debug the native DLL?](#how-do-i-debug-the-native-dll)
 
 ## Why does the plugin fail to work after changing configuration?
 
 To rerun in UnityEditor without rebooting, we must reload the EOS SDK dll between runs.  
-To find out why and how to do so look [here](https://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/docs/unity_specific.md).
+To find out why and how to do so look see our documentation on [Unity Specific aspects of implementing EOS](https://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/docs/unity_specific.md).
 
 ## How do I override sandbox or deployment IDs when publishing on the Epic Games Store?
 
-This functionality is outlined in [here](/docs/epic_game_store.md#overriding-sandbox-andor-deployment-id).
+This functionality is outlined in our [document on the Epic Game Store](/docs/epic_game_store.md#overriding-sandbox-andor-deployment-id).
 
 ## How do I get the Epic Username?
 It depends on what one means by "Username".
@@ -108,7 +113,7 @@ EOSManager.Instance.StartLoginWithLoginTypeAndToken(
 As a developer you will need to have an Epic Games account in order to interact with the [EOS Developer Portal](https://dev.epicgames.com/portal) and manage your product.
 
 ### As a player
-Players are given multiple login options, which are slightly different from platform to platform. Details of which login methods are supported by each platform are listed [here](/docs/login_type_by_platform.md).
+Players are given multiple login options, which are slightly different from platform to platform. Details of which login methods are supported by each platform are listed in our documentation outlining [login type by platform](/docs/login_type_by_platform.md).
 
 ## What does the "DllNotFoundException" error mean? 
 
@@ -118,7 +123,7 @@ Which mainly happens when adding the UPM `via git url`
 To fix this you may do one of the following:
 
 - Initialize git lfs on the package folder (from a command window `git lfs install`).
-- Add the UPM `via tarball` downloaded [here](https://github.com/PlayEveryWare/eos_plugin_for_unity/releases) instead.
+- Add the UPM `via tarball` downloaded the [releases](https://github.com/PlayEveryWare/eos_plugin_for_unity/releases) on GitHub instead.
 
 ## Why am I getting Overlay Errors?
 Overlay errors are most likely due to not having the overlay installed, this is done in two steps:

--- a/docs/iOS/README_iOS.md
+++ b/docs/iOS/README_iOS.md
@@ -29,7 +29,7 @@ You can follow the standard <a href="/README.md#samples">Samples</a> process. Pl
 
 ## Running the samples
 
-When following the steps to <a href="/README.md#running-the-samples">run a sample</a> from a build for iOS, in Xcode, open the `.xcodeproj` from the resulting build folder. Follow the Apple Developer instructions to build and run the app [here](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device). If running on a device you may need to <a href="https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device">enable developer mode</a> on the device. This may require you to set up <a href="https://help.apple.com/xcode/mac/current/#/dev80cc24546">automatic signing</a> as well.
+When following the steps to <a href="/README.md#running-the-samples">run a sample</a> from a build for iOS, in Xcode, open the `.xcodeproj` from the resulting build folder. Follow the [Apple Developer instructions](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device) to build and run the app. If running on a device you may need to <a href="https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device">enable developer mode</a> on the device. This may require you to set up <a href="https://help.apple.com/xcode/mac/current/#/dev80cc24546">automatic signing</a> as well.
 
 > [!NOTE]
 > Find the build steps in the Unity docs <a href="https://docs.unity3d.com/2021.3/Documentation/Manual/iphone-BuildProcess.html">here</a>.

--- a/docs/macOS/README_macOS.md
+++ b/docs/macOS/README_macOS.md
@@ -8,7 +8,7 @@
 ## Prerequisites:
 
 > [!NOTE]
-> Most environment setup tasks can be accomplished by executing the setup script located [here](/tools/scripts/setup-macos.sh) by running the following command from within a terminal window at the root of the repository:
+> Most environment setup tasks can be accomplished by executing the [setup-macos.sh](/tools/scripts/setup-macos.sh) script located in the `/tools/scripts/` directory by running the following command from within a terminal window at the root of the repository:
 > ```
 > ./tools/scripts/setup-macos.sh
 > ```

--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -7,4 +7,4 @@ If you are getting a error logging in pertaining to the EOS Overlay, this is cau
 - The overlay is not yet installed. 
     - To install it create a build of the demo and run the bootstrapper included in the build folder, this will install the overlay.
 - Epic Games Launcher is not installed.
-    - The launcher can be downloaded [here](https://store.epicgames.com/en-US/download).
+    - The launcher can be downloaded here: [Download Epic Games Launcher](https://store.epicgames.com/en-US/download).

--- a/docs/player_authentication.md
+++ b/docs/player_authentication.md
@@ -21,9 +21,9 @@ There are two login interfaces:
 * **Auth Login**       for authorizing an **Epic Account** and related services 
 * **Connect Login**    for connecting the **User** for one **ProductID (Game)**
 
-More information about the distinction can be found [here](https://dev.epicgames.com/en-US/news/accessing-eos-game-services-with-the-connect-interface#a-brief-summary-of-auth-vs-connect-interfaces)
+More information about the distinction can be found in the Epic news release ["A Brief Summary of Auth VS Connect Interfaces"](https://dev.epicgames.com/en-US/news/accessing-eos-game-services-with-the-connect-interface#a-brief-summary-of-auth-vs-connect-interfaces).
 
-For information on how to authenticate a user via Apple, check out [this](/docs/apple_signin.md) guide.
+For information on how to authenticate a user via Apple, check out our [Apple Sign-In guide](/docs/apple_signin.md).
 
 ### Auth Login
 
@@ -34,7 +34,7 @@ For information on how to authenticate a user via Apple, check out [this](/docs/
 * **External Auth** is currently only for Steam session ticket login on these platforms
 * **Exchange Code** is for logging in on Epic Game Store deployments
 
-A list of which `LoginCredentialType` to use on which platform could be found [here](https://github.com/PlayEveryWare/eos_plugin_for_unity/tree/development/docs/login_type_by_platform.md)
+A list of which `LoginCredentialType` to use on which platform could be found in our documentation here: [Login Type by Platform](https://github.com/PlayEveryWare/eos_plugin_for_unity/tree/development/docs/login_type_by_platform.md)
 
 ### Connect Login
 

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -36,7 +36,7 @@ The included samples show examples of fully functional [feature implementations]
 > [!IMPORTANT]
 > The plugin must be <a href="/docs/configure_plugin.md">configured</a> for samples to be functional. Some Samples may not be accessible if the extra packs were not <a href="http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/README.md#importing-samples">imported</a>.
 
-Sample walkthroughs for each scene can be found [here](/docs/Walkthrough.md).
+Checkout our [Sample Walkthroughs](/docs/Walkthrough.md) for a scene-by-scene walkthrough of each sample.
 
 <details>
   <summary><b>Steps to run a sample in editor</b></summary>
@@ -56,7 +56,7 @@ Sample walkthroughs for each scene can be found [here](/docs/Walkthrough.md).
     ![Auth and Friends Screenshot](/docs/images/sample_screen_account_login.gif)
 
     > [!NOTE]
-    > Additional info on login type options, implementation, and use cases can be found [here](/docs/player_authentication.md).
+    > Additional info on login type options, implementation, and use cases can be found in our [Player Authentication](/docs/player_authentication.md) document.
 
 </details>
 
@@ -88,6 +88,6 @@ Sample walkthroughs for each scene can be found [here](/docs/Walkthrough.md).
     ![Auth and Friends Screenshot](/docs/images/sample_screen_account_login.gif)
 
     > [!NOTE]
-    > Additional info on login type options, implementation, and use cases can be found [here](/docs/player_authentication.md).
+    > Additional info on login type options, implementation, and use cases can be found in our [Player Authentication](/docs/player_authentication.md) document.
 
 </details>

--- a/docs/scene_walkthrough/P2P_netcode_walkthrough.md
+++ b/docs/scene_walkthrough/P2P_netcode_walkthrough.md
@@ -15,5 +15,5 @@ Upon import, the `com.unity.netcode.gameobjects` package that this scene require
 *Default version `1.0.2`.  Verified Working Versions `1.5.1` , `1.5.2`*  
 
 > [!NOTE]
-> More documentation on the P2P interface can be found [here](https://dev.epicgames.com/docs/game-services/p-2-p).
+> See [Epic's documentation on the P2P interface](https://dev.epicgames.com/docs/game-services/p-2-p) for more information.
 

--- a/docs/scene_walkthrough/P2P_walkthrough.md
+++ b/docs/scene_walkthrough/P2P_walkthrough.md
@@ -9,4 +9,4 @@ The Peer 2 Peer demo showcases the peer 2 peer interface. This is done through a
 ![P2P Chat](../images/eos_sdk_p2p.png)
 
 > [!NOTE]
-> More documentation on the Peer 2 Peer interface can be found [here](https://dev.epicgames.com/docs/game-services/p-2-p).
+> See [Epic's Peer 2 Peer documentation](https://dev.epicgames.com/docs/game-services/p-2-p) for more information.

--- a/docs/scene_walkthrough/achievements_walkthrough.md
+++ b/docs/scene_walkthrough/achievements_walkthrough.md
@@ -30,4 +30,4 @@ To make testing easier, one could manually unlock or reset an user's achievement
 *Go to `[Targeted Game] > Game Services > Stats` instead, the remaining steps are similar*
 
 > [!NOTE]
-> More information on the Achievement interface can be found [here](https://dev.epicgames.com/docs/game-services/achievements).
+> See Epic's [Achievements documentation](https://dev.epicgames.com/docs/game-services/achievements) for more information on the Achievement interface.

--- a/docs/scene_walkthrough/auth&friends_walkthrough.md
+++ b/docs/scene_walkthrough/auth&friends_walkthrough.md
@@ -9,4 +9,4 @@ This demo showcases an implementation of the friends list into a game UI. The pa
 ![Friends Tab](../images/eos_sdk_friends_panel.png)
 
 > [!NOTE]
-> More documentation on the Auth and Friends interface can be found [here](https://dev.epicgames.com/docs/epic-account-services/auth), with more specific information on the friends interface [here](https://dev.epicgames.com/docs/epic-account-services/eos-friends-interface).
+> See [Epic's documentation on the Auth interface](https://dev.epicgames.com/docs/epic-account-services/auth) as well as [Epic's documentation on the Friends interface](https://dev.epicgames.com/docs/epic-account-services/eos-friends-interface) for more information on each respective topic.

--- a/docs/scene_walkthrough/customInvites_walkthrough.md
+++ b/docs/scene_walkthrough/customInvites_walkthrough.md
@@ -12,4 +12,4 @@ This demo showcases the custom invite functionality allowing for messaging with 
 
 
 > [!NOTE] 
-> More documentation on the Custom Invites interface can be found [here](https://dev.epicgames.com/docs/game-services/custom-invites-interface).
+> See [Epic's documentation on the Custom Invites interface](https://dev.epicgames.com/docs/game-services/custom-invites-interface) for more information.

--- a/docs/scene_walkthrough/leaderboards_walkthrough.md
+++ b/docs/scene_walkthrough/leaderboards_walkthrough.md
@@ -11,4 +11,4 @@ This demo showcases the leaderboard functionality to track scores across the pla
 ![Leaderboards](../images/eos_sdk_leaderboards.png)
 
 > [!NOTE]
-> More documentation on the Leaderboard interface can be found [here](https://dev.epicgames.com/docs/game-services/leaderboards).
+> See [Epic's documentation on the Leaderboard interface](https://dev.epicgames.com/docs/game-services/leaderboards) for more information.

--- a/docs/scene_walkthrough/lobbies_walkthrough.md
+++ b/docs/scene_walkthrough/lobbies_walkthrough.md
@@ -41,4 +41,4 @@ This demo showcases the lobby and includes a voice chat interface in a combined 
 
 
 > [!NOTE]
-> More documentation on the lobby interface can be found [here](https://dev.epicgames.com/docs/game-services/lobbies).
+> See [Epic's documentation on the lobby interface](https://dev.epicgames.com/docs/game-services/lobbies) for more information.

--- a/docs/scene_walkthrough/metrics_walkthrough.md
+++ b/docs/scene_walkthrough/metrics_walkthrough.md
@@ -9,4 +9,4 @@ The Metrics demo showcases the player metrics interface, allowing for game use a
 
 
 > [!NOTE]
-> More documentation on the metrics interface can be found [here](https://dev.epicgames.com/docs/game-services/eos-metrics-interface).
+> See [Epic's documentation on the metrics interface](https://dev.epicgames.com/docs/game-services/eos-metrics-interface) for more information.

--- a/docs/scene_walkthrough/player_data_storage_walkthrough.md
+++ b/docs/scene_walkthrough/player_data_storage_walkthrough.md
@@ -13,4 +13,4 @@ This demo showcases the Player Data Storage interface. This allows games to stor
 ![Player Data Storage](../images/eos_sdk_player_data_storage.png)
 
 > [!NOTE] 
-> More documentation on the Player Data Storage interface can be found [here](https://dev.epicgames.com/docs/game-services/player-data-storage).
+> See [Epic's documentation on the Player Data Storage interface](https://dev.epicgames.com/docs/game-services/player-data-storage) for more information.

--- a/docs/scene_walkthrough/player_reports_and_sanctions_walkthrough.md
+++ b/docs/scene_walkthrough/player_reports_and_sanctions_walkthrough.md
@@ -13,4 +13,4 @@ This demo showcases the reports interface and sanctions interface. This is done 
 ![Reports](../images/eos_sdk_player_reports_and_sanctions.png)
 
 > [!NOTE]
-> More documentation on the reports interface can be found [here](https://dev.epicgames.com/docs/game-services/reports-interface), and more documentation on the sanctions interface can be found [here](https://dev.epicgames.com/docs/game-services/sanctions-interface).
+> See [Epic's documentation on the reports interface](https://dev.epicgames.com/docs/game-services/reports-interface), and [Epic's documentation on the sanctions interface](https://dev.epicgames.com/docs/game-services/sanctions-interface) respectively for more information.

--- a/docs/scene_walkthrough/sessions_and_matchmaking_walkthrough.md
+++ b/docs/scene_walkthrough/sessions_and_matchmaking_walkthrough.md
@@ -35,4 +35,4 @@ This demo showcases the sessions interface, users can create, manage and join se
 ![Current Sessions](../images/eos_sdk_sessions_current_sessions.png)
 
 > [!NOTE]
-> More documentation on the sessions interface can be found [here](https://dev.epicgames.com/docs/game-services/sessions).
+> See [Epic's documentation on the sessions interface](https://dev.epicgames.com/docs/game-services/sessions) for more information.

--- a/docs/scene_walkthrough/store_walkthrough.md
+++ b/docs/scene_walkthrough/store_walkthrough.md
@@ -8,4 +8,4 @@ This demo showcases the store interface through a faux store.
 
 
 > [!NOTE]
-> More documentation on the store can be found [here](https://dev.epicgames.com/docs/epic-games-store/services/ecom/ecom-overview).
+> See [Epic's documentation on the store](https://dev.epicgames.com/docs/epic-games-store/services/ecom/ecom-overview) for more information.

--- a/docs/scene_walkthrough/title_storage_walkthrough.md
+++ b/docs/scene_walkthrough/title_storage_walkthrough.md
@@ -16,4 +16,4 @@ This demo showcases the title storage interface. This functions similar to the p
     - ``File Contents`` Displays the contents of the selected file.
 
  > [!NOTE]
- > More documentation on the Title Storage interface can be found [here](https://dev.epicgames.com/docs/game-services/title-storage)
+ > See [Epic's documentation on the Title Storage interface](https://dev.epicgames.com/docs/game-services/title-storage) for more information.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -74,7 +74,7 @@ Examples:
 `(style)`: Changes to a either code or documentation that are style only.
 `(comments)`: Used for changes that only add comments.
 
-More details [here](https://www.conventionalcommits.org/en/v1.0.0/).
+More details see the documentation for [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Change-list Style Guide
 TODO: There isn't a change-list yet, but it will probably follow https://keepachangelog.com/en/1.0.0/.

--- a/docs/steam.md
+++ b/docs/steam.md
@@ -9,7 +9,7 @@ This document is a guide to connect the dots between EOS SDK and Steam SDK.
 ## Prerequisites
 
 - Install Steam SDK version `1.57` minimum.  
-- Have Steam added as an `Indentity Provider` for your game (see [here](https://dev.epicgames.com/docs/dev-portal/identity-provider-management#steam) for how to do that).
+- Have Steam added as an [Indentity Provider](https://dev.epicgames.com/docs/dev-portal/identity-provider-management#steam) for your game.
 
 ## External C# Wrappers for the Steam SDK
 


### PR DESCRIPTION
This PR updates the documentation to remove usages of the 'here' links, giving users an easier preview of what the link destination is.

It also clarifies the support channels for users to use.