### PR TITLE
fix(steam): resize buffer before fetching App ticket and Session ticket.

### DIFF
--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -81,10 +81,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
             byte[] buffer = new byte[bufferSize];
             uint ticketSize = 0;
             bool success = SteamUser.GetEncryptedAppTicket(buffer, bufferSize, out ticketSize);
+
             if (!success && (int)ticketSize > bufferSize)
             {
-                SteamUser.CancelAuthTicket(sessionTicketHandle);
                 bufferSize = (int)ticketSize;
+                buffer = new byte[bufferSize];
                 success = SteamUser.GetEncryptedAppTicket(buffer, bufferSize, out ticketSize);
             }
             if (!success)
@@ -95,6 +96,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
                 return;
             }
 
+            // Resize buffer to be the _exact_ ticketsize
             Array.Resize(ref buffer, (int)ticketSize);
             //convert to hex string
             encryptedAppTicket = System.BitConverter.ToString(buffer).Replace("-", "");
@@ -318,12 +320,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
             authId.SetSteamID(SteamUser.GetSteamID());
             authId.SetGenericString("epiconlineservices");
             sessionTicketHandle = SteamUser.GetAuthSessionTicket(buffer, bufferSize, out ticketSize, ref authId);
+
             if ((int)ticketSize > bufferSize)
             {
                 SteamUser.CancelAuthTicket(sessionTicketHandle);
                 bufferSize = (int)ticketSize;
+                buffer = new byte[bufferSize];
+
                 sessionTicketHandle = SteamUser.GetAuthSessionTicket(buffer, bufferSize, out ticketSize, ref authId);
             }
+
+            // Resize buffer to be the _exact_ ticketsize
             Array.Resize(ref buffer, (int)ticketSize);
             //convert to hex string
             sessionTicketString = System.BitConverter.ToString(buffer).Replace("-", "");


### PR DESCRIPTION
# Intro 
This is an interesting find by a [user](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues/581). The existing code, if it were to fail to grab either ticket type, would potentially cause a buffer overflow. Because 'most' tickets are the default size of 1024, this code defect probably hasn't been seen in the wild yet.

# Overview of changes
There are three changes:
* Remove unneeded CancelAuthTicket, since it was added to a call before getting the Encrypted App ticket (not needed)
* Allocate a new byte Array to fit the Encrypted App ticket when our default array isn't large enough.
* Allocate a new byte Array to fit the Auth Session ticket when our default array isn't large enough.
