### PR TITLE
chore(wsa, dynamic_loading): remove code associated with wsa dynamic

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -614,7 +614,6 @@ namespace PlayEveryWare.EpicOnlineServices
                 s_state = EOSState.Starting;
 
                 LoadEOSLibraries();
-                NativeCallToUnloadEOS();
 
                 var epicArgs = GetCommandLineArgsFromEpicLauncher();
 

--- a/Assets/Plugins/Source/Core/EOSManager_DynamicLoading.cs
+++ b/Assets/Plugins/Source/Core/EOSManager_DynamicLoading.cs
@@ -24,7 +24,7 @@
 #define USE_EOS_GFX_PLUGIN_NATIVE_RENDER
 #endif
 
-#if UNITY_64 || UNITY_WSA
+#if UNITY_64
 #define PLATFORM_64BITS
 // As far as I know, on Windows, if it isn't 64 bit, it's 32 bit
 #elif (UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN)
@@ -67,7 +67,7 @@ namespace PlayEveryWare.EpicOnlineServices
             public const string GfxPluginNativeRenderPath =
 #if UNITY_STANDALONE_OSX 
                 "GfxPluginNativeRender-macOS";
-#elif (UNITY_STANDALONE_WIN || UNITY_WSA) && PLATFORM_64BITS
+#elif UNITY_STANDALONE_WIN && PLATFORM_64BITS
                 "GfxPluginNativeRender-x64";
 #elif (UNITY_STANDALONE_WIN) && PLATFORM_32BITS
                 "GfxPluginNativeRender-x86";

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
@@ -170,8 +170,6 @@ extern "C"
 {
     void __declspec(dllexport) __stdcall UnityPluginLoad(void* unityInterfaces);
     void __declspec(dllexport) __stdcall UnityPluginUnload();
-
-    void __declspec(dllexport) __stdcall UnloadEOS();
 }
 
 //-------------------------------------------------------------------------
@@ -1515,21 +1513,6 @@ DLL_EXPORT(void) UnityPluginUnload()
     s_eos_sdk_overlay_lib_handle = nullptr;
 
     global_log_close();
-}
-
-//-------------------------------------------------------------------------
-DLL_EXPORT(void) UnloadEOS()
-{
-    if (EOS_Shutdown_ptr)
-    {
-        log_inform("EOS shutdown");
-        EOS_Shutdown_ptr();
-    }
-    if (s_eos_sdk_lib_handle)
-    {
-        log_inform("Unload eos sdk handle");
-        unload_library(s_eos_sdk_lib_handle);
-    }
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
# Intro 
Early in the project's history, there was some hopeful support for Windows Store App (WSA) added to the plugin. This was done to round out the number of platforms our plugin supported. Eventually, support for this platform fell by the wayside, and eventually was dropped. It actually might be more accurate to say that it wasn't ever really supported, and the code added to the plugin to support that platform doesn't _really_ work.

# Overview of changes
This particular PR removes the code that attempted to do 'clever' dynamic loading things so it could determine which version of Windows the plugin was running on, 32-bit or 64-bit. Given that it doesn't actually work, and makes the dynamic library loading code even more difficult to read, I believe it is time to get rid of the code 