### PR TITLE
Fix: Cross-Platform Building (Currently broken)

### DIFF
--- a/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
+++ b/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
@@ -30,8 +30,7 @@ using jsize = System.Int32;
 using JavaVM = System.IntPtr;
 using System.Diagnostics;
 
-#if UNITY_ANDROID && !UNITY_EDITOR
-[assembly: AlwaysLinkAssembly]
+#if UNITY_ANDROID
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
+++ b/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
@@ -20,6 +20,8 @@
 * SOFTWARE.
 */
 
+#if !EOS_DISABLE
+
 using UnityEngine;
 using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
@@ -113,4 +115,5 @@ namespace PlayEveryWare.EpicOnlineServices
         }
     }
 }
+#endif
 #endif

--- a/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
+++ b/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
@@ -30,7 +30,8 @@ using jsize = System.Int32;
 using JavaVM = System.IntPtr;
 using System.Diagnostics;
 
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
+
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/Android/Editor/AndroidBuilder.cs
+++ b/Assets/Plugins/Android/Editor/AndroidBuilder.cs
@@ -36,7 +36,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
     public class AndroidBuilder : PlatformSpecificBuilder
     {
-        public AndroidBuilder() : base("Plugins/Android") { }
+        public AndroidBuilder() : base("Plugins/Android", BuildTarget.Android) { }
 
         public override void PreBuild(BuildReport report)
         {

--- a/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
+++ b/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
@@ -20,9 +20,7 @@
 * SOFTWARE.
 */
 
-#if UNITY_EDITOR
-#define EOS_DYNAMIC_BINDINGS
-#endif
+#if !EOS_DISABLE
 
 //#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
 using PlayEveryWare.EpicOnlineServices.Utility;
@@ -64,7 +62,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public override void LoadDelegatesWithEOSBindingAPI()
         {
-#if EOS_DYNAMIC_BINDINGS
+#if UNITY_EDITOR
             // TODO: This code does not appear to do anything...
             const string EOSBinaryName = Epic.OnlineServices.Config.LibraryName;
             var eosLibraryHandle = EOSManager.EOSSingleton.LoadDynamicLibrary(EOSBinaryName);
@@ -128,4 +126,4 @@ namespace PlayEveryWare.EpicOnlineServices
     }
 }
 #endif
-
+#endif

--- a/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
+++ b/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
@@ -28,7 +28,7 @@ using UnityEngine;
 using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
 
-#if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX)
+#if (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX) && (!UNITY_EDITOR_WIN && !UNITY_EDITOR_OSX)
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
+++ b/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
@@ -28,7 +28,8 @@ using UnityEngine;
 using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
 
-#if (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX) && (!UNITY_EDITOR_WIN && !UNITY_EDITOR_OSX)
+// If standalone linux and not editor, or the linux editor
+#if (UNITY_STANDALONE_LINUX && !UNITY_EDITOR) || UNITY_EDITOR_LINUX
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
+++ b/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
@@ -63,7 +63,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public override void LoadDelegatesWithEOSBindingAPI()
         {
-#if UNITY_EDITOR
+#if EOS_DYNAMIC_BINDINGS || UNITY_EDITOR
             // TODO: This code does not appear to do anything...
             const string EOSBinaryName = Epic.OnlineServices.Config.LibraryName;
             var eosLibraryHandle = EOSManager.EOSSingleton.LoadDynamicLibrary(EOSBinaryName);

--- a/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
+++ b/Assets/Plugins/Linux/Core/LinuxPlatformSpecifics.cs
@@ -20,12 +20,6 @@
 * SOFTWARE.
 */
 
-#if UNITY_64 || UNITY_EDITOR_64
-#define PLATFORM_64BITS
-#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
-#define PLATFORM_32BITS
-#endif
-
 #if UNITY_EDITOR
 #define EOS_DYNAMIC_BINDINGS
 #endif
@@ -37,10 +31,6 @@ using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
 
 #if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX)
-
-#if !UNITY_EDITOR_LINUX
-[assembly: AlwaysLinkAssembly]
-#endif
 
 namespace PlayEveryWare.EpicOnlineServices
 {
@@ -58,14 +48,6 @@ namespace PlayEveryWare.EpicOnlineServices
     public class LinuxPlatformSpecifics : PlatformSpecifics<LinuxConfig>
     {
         public static string SteamConfigPath = "eos_steam_config.json";
-
-#if ENABLE_CONFIGURE_STEAM_FROM_MANAGED
-#if PLATFORM_64BITS
-        static string SteamDllName = "steam_api64.dll";
-#else
-static string SteamDllName = "steam_api.dll";
-#endif
-#endif
 
         private static GCHandle SteamOptionsGCHandle;
 

--- a/Assets/Plugins/Linux/Editor/LinuxBuilder.cs
+++ b/Assets/Plugins/Linux/Editor/LinuxBuilder.cs
@@ -26,9 +26,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
     public class LinuxBuilder : PlatformSpecificBuilder
     {
-        public LinuxBuilder() : base(
-            "Plugins/Linux",
-            BuildTarget.StandaloneLinux64)
+        public LinuxBuilder() : base("Plugins/Linux", BuildTarget.StandaloneLinux64)
         {
             AddProjectFileToBinaryMapping(
                 "DynamicLibraryLoaderHelper_Linux/Makefile",

--- a/Assets/Plugins/Linux/Editor/LinuxBuilder.cs
+++ b/Assets/Plugins/Linux/Editor/LinuxBuilder.cs
@@ -8,8 +8,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,9 +22,13 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
+    using UnityEditor;
+
     public class LinuxBuilder : PlatformSpecificBuilder
     {
-        public LinuxBuilder() : base("Plugins/Linux")
+        public LinuxBuilder() : base(
+            "Plugins/Linux",
+            BuildTarget.StandaloneLinux64)
         {
             AddProjectFileToBinaryMapping(
                 "DynamicLibraryLoaderHelper_Linux/Makefile",

--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -33,13 +33,6 @@
 #define USE_STATIC_EOS_VARIABLE
 #endif
 
-#if UNITY_64
-#define PLATFORM_64BITS
-#elif (UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN)
-#define PLATFORM_32BITS
-#endif
-
-
 //#define ENABLE_DEBUG_EOSMANAGER
 
 // If using a 1.12 or newer, this allows the eos manager to use the new

--- a/Assets/Plugins/Source/Core/EOSManager_DynamicLoading.cs
+++ b/Assets/Plugins/Source/Core/EOSManager_DynamicLoading.cs
@@ -24,14 +24,6 @@
 #define USE_EOS_GFX_PLUGIN_NATIVE_RENDER
 #endif
 
-#if UNITY_64
-#define PLATFORM_64BITS
-// As far as I know, on Windows, if it isn't 64 bit, it's 32 bit
-#elif (UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN)
-#define PLATFORM_32BITS
-#endif
-
-
 #if UNITY_EDITOR
 #define EOS_DYNAMIC_BINDINGS
 #endif
@@ -66,12 +58,14 @@ namespace PlayEveryWare.EpicOnlineServices
             public const string GfxPluginNativeRenderPath =
 #if UNITY_STANDALONE_OSX
                 "GfxPluginNativeRender-macOS";
-#elif UNITY_STANDALONE_WIN && PLATFORM_64BITS
+#elif UNITY_STANDALONE_WIN
+#if UNITY_64
                 "GfxPluginNativeRender-x64";
-#elif (UNITY_STANDALONE_WIN) && PLATFORM_32BITS
-                "GfxPluginNativeRender-x86";
 #else
-#error Unknown platform
+                "GfxPluginNativeRender-x86";
+#endif // UNITY_64
+#else
+                #error Unknown platform
                 "GfxPluginNativeRender-unknown";
 #endif
 

--- a/Assets/Plugins/Source/Core/PlatformManager.cs
+++ b/Assets/Plugins/Source/Core/PlatformManager.cs
@@ -156,6 +156,17 @@ namespace PlayEveryWare.EpicOnlineServices
             };
 
         /// <summary>
+        /// Get the platform that matches the given build target.
+        /// </summary>
+        /// <param name="target">The build target being built for.</param>
+        /// <param name="platform">The platform for that build target.</param>
+        /// <returns>True if platform was determined, false otherwise.</returns>
+        public static bool TryGetPlatform(BuildTarget target, out Platform platform)
+        {
+            return TargetToPlatformsMap.TryGetValue(target, out platform);
+        }
+
+        /// <summary>
         /// Get the config type for the current platform.
         /// </summary>
         /// <returns>The config type for the current platform.</returns>

--- a/Assets/Plugins/Source/Core/PlatformSpecifics.cs
+++ b/Assets/Plugins/Source/Core/PlatformSpecifics.cs
@@ -21,7 +21,7 @@
  */
 
 #if !EOS_DISABLE
-#if UNITY_EDITOR
+#if !UNITY_EDITOR
 using UnityEngine.Scripting;
 [assembly: AlwaysLinkAssembly]
 #endif

--- a/Assets/Plugins/Source/Core/PlatformSpecifics.cs
+++ b/Assets/Plugins/Source/Core/PlatformSpecifics.cs
@@ -21,14 +21,20 @@
  */
 
 #if !EOS_DISABLE
+#if UNITY_EDITOR
+using UnityEngine.Scripting;
+[assembly: AlwaysLinkAssembly]
+#endif
 namespace PlayEveryWare.EpicOnlineServices
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using UnityEngine;
+    using UnityEngine.Scripting;
     using Utility;
     using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
+
 
     public abstract class PlatformSpecifics<T> : IPlatformSpecifics where T : PlatformConfig, new()
     {

--- a/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
@@ -28,10 +28,22 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
     public class BuildRunner : IPreprocessBuildWithReport, IPostprocessBuildWithReport
     {
+        /// <summary>
+        /// Callback Order for BuildRunner is 1 because all
+        /// PlatformSpecificBuilder implementations should have their callback
+        /// set to 0 so that they can register themselves where appropriate.
+        /// </summary>
         public int callbackOrder => 1;
 
+        /// <summary>
+        /// Private value for public property (separated for easier debugging)
+        /// </summary>
         private static PlatformSpecificBuilder s_builder;
 
+        /// <summary>
+        /// Stores an instance of the builder that is to be used by the
+        /// BuildRunner.
+        /// </summary>
         public static PlatformSpecificBuilder Builder
         {
             get

--- a/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
@@ -8,8 +8,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,114 +22,55 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
-    using Editor.Config;
     using Editor.Utility;
-    using System;
-    using System.IO;
-    using System.Threading.Tasks;
-    using UnityEditor;
     using UnityEditor.Build;
     using UnityEditor.Build.Reporting;
-    using UnityEngine;
-    
-    public class BuildRunner : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+
+    public class BuildRunner : IPreprocessBuildWithReport, 
+        IPostprocessBuildWithReport
     {
-        public int callbackOrder { get { return 0; } }
+        public int callbackOrder => 1;
 
-        public static IPlatformSpecificBuilder GetBuilder()
+        private static PlatformSpecificBuilder s_builder;
+
+        public static PlatformSpecificBuilder Builder
         {
-            IPlatformSpecificBuilder builder = null;
-            // NOTE: Try to make it so that (regarding build tasks) this is the ONLY place where compiler defines are
-            //       utilized. Reducing the number of places in the code where this happens will limit the number of
-            //       potential failure points, and keep the build process as linear as possible.
-
-            try
+            get
             {
-#if UNITY_IOS
-                builder = new IOSBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.iOS;
-#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
-                builder = new LinuxBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.Linux;
-#elif UNITY_ANDROID
-                builder = new AndroidBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.Android;
-#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-                builder = new MacOSBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.macOS;
-
-                /*
-                 * The following conditionals provide functionality for building on platforms that are restricted
-                 * access. For information on how to implement the EOS Plugin for Unity for the following platforms,
-                 * please reach out to PlayEveryWare at eos-support@playeveryware.com.
-                 */
-#elif UNITY_PS4
-                //builder = new PS4Builder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.PS4;
-#elif UNITY_PS5
-                //builder = new PS5Builder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.PS5;
-#elif UNITY_SWITCH
-                //builder = new SwitchBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.Switch;
-#elif UNITY_GAMECORE_XBOXONE
-                //builder = new XboxOneBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.XboxOne;
-#elif UNITY_GAMECORE_SCARLETT
-                //builder = new XboxSeriesXBuilder();
-                PlatformManager.CurrentPlatform = PlatformManager.Platform.XboxSeriesX;
-#elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
-    #if UNITY_64
-                    builder = new WindowsBuilder64();
-    #else
-                    builder = new WindowsBuilder32();
-    #endif
-                    PlatformManager.CurrentPlatform = PlatformManager.Platform.Windows;
-#else
-    #error "Undefined Platform!"
-#endif
+                return s_builder;
             }
-            catch (Exception e)
+            set
             {
-                Debug.LogError($"Exception while creating builder: {e.Message}");
-                throw new BuildFailedException(e);
+                s_builder = value;
             }
-
-            return builder;
         }
 
         /// <summary>
-        /// For EOS Plugin, this is the only place where anything can happen before build.
+        /// For EOS Plugin, this is the only place where anything can happen
+        /// before build.
         /// </summary>
         /// <param name="report">The pre-process build report.</param>
         public void OnPreprocessBuild(BuildReport report)
         {
-            bool eosDisabled = ScriptingDefineUtility.IsEOSDisabled(report);
-
-            // Don't do any preprocessing if EOS has been disabled.
-            if (eosDisabled)
+            // Set the current platform that is being built against
+            if (PlatformManager.TryGetPlatform(report.summary.platform, out PlatformManager.Platform platform))
             {
-                return;
+                PlatformManager.CurrentPlatform = platform;
             }
 
-            // Perform the pre-build task for the platform using its builder.
-            GetBuilder()?.PreBuild(report);
+            // Run the static builder's prebuild.
+            s_builder?.PreBuild(report);
         }
 
         /// <summary>
-        /// For EOS Plugin, this is the only place where anything can happen as a post build task
+        /// For EOS Plugin, this is the only place where anything can happen as
+        /// a post build task
         /// </summary>
         /// <param name="report">The report from the post-process build.</param>
         public void OnPostprocessBuild(BuildReport report)
         {
-            // Don't do any postprocessing if EOS has been disabled.
-            if (ScriptingDefineUtility.IsEOSDisabled(report))
-            {
-                return;
-            }
-
-            // Perform the post-build task for the platform using its builder.
-            GetBuilder()?.PostBuild(report);
+            // Run the static builder's postbuild
+            s_builder?.PostBuild(report);
         }
     }
 }

--- a/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
@@ -26,8 +26,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     using UnityEditor.Build;
     using UnityEditor.Build.Reporting;
 
-    public class BuildRunner : IPreprocessBuildWithReport, 
-        IPostprocessBuildWithReport
+    public class BuildRunner : IPreprocessBuildWithReport, IPostprocessBuildWithReport
     {
         public int callbackOrder => 1;
 

--- a/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
@@ -70,7 +70,10 @@ namespace PlayEveryWare.EpicOnlineServices.Build
         /// </summary>
         public int callbackOrder => 1;
 
-        protected BuildTarget[] buildTargets;
+        /// <summary>
+        /// Stores the targets for which the builder can be used.
+        /// </summary>
+        private BuildTarget[] _buildTargets;
 
         /// <summary>
         /// Constructs a new PlatformSpecificBuilder script.
@@ -84,16 +87,25 @@ namespace PlayEveryWare.EpicOnlineServices.Build
                 nativeCodeOutputDirectory);
 
             _projectFileToBinaryFilesMap = new Dictionary<string, string[]>();
-            this.buildTargets = buildTargets;
+            _buildTargets = buildTargets;
         }
 
+        /// <summary>
+        /// This pre-process build step is designed to take place before the
+        /// BuildRunner executes because it is here that which platform builder
+        /// to use is determined.
+        /// </summary>
+        /// <param name="report">The prebuild report.</param>
         public void OnPreprocessBuild(BuildReport report)
         {
             // If the platform being built is one of the platforms that this
             // builder builds to, then set this as the builder with the
             // BuildRunner.
-            if (buildTargets.Contains(report.summary.platform))
+            if (_buildTargets.Contains(report.summary.platform))
             {
+                // Note that in this context, despite being within an abstract
+                // class, the most derived instance will be returned when
+                // "this" is accessed.
                 BuildRunner.Builder = this;
             }
         }

--- a/Assets/Plugins/Source/Editor/Utility/MakefileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/MakefileUtility.cs
@@ -75,7 +75,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         public static void BuildLibrariesMac()
         {
 #if UNITY_EDITOR_OSX
-            BuildMac();
+            Task.Run(BuildMac);
 #endif
         }
 

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -36,7 +36,7 @@ using Epic.OnlineServices.Platform;
 using System.Runtime.InteropServices;
 using UnityEngine.Scripting;
 
-#if (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA_10_0)
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -80,7 +80,7 @@ namespace PlayEveryWare.EpicOnlineServices
         public override void LoadDelegatesWithEOSBindingAPI()
         {
             // In the editor, EOS needs to be dynamically bound.
-#if UNITY_EDITOR 
+#if EOS_DYNAMIC_BINDINGS || UNITY_EDITOR 
             const string EOSBinaryName = Epic.OnlineServices.Config.LibraryName;
             var eosLibraryHandle = EOSManager.EOSSingleton.LoadDynamicLibrary(EOSBinaryName);
             Epic.OnlineServices.WindowsBindings.Hook<DLLHandle>(eosLibraryHandle, (DLLHandle handle, string functionName) => {

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -26,7 +26,7 @@
 #define EOS_DYNAMIC_BINDINGS
 #endif
 
-#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
+//#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
 
 using System.IO;
 using System.Collections.Generic;
@@ -37,10 +37,6 @@ using System.Runtime.InteropServices;
 using UnityEngine.Scripting;
 
 #if (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA_10_0)
-
-#if !UNITY_EDITOR_WIN
-[assembly: AlwaysLinkAssembly]
-#endif
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -37,7 +37,6 @@ using UnityEngine.Scripting;
 
 namespace PlayEveryWare.EpicOnlineServices
 {
-    using System.Runtime.CompilerServices;
     using Utility;
 
     public class EOSCreateOptions

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -36,6 +36,7 @@ using UnityEngine.Scripting;
 
 namespace PlayEveryWare.EpicOnlineServices
 {
+    using System.Runtime.CompilerServices;
     using Utility;
 
     public class EOSCreateOptions

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -32,7 +32,7 @@ using Epic.OnlineServices.Platform;
 using System.Runtime.InteropServices;
 using UnityEngine.Scripting;
 
-#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+#if (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN) && (!UNITY_EDITOR_LINUX && !UNITY_EDITOR_OSX)
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -21,17 +21,12 @@
 */
 
 #if !EOS_DISABLE
-#if UNITY_64 || UNITY_EDITOR_64
-#define PLATFORM_64BITS
-#elif (UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN)
-#define PLATFORM_32BITS
-#endif
 
 #if UNITY_EDITOR
 #define EOS_DYNAMIC_BINDINGS
 #endif
 
-//#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
+#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
 
 using System.IO;
 using System.Collections.Generic;
@@ -68,10 +63,11 @@ namespace PlayEveryWare.EpicOnlineServices
         public static string SteamConfigPath = "eos_steam_config.json";
 
 #if ENABLE_CONFIGURE_STEAM_FROM_MANAGED
-#if PLATFORM_64BITS
-        static string SteamDllName = "steam_api64.dll";
+        private static readonly string SteamDllName = 
+#if UNITY_64
+        "steam_api64.dll";
 #else
-static string SteamDllName = "steam_api.dll";
+        "steam_api.dll";
 #endif
 #endif
 
@@ -120,12 +116,10 @@ static string SteamDllName = "steam_api.dll";
         public override void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions)
         {
             string pluginPlatformPath =
-#if PLATFORM_64BITS
+#if UNITY_64
             "x64";
-#elif PLATFORM_32BITS
-            "x86";
 #else
-            "";
+            "x86";
 #endif
 
             if (pluginPlatformPath.Length > 0)

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -32,7 +32,8 @@ using Epic.OnlineServices.Platform;
 using System.Runtime.InteropServices;
 using UnityEngine.Scripting;
 
-#if (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN) && (!UNITY_EDITOR_LINUX && !UNITY_EDITOR_OSX)
+// If standalone windows and not editor, or the windows editor.
+#if (UNITY_STANDALONE_WIN && !UNITY_EDITOR) || UNITY_EDITOR_WIN
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -22,10 +22,6 @@
 
 #if !EOS_DISABLE
 
-#if UNITY_EDITOR
-#define EOS_DYNAMIC_BINDINGS
-#endif
-
 //#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
 
 using System.IO;
@@ -81,7 +77,8 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public override void LoadDelegatesWithEOSBindingAPI()
         {
-#if EOS_DYNAMIC_BINDINGS
+            // In the editor, EOS needs to be dynamically bound.
+#if UNITY_EDITOR 
             const string EOSBinaryName = Epic.OnlineServices.Config.LibraryName;
             var eosLibraryHandle = EOSManager.EOSSingleton.LoadDynamicLibrary(EOSBinaryName);
             Epic.OnlineServices.WindowsBindings.Hook<DLLHandle>(eosLibraryHandle, (DLLHandle handle, string functionName) => {

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -68,8 +68,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     {
         private const string ProjectPathToEOSBootstrapperTool = "tools/bin/EOSBootstrapperTool.exe";
 
-        protected WindowsBuilder(string nativeBinaryDirectory, params BuildTarget[] buildTargets) :
-            base(nativeBinaryDirectory, buildTargets) {   }
+        protected WindowsBuilder(string nativeBinaryDirectory, params BuildTarget[] buildTargets) : base(nativeBinaryDirectory, buildTargets) {   }
 
         public override void PostBuild(BuildReport report)
         {

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -34,7 +34,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     /// </summary>
     public class WindowsBuilder64 : WindowsBuilder
     {
-        public WindowsBuilder64() : base("Plugins/Windows/x64")
+        public WindowsBuilder64() : base("Plugins/Windows/x64", BuildTarget.StandaloneWindows64)
         {
             AddProjectFileToBinaryMapping(
                 "DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.sln",
@@ -48,7 +48,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     /// </summary>
     public class WindowsBuilder32 : WindowsBuilder
     {
-        public WindowsBuilder32() : base("Plugins/Windows/x86")
+        public WindowsBuilder32() : base("Plugins/Windows/x86", BuildTarget.StandaloneWindows)
         {
             // TODO: These libraries do not appear to be building properly - and the process
             //       also appears to delete the x64 libraries. It's possible that both things
@@ -68,10 +68,8 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     {
         private const string ProjectPathToEOSBootstrapperTool = "tools/bin/EOSBootstrapperTool.exe";
 
-        protected WindowsBuilder(string nativeBinaryDirectory) :
-            base(nativeBinaryDirectory, 
-                BuildTarget.StandaloneWindows, 
-                BuildTarget.StandaloneWindows64) {   }
+        protected WindowsBuilder(string nativeBinaryDirectory, params BuildTarget[] buildTargets) :
+            base(nativeBinaryDirectory, buildTargets) {   }
 
         public override void PostBuild(BuildReport report)
         {

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -22,13 +22,12 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
-    using Editor;
     using PlayEveryWare.EpicOnlineServices.Editor.Config;
-    using UnityEditor.Build.Reporting;
     using System.IO;
+    using UnityEditor;
     using UnityEditor.Build;
+    using UnityEditor.Build.Reporting;
     using UnityEngine;
-    using Utility;
 
     /// <summary>
     /// WindowsBuilder for 64-bit deployment.
@@ -70,7 +69,9 @@ namespace PlayEveryWare.EpicOnlineServices.Build
         private const string ProjectPathToEOSBootstrapperTool = "tools/bin/EOSBootstrapperTool.exe";
 
         protected WindowsBuilder(string nativeBinaryDirectory) :
-            base(nativeBinaryDirectory) {   }
+            base(nativeBinaryDirectory, 
+                BuildTarget.StandaloneWindows, 
+                BuildTarget.StandaloneWindows64) {   }
 
         public override void PostBuild(BuildReport report)
         {

--- a/Assets/Plugins/iOS/Core/IOSPlatformSpecifics.cs
+++ b/Assets/Plugins/iOS/Core/IOSPlatformSpecifics.cs
@@ -24,8 +24,7 @@ using UnityEngine;
 using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
 
-#if UNITY_IOS && !UNITY_EDITOR
-[assembly: AlwaysLinkAssembly]
+#if UNITY_IOS
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/iOS/Core/IOSPlatformSpecifics.cs
+++ b/Assets/Plugins/iOS/Core/IOSPlatformSpecifics.cs
@@ -20,11 +20,13 @@
 * SOFTWARE.
 */
 
+#if !EOS_DISABLE
 using UnityEngine;
 using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
 
-#if UNITY_IOS
+#if UNITY_IOS && !UNITY_EDITOR
+
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;
@@ -64,4 +66,5 @@ namespace PlayEveryWare.EpicOnlineServices
         }
     }
 }
+#endif
 #endif

--- a/Assets/Plugins/iOS/Core/IOSPlatformSpecifics.cs
+++ b/Assets/Plugins/iOS/Core/IOSPlatformSpecifics.cs
@@ -25,6 +25,7 @@ using UnityEngine;
 using UnityEngine.Scripting;
 using System.Runtime.InteropServices;
 
+// If iOS and not editor.
 #if UNITY_IOS && !UNITY_EDITOR
 
 namespace PlayEveryWare.EpicOnlineServices

--- a/Assets/Plugins/iOS/Editor/IOSBuilder.cs
+++ b/Assets/Plugins/iOS/Editor/IOSBuilder.cs
@@ -23,6 +23,7 @@
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
     using System.IO;
+    using UnityEditor;
     using UnityEditor.Build.Reporting;
     using Utility;
 
@@ -38,7 +39,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
     /// </summary>
     public class IOSBuilder : PlatformSpecificBuilder
     {
-        public IOSBuilder() : base("Plugins/iOS") { }
+        public IOSBuilder() : base("Plugins/iOS", BuildTarget.iOS) { }
 
         /// <summary>
         /// Perform post build tasks that are unique to the iOS platform.

--- a/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
+++ b/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
@@ -25,10 +25,6 @@ using UnityEngine.Scripting;
 
 #if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && !UNITY_EDITOR_WIN
 
-#if !UNITY_EDITOR_OSX
-[assembly: AlwaysLinkAssembly]
-#endif
-
 namespace PlayEveryWare.EpicOnlineServices 
 {
     using Epic.OnlineServices.Platform;

--- a/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
+++ b/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
@@ -20,9 +20,12 @@
 * SOFTWARE.
 */
 
+#if !EOS_DISABLE
+
 using UnityEngine;
 using UnityEngine.Scripting;
 
+// If the platform is OSX, and the editor is not Windows.
 #if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && !UNITY_EDITOR_WIN
 
 namespace PlayEveryWare.EpicOnlineServices 
@@ -52,4 +55,6 @@ namespace PlayEveryWare.EpicOnlineServices
         }
     }
 }
-#endif
+
+#endif // (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && !UNITY_EDITOR_WIN
+#endif // !EOS_DISABLE

--- a/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
+++ b/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
@@ -25,8 +25,8 @@
 using UnityEngine;
 using UnityEngine.Scripting;
 
-// If the platform is OSX, and the editor is not Windows.
-#if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && (!UNITY_EDITOR_WIN && !UNITY_EDITOR_LINUX)
+// If standalone osx and not editor, or the osx editor.
+#if (UNITY_STANDALONE_OSX && !UNITY_EDITOR) || UNITY_EDITOR_OSX
 
 namespace PlayEveryWare.EpicOnlineServices 
 {

--- a/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
+++ b/Assets/Plugins/macOS/Core/MacOSPlatformSpecifics.cs
@@ -26,7 +26,7 @@ using UnityEngine;
 using UnityEngine.Scripting;
 
 // If the platform is OSX, and the editor is not Windows.
-#if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && !UNITY_EDITOR_WIN
+#if (UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX) && (!UNITY_EDITOR_WIN && !UNITY_EDITOR_LINUX)
 
 namespace PlayEveryWare.EpicOnlineServices 
 {

--- a/Assets/Plugins/macOS/Editor/MacOSBuilder.cs
+++ b/Assets/Plugins/macOS/Editor/MacOSBuilder.cs
@@ -8,8 +8,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -23,12 +23,15 @@
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
     using System.IO;
+    using UnityEditor;
     using UnityEditor.Build.Reporting;
     using UnityEngine;
 
     public class MacOSBuilder : PlatformSpecificBuilder
     {
-        public MacOSBuilder() : base("Plugins/macOS") { }
+        public MacOSBuilder() : base(
+            "Plugins/macOS",
+            BuildTarget.StandaloneOSX) { }
 
         public override void PreBuild(BuildReport report)
         {

--- a/Assets/Plugins/macOS/Editor/MacOSBuilder.cs
+++ b/Assets/Plugins/macOS/Editor/MacOSBuilder.cs
@@ -29,9 +29,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
     public class MacOSBuilder : PlatformSpecificBuilder
     {
-        public MacOSBuilder() : base(
-            "Plugins/macOS",
-            BuildTarget.StandaloneOSX) { }
+        public MacOSBuilder() : base("Plugins/macOS",BuildTarget.StandaloneOSX) { }
 
         public override void PreBuild(BuildReport report)
         {


### PR DESCRIPTION
# Cross-Platform Build Fixes

Contrary to how it may appear upon first glance - this is not a refactor but a certified fix. In the process of hunting down a bug that a user discovered with the failure to build on the Mac I discovered that none of the cross-platform compilations were working correctly. Mac works if you build on mac, Windows works if you build on Windows, Linux with Linux.

There are two main areas I discovered that needed to be addressed to fix this - and I'm being as verbose both in this description and by adding comments to some of the files to illustrate clearly the changes that were made.
 
## Scripting Defines

There are currently a variety of bugs that exist because of the complicated nature of the scripting define conditionals at the top of some of the classes that derive from `PlatformSpecifics`. 

This PR addresses those issues and resolves a variety of open issues.

Most of these circumstances are pertaining to building on one platform to another platform. Because most developers who work on this plugin do so from the Windows platform, some of the configurations are currently in a broken state because of how the define conditionals work.

Below is a table of what is now supported (which is what documentation already _says_ is supported)

|Host Platform|Target Platform|
|-:|:-|
|Mac|Windows, Linux, Android, iOS|
|Windows|Mac, Linux, Android, iOS|
|Linux|Windows, Mac, Android, iOS|

_To be clear: you can't actually fully deploy an iOS app from anything but Mac, same as with targeting Mac - but "build" in this context means that Unity will do all the building it is capable of doing for that platform given the platform you are building from._

## `BuildRunner` Builder Selection

Previously, build runners were determined using the scripting defines for each platform. The problem with this approach is that it inherently _does not correctly build from one platform to another_.

The reason that this has gone unnoticed for a while is that many of the platform-specific tasks that are unique to each platform are minor - so the build runner for OSX is _close enough_ to the build runner for Windows that it doesn't cause any build errors. 

There are some circumstances where errors are reported - but more importantly these changes both avoid those errors - _and correctly implement cross-platform compilation_.