### PR TITLE
fix: Remove `Newtonsoft` dependency errantly introduced.

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/JsonUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/JsonUtility.cs
@@ -22,7 +22,6 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Utility
 {
-    using Codice.Client.ChangeTrackerService;
     using UnityEngine;
 
     /// <summary>

--- a/Assets/Plugins/Source/Core/Utility/JsonUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/JsonUtility.cs
@@ -8,8 +8,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -18,13 +18,11 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- */
+*/
 
 namespace PlayEveryWare.EpicOnlineServices.Utility
 {
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
-    using System;
+    using Codice.Client.ChangeTrackerService;
     using UnityEngine;
 
     /// <summary>
@@ -33,46 +31,41 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
     public static class JsonUtility
     {
         /// <summary>
-        /// Attempts to parse the given JSON string. If problems are encountered, an error will be logged and the exception will continue.
+        /// Tries to parse the given JSON into an object.
         /// </summary>
-        /// <param name="json">The JSON string to validate.</param>
-        private static void ValidateJson(string json)
+        /// <typeparam name="T">The type to deserialize from the given json.
+        /// </typeparam>
+        /// <param name="json">
+        /// The JSON to deserialize from.
+        /// </param>
+        /// <param name="obj">The object to contain the deserialized value.
+        /// </param>
+        /// <returns>
+        /// True if the json was successfully deserialized, false otherwise.
+        /// </returns>
+        private static bool TryFromJson<T>(string json, out T obj)
         {
             try
             {
-                var parsedToken = JToken.Parse(json);
-            }
-            catch (JsonReaderException ex)
-            {
-                Debug.LogError($"Invalid JSON: {ex.Message}");
-#if UNITY_EDITOR
-                throw;
-#endif
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError($"An error occurred while attempting to validate JSON: {ex.Message}");
-#if UNITY_EDITOR
-                throw;
-#endif
-            }
-        }
-
-        /// <summary>
-        /// Determines if the given json string is valid json or not. If JSON is invalid, errors will be logged, but exceptions will be suppressed.
-        /// </summary>
-        /// <param name="json">The JSON string to validate.</param>
-        /// <returns>True if json is valid, false otherwise.</returns>
-        private static bool IsJsonValid(string json)
-        {
-            try
-            {
-                ValidateJson(json);
+                obj = UnityEngine.JsonUtility.FromJson<T>(json);
                 return true;
             }
             catch
             {
+                Debug.LogError($"Unable to parse object of type " +
+                               $"\"{typeof(T).FullName}\" from " +
+                               $"JSON: \"{json}\".");
+#if UNITY_EDITOR
+                // If running in the context of the Unity editor, then throw the
+                // exception in an effort to "fail loudly" so that the user is
+                // more likely to fix the problem. If not in editor mode, still
+                // log the error, but do not throw an exception.
+                throw;
+#else
+                // The else conditional is here because if an exception is not
+                // thrown, a value still needs to be returned.
                 return false;
+#endif
             }
         }
 
@@ -81,23 +74,32 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// </summary>
         /// <param name="obj">The object to serialize into JSON.</param>
         /// <param name="pretty">Whether to make the JSON pretty.</param>
-        /// <returns>String representation of the given object serialized.</returns>
+        /// <returns>
+        /// String representation of the given object serialized.
+        /// </returns>
         public static string ToJson(object obj, bool pretty = false)
         {
-            return JsonConvert.SerializeObject(obj, pretty ? Formatting.Indented : Formatting.None);
+            return UnityEngine.JsonUtility.ToJson(obj, pretty);
         }
 
         /// <summary>
-        /// Return an object deserialized from the given json string. If json is invalid, errors will
-        /// be logged, and an object with default values will be returned.
+        /// Return an object deserialized from the given json string. If json is
+        /// invalid, errors will be logged, and an object with default values
+        /// will be returned depending on whether running in editor mode or as a
+        /// standalone.
         /// </summary>
         /// <typeparam name="T">The type of object to deserialize.</typeparam>
         /// <param name="json">The JSON string.</param>
         /// <returns>The deserialized object.</returns>
         public static T FromJson<T>(string json)
         {
-            ValidateJson(json);
-            return JsonConvert.DeserializeObject<T>(json);
+            // NOTE: The return value of the TryFromJson method call below is
+            //       not observed, because regardless of if the from json method
+            //       was successful, the value defined by the out variable is
+            //       returned to the caller.
+            _ = TryFromJson(json, out T returnObject);
+
+            return returnObject;
         }
 
         /// <summary>
@@ -113,20 +115,39 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         }
 
         /// <summary>
-        /// Overwrites the given json object with values deserialized from the given json string.
-        /// If json is invalid, errors will be logged and no change will be made to the object.
+        /// Overwrites the given json object with values deserialized from the
+        /// given json string. If json is invalid, errors will be logged and no
+        /// change will be made to the object.
         /// </summary>
-        /// <param name="json">The string of json to deserialize values from.</param>
-        /// <param name="obj">The object to change the values of.</param>
-        public static void FromJsonOverwrite(string json, object obj)
+        /// <param name="json">
+        /// The string of json to deserialize values from.
+        /// </param>
+        /// <param name="obj">
+        /// The object to change the values of.
+        /// </param>
+        public static void FromJsonOverwrite<T>(string json, T obj)
         {
-            if (IsJsonValid(json))
+            // NOTES:
+            //
+            // If the type 'T' indicated is abstract, then it is not possible to
+            // use UnityEngine.JsonUtility to verify the validity of the
+            // incoming JSON. This is because the validation is accomplished by
+            // performing the deserialization step and catching any thrown
+            // exceptions. Therefore, if the type indicated is abstract, don't
+            // bother trying to validate, go straight to using the
+            // 'FromJsonOverwrite' function in UnityEngine.JsonUtility.
+            //
+            // If the type indicated is _not_ abstract, then it is possible to
+            // utilize the validation approach, therefore in that scenario
+            // perform validation before performing the intended operation.
+            //
+            // That this code can only validate JSON representing a non-abstract
+            // class is a limitation of the UnityEngine.JsonUtility. Most other
+            // available libraries will support this and remove the need for
+            // this check.
+            if (typeof(T).IsAbstract || TryFromJson(json, out T _))
             {
                 UnityEngine.JsonUtility.FromJsonOverwrite(json, obj);
-            }
-            else
-            {
-                Debug.LogWarning($"Object's values were not set using the json given, because the json was invalid.");
             }
         }
     }


### PR DESCRIPTION
As the title indicates, this PR removes the dependency on the `Newtonsoft` library used for JSON parsing that was errantly introduced without properly marking it as a dependency. The decision was made to remove the dependency until a time that we decide with more intentionality to add the dependency.

The change in functionality is that if invalid JSON is detected, an error will be logged, however that error will no longer contain detailed information regarding the nature of the invalidity of the JSON in question. 

This PR was originally merged before a subtle change was observed that warranted reverting and re-opening. The original PR was approved by @andrew-hirata-playeveryware, and @WispyMouse was the one to discover what was previously overlooked - so they are the only ones whose review is requested this time around.

The PR was THEN reverted because it was causing some errors in the editor. 

All issues should now be resolved. I am not going to merge into `development` until I get two approving reviews - and even then, will not merge it in until closer to the end of the day - in order to continue work on the next release and incorporate the changes.