### PR TITLE
fix: Properly support behavior when `EOS_DISABLE` is defined.

### DIFF
--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -20,6 +20,7 @@
 * SOFTWARE.
 */
 
+#if !EOS_DISABLE
 #if UNITY_64 || UNITY_EDITOR_64
 #define PLATFORM_64BITS
 #elif (UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN)
@@ -204,4 +205,4 @@ static string SteamDllName = "steam_api.dll";
     }
 }
 #endif
-
+#endif // !EOS_DISABLE

--- a/Assets/Plugins/iOS/Editor/IOSBuilder.cs
+++ b/Assets/Plugins/iOS/Editor/IOSBuilder.cs
@@ -8,8 +8,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -19,25 +19,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
     using System.IO;
     using UnityEditor.Build.Reporting;
+    using Utility;
 
-#if UNITY_IOS // This conditional is here so that no compiler errors will happen if the Unity Editor is not configured to build for iOS
+    // This conditional is here so that no compiler errors will happen if the
+    // Unity Editor is not configured to build for iOS.
+#if UNITY_IOS 
     using UnityEditor.iOS.Xcode;
 #endif
 
+    /// <summary>
+    /// Contains implementation of assorted build tasks that are unique to
+    /// building the plugin for an iOS project.
+    /// </summary>
     public class IOSBuilder : PlatformSpecificBuilder
     {
         public IOSBuilder() : base("Plugins/iOS") { }
 
+        /// <summary>
+        /// Perform post build tasks that are unique to the iOS platform.
+        /// </summary>
+        /// <param name="report">The build report.</param>
         public override void PostBuild(BuildReport report)
         {
+            // Per documentation on base implementation, begin the overriden
+            // implementation of the PostBuild function by calling first the
+            // base implementation.
+            base.PostBuild(report);
 
-#if UNITY_IOS // This conditional is here so that no compiler errors will happen if the Unity Editor is not configured to build for iOS
-            string projPath = report.summary.outputPath + "/Unity-iPhone.xcodeproj/project.pbxproj";
+            // This conditional is here so that no compiler errors will happen
+            // if the Unity Editor is not configured to build for iOS.
+#if UNITY_IOS 
+            string projPath = report.summary.outputPath + 
+                              "/Unity-iPhone.xcodeproj/project.pbxproj";
 
             PBXProject proj = new();
 
@@ -46,14 +64,27 @@ namespace PlayEveryWare.EpicOnlineServices.Build
             string targetGUID = proj.GetUnityMainTargetGuid();
             string unityTargetGUID = proj.GetUnityFrameworkTargetGuid();
 
-            proj.SetBuildProperty(targetGUID, "ENABLE_BITCODE", "false");
-            proj.SetBuildProperty(unityTargetGUID, "ENABLE_BITCODE", "false");
+            proj.SetBuildProperty(
+                targetGUID, 
+                "ENABLE_BITCODE", 
+                "false");
 
-            proj.AddFrameworkToProject(targetGUID, "SafariServices.framework", true);
-            proj.AddFrameworkToProject(targetGUID, "AuthenticationServices.framework", true);
+            proj.SetBuildProperty(
+                unityTargetGUID,
+                "ENABLE_BITCODE", 
+                "false");
+
+            proj.AddFrameworkToProject(targetGUID,
+                "SafariServices.framework", 
+                true);
+
+            proj.AddFrameworkToProject(targetGUID, 
+                "AuthenticationServices.framework", 
+                true);
 
             File.WriteAllText(projPath, proj.WriteToString());
 #endif
         }
     }
 }
+#endif // !EOS_DISABLE

--- a/Assets/Plugins/iOS/Editor/IOSBuilder.cs
+++ b/Assets/Plugins/iOS/Editor/IOSBuilder.cs
@@ -64,23 +64,11 @@ namespace PlayEveryWare.EpicOnlineServices.Build
             string targetGUID = proj.GetUnityMainTargetGuid();
             string unityTargetGUID = proj.GetUnityFrameworkTargetGuid();
 
-            proj.SetBuildProperty(
-                targetGUID, 
-                "ENABLE_BITCODE", 
-                "false");
+            proj.SetBuildProperty(targetGUID, "ENABLE_BITCODE", "false");
+            proj.SetBuildProperty(unityTargetGUID,"ENABLE_BITCODE", "false");
 
-            proj.SetBuildProperty(
-                unityTargetGUID,
-                "ENABLE_BITCODE", 
-                "false");
-
-            proj.AddFrameworkToProject(targetGUID,
-                "SafariServices.framework", 
-                true);
-
-            proj.AddFrameworkToProject(targetGUID, 
-                "AuthenticationServices.framework", 
-                true);
+            proj.AddFrameworkToProject(targetGUID,"SafariServices.framework", true);
+            proj.AddFrameworkToProject(targetGUID, "AuthenticationServices.framework", true);
 
             File.WriteAllText(projPath, proj.WriteToString());
 #endif


### PR DESCRIPTION
In some circumstances (some build configurations) if the scripting define `EOS_DISABLE` has been added within the Player Settings window of the Unity project, compilation errors will result.

This PR represents changes that affect the correct implementation of that define. Along the way, missing comments were added to the `IOSBuilder` class, and some very minor formatting changes were made to increase readability.

This closes issue #653. 