### PR TITLE
fix: ensure that correct EpicAccountId is being used for connect login.

### DIFF
--- a/Assets/Scripts/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/UI/Login/UILoginMenu.cs
@@ -1258,9 +1258,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         }
 
         //-------------------------------------------------------------------------
-        private void StartConnectLoginWithLoginCallbackInfo(LoginCallbackInfo loginCallbackInfo)
+        private void StartConnectLoginWithEpicAccount(EpicAccountId LocalUserId)
         {
-            EOSManager.Instance.StartConnectLoginWithEpicAccount(loginCallbackInfo.LocalUserId, (Epic.OnlineServices.Connect.LoginCallbackInfo connectLoginCallbackInfo) =>
+            EOSManager.Instance.StartConnectLoginWithEpicAccount(LocalUserId, (Epic.OnlineServices.Connect.LoginCallbackInfo connectLoginCallbackInfo) =>
             {
                 if (connectLoginCallbackInfo.ResultCode == Result.Success)
                 {
@@ -1273,7 +1273,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     EOSManager.Instance.CreateConnectUserWithContinuanceToken(connectLoginCallbackInfo.ContinuanceToken, (Epic.OnlineServices.Connect.CreateUserCallbackInfo createUserCallbackInfo) =>
                     {
                         print("Creating new connect user");
-                        EOSManager.Instance.StartConnectLoginWithEpicAccount(loginCallbackInfo.LocalUserId, (Epic.OnlineServices.Connect.LoginCallbackInfo retryConnectLoginCallbackInfo) =>
+                        EOSManager.Instance.StartConnectLoginWithEpicAccount(LocalUserId, (Epic.OnlineServices.Connect.LoginCallbackInfo retryConnectLoginCallbackInfo) =>
                         {
                             if (retryConnectLoginCallbackInfo.ResultCode == Result.Success)
                             {
@@ -1310,7 +1310,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             else if (loginCallbackInfo.ResultCode == Epic.OnlineServices.Result.Success)
             {
-                StartConnectLoginWithLoginCallbackInfo(loginCallbackInfo);
+                StartConnectLoginWithEpicAccount(loginCallbackInfo.LocalUserId);
             }
             else if (loginCallbackInfo.ResultCode == Epic.OnlineServices.Result.InvalidUser)
             {
@@ -1325,7 +1325,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 {
                     if (linkAccountCallbackInfo.ResultCode == Result.Success)
                     {
-                        StartConnectLoginWithLoginCallbackInfo(loginCallbackInfo);
+                        StartConnectLoginWithEpicAccount(linkAccountCallbackInfo.LocalUserId);
                     }
                     else
                     {


### PR DESCRIPTION

# Intro 
The previous code was using a stale EpicAccountId that is sometimes an invalid one. This issue was reported in #576. 

# Overview of changes
The new one ensures that the most recently used EpicAccountId is the one passed back via the callback, which should ensure that it isn't every NULL.