### PR TITLE
fix: Remove `Newtonsoft` dependency errantly introduced.

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/JsonUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/JsonUtility.cs
@@ -54,7 +54,17 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             catch (System.ArgumentException)
             {
                 Debug.LogError($"Invalid JSON: \"{json}\".");
+                // NOTE: This compile-time conditional is here so that an
+                //       exception will not be thrown unless it is running in
+                //       editor mode. This ensures that invalid JSON won't crash
+                //       a shipped game - but will log an error.
+#if UNITY_EDITOR
+                // Calling throw from within the catch block so that the 
+                // exception that caused the catch block to be entered can be
+                // bubbled up the call-stack and handled by the context it is
+                // called from.
                 throw;
+#endif
             }
 
             return false;


### PR DESCRIPTION
As the title indicates, this PR removes the dependency on the `Newtonsoft` library used for JSON parsing that was errantly introduced without properly marking it as a dependency. The decision was made to remove the dependency until a time that we decide with more intentionality to add the dependency.

The change in functionality is that if invalid JSON is detected, an error will be logged, however that error will no longer contain detailed information regarding the nature of the invalidity of the JSON in question. 

This PR was originally merged before a subtle change was observed that warranted reverting and re-opening. The original PR was approved by @andrew-hirata-playeveryware, and @WispyMouse was the one to discover what was previously overlooked - so they are the only ones whose review is requested this time around.