### PR TITLE
Hotfix (Release 3.1.1)

### DIFF
--- a/Assets/Plugins/Source/Core/EOSCreateOptions.cs
+++ b/Assets/Plugins/Source/Core/EOSCreateOptions.cs
@@ -44,7 +44,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         #region Platform-Specific properties
 
-#if UNITY_PS5 || UNITY_GAMECORE || UNITY_SWITCH || UNITY_ANDROID || UNITY_IOS
+#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)
         public IntegratedPlatformOptionsContainer IntegratedPlatformOptionsContainerHandle { get => options.IntegratedPlatformOptionsContainerHandle; set => options.IntegratedPlatformOptionsContainerHandle = value; }
 #endif
 

--- a/Assets/Plugins/Source/Core/EOSInitializeOptions.cs
+++ b/Assets/Plugins/Source/Core/EOSInitializeOptions.cs
@@ -32,20 +32,14 @@ namespace PlayEveryWare.EpicOnlineServices
         #region Platform-specific stuff
 
         public
-#if !UNITY_EDITOR
-        Epic.OnlineServices.Platform.InitializeOptions
-#else
-#if UNITY_STANDALONE_WIN || UNITY_IOS || UNITY_STANDALONE_OSX || UNITY_STANDALONE_LINUX
-        Epic.OnlineServices.Platform.InitializeOptions
-#elif UNITY_ANDROID
-        Epic.OnlineServices.Platform.AndroidInitializeOptions
-#else
-        // Leaving "else" open so that if a new platform comes along we'll catch it.
-#endif
+#if UNITY_EDITOR
+            InitializeOptions
+#elif UNITY_ANDROID // NOTE: Android is the only public platform with unique initialize options.
+            AndroidInitializeOptions
 #endif
         options;
 
-        #endregion
+#endregion
 
         public IntPtr AllocateMemoryFunction { get => options.AllocateMemoryFunction; set => options.AllocateMemoryFunction = value; }
         public IntPtr ReallocateMemoryFunction { get => options.ReallocateMemoryFunction; set => options.ReallocateMemoryFunction = value; }

--- a/Assets/Plugins/Source/Core/PlatformSpecifics.cs
+++ b/Assets/Plugins/Source/Core/PlatformSpecifics.cs
@@ -101,7 +101,14 @@ namespace PlayEveryWare.EpicOnlineServices
             }
 
             string configPath = PlatformManager.GetConfigFilePath(Platform);
-            string configJson = File.ReadAllText(configPath);
+            
+            string configJson =
+#if UNITY_ANDROID && !UNITY_EDITOR
+                AndroidFileIOHelper.ReadAllText(configPath);
+#else
+                File.ReadAllText(configPath);
+#endif
+            
             T config = JsonUtility.FromJson<T>(configJson);
 
             if (config != null && initializeOptions.OverrideThreadAffinity.HasValue)
@@ -129,7 +136,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return 1;
         }
 
-        #endregion
+#endregion
     }
 }
 #endif //!EOS_DISABLE

--- a/Assets/Plugins/Source/Editor/Configs/EditorConfig.cs
+++ b/Assets/Plugins/Source/Editor/Configs/EditorConfig.cs
@@ -38,6 +38,9 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Config
     {
         protected EditorConfig(string filename) : base(filename, Path.Combine(FileUtility.GetProjectPath(), "etc/config/")) { }
 
+        // NOTE: This compiler block is here because the base class "Config" has
+        //       the WriteAsync function surrounded by the same conditional.
+#if UNITY_EDITOR
         // Overridden functionality changes the default parameter value for updateAssetDatabase, because EditorConfig
         // should not be anywhere within Assets.
         public override async Task WriteAsync(bool prettyPrint = true, bool updateAssetDatabase = false)
@@ -45,5 +48,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Config
             // Override the base function
             await base.WriteAsync(prettyPrint, updateAssetDatabase);
         }
+#endif
     }
+    
 }

--- a/Assets/Plugins/Source/Editor/Utility/BuildUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/BuildUtility.cs
@@ -26,7 +26,6 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
-    using Codice.Client.IssueTracker;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using PlayEveryWare.EpicOnlineServices.Utility;

--- a/etc/PackageTemplate/CHANGELOG.md
+++ b/etc/PackageTemplate/CHANGELOG.md
@@ -2,7 +2,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [3.1.0] - 2023-03-25
+# [3.1.1] - 2024-04-15
+
+### Fixed
+- Fix file access to be compiler-conditional for Android.
+- Make compile-time conditional surrounding interface property match the compile-time conditional surrounding the implementation.
+- Add compile-time conditional around WriteAsync override implementation.
+
+# [3.1.0] - 2024-04-11
 ### Added
 - feat: Added extension methods to be used by sample scripts.
 - feat: Moved checks for input to `InputUtility` class for better abstraction.

--- a/etc/PackageTemplate/package.json
+++ b/etc/PackageTemplate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.playeveryware.eos",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "unity": "2020.1",
     "unityRelease": "11f1",
     "displayName": "Epic Online Services Plugin for Unity",


### PR DESCRIPTION
This hotfix resolves the following issues discovered with the `v3.1.0` release:

- Mismatch between the compile-time conditional surrounding an interface property and the compile-time conditional surrounding the implementing property.
- Closes issue #602 by using compile-time conditionals to use the correct method to read a file on Android
- Closes issue #606 by removing errantly included using statement.

> [!NOTE]
> While this PR is going _into_ `development`, once approved the changes will be patched through to all the branches down-stream from our pipeline, and a new release will be generated including the changes.