### PR TITLE
fix(leaderboard sample): Refresh leaderboards after stat ingestion and after wait

### DIFF
--- a/Assets/Scripts/EOSLeaderboardManager.cs
+++ b/Assets/Scripts/EOSLeaderboardManager.cs
@@ -452,7 +452,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             // Create an empty callback to pass to the function
             OnIngestStatCompleteCallback callback = (ref IngestStatCompleteCallbackInfo emptyCallback) => { };
-            this.IngestStat(statName, amount, callback);
+            IngestStat(statName, amount, callback);
         }
 
         /// <summary>Call to ingest the stat values into EOS Stat interface.</summary>
@@ -479,7 +479,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             OnIngestStatCompleteCallback combinedCallback = (ref IngestStatCompleteCallbackInfo callbackForCombined) => 
             {
-                this.StatsIngestCallbackFn(ref callbackForCombined);
+                StatsIngestCallbackFn(ref callbackForCombined);
                 ingestStatCallback(ref callbackForCombined);
             };
 

--- a/Assets/Scripts/EOSLeaderboardManager.cs
+++ b/Assets/Scripts/EOSLeaderboardManager.cs
@@ -445,10 +445,21 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             QueryUserScoresCallback?.Invoke(Result.Success);
         }
 
-        /// <summary>Call to ingest the stat values into EOS Stat interface.</summary>
+        /// <summary>Call to ingest the stat values into EOS Stat interface. This calls out to <see cref="IngestStat(string, int, OnIngestStatCompleteCallback)"/> with an empty callback passed to it.</summary>
         /// <param name="statName">Name of the stat</param>
         /// <param name="amount">The amount to ingest for specified stat</param>
         public void IngestStat(string statName, int amount)
+        {
+            // Create an empty callback to pass to the function
+            OnIngestStatCompleteCallback callback = (ref IngestStatCompleteCallbackInfo emptyCallback) => { };
+            this.IngestStat(statName, amount, callback);
+        }
+
+        /// <summary>Call to ingest the stat values into EOS Stat interface.</summary>
+        /// <param name="statName">Name of the stat</param>
+        /// <param name="amount">The amount to ingest for specified stat</param>
+        /// <param name="ingestStatCallback">Callback to run after the stat is ingested, containing information about the success of the method.</param>
+        public void IngestStat(string statName, int amount, OnIngestStatCompleteCallback ingestStatCallback)
         {
             IngestData[] stats =
             {
@@ -466,7 +477,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 Stats = stats
             };
 
-            StatsHandle.IngestStat(ref options, null, StatsIngestCallbackFn);
+            OnIngestStatCompleteCallback combinedCallback = (ref IngestStatCompleteCallbackInfo callbackForCombined) => 
+            {
+                this.StatsIngestCallbackFn(ref callbackForCombined);
+                ingestStatCallback(ref callbackForCombined);
+            };
+
+            StatsHandle.IngestStat(ref options, null, combinedCallback);
         }
 
         private void StatsIngestCallbackFn(ref IngestStatCompleteCallbackInfo data)

--- a/Assets/Scripts/UI/Leaderboard/UILeaderboardMenu.cs
+++ b/Assets/Scripts/UI/Leaderboard/UILeaderboardMenu.cs
@@ -127,7 +127,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 Debug.LogErrorFormat("UILeaderboardMenu (QueryRanksCompleted): returned result error: {0}", result);
 
                 // Even if we failed, try to refresh the leaderboard again later
-                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                if (refreshLeaderboardCoroutine != null)
+                {
+                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                }
                 refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
 
                 return;
@@ -162,7 +165,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     }
                 }
 
-                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                if (refreshLeaderboardCoroutine != null)
+                {
+                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                }
                 refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
             }
         }
@@ -245,7 +251,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 Debug.LogErrorFormat("UILeaderboardMenu (QueryUserScoresCompleted): returned result error: {0}", result);
 
                 // Even if we failed, try to refresh the leaderboard again later
-                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                if (refreshLeaderboardCoroutine != null)
+                {
+                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                }
                 refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
 
                 return;
@@ -303,7 +312,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     }
                 }
 
-                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                if (refreshLeaderboardCoroutine != null)
+                {
+                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                }
                 refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
             }
         }

--- a/Assets/Scripts/UI/Leaderboard/UILeaderboardMenu.cs
+++ b/Assets/Scripts/UI/Leaderboard/UILeaderboardMenu.cs
@@ -29,6 +29,7 @@ using Epic.OnlineServices.Leaderboards;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
+using Epic.OnlineServices.Stats;
 
 namespace PlayEveryWare.EpicOnlineServices.Samples
 {
@@ -62,6 +63,28 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private EOSLeaderboardManager LeaderboardManager;
         private EOSFriendsManager PlayerManager;
+
+        /// <summary>
+        /// If this value is greater than 0, then every time this number of seconds pass, the current viewed leaderboard will refresh.
+        /// The internal timer for this resets whenever a leaderboard is queried.
+        /// There is no way to determine when a successfully ingested stat has been fully processed, and that stat proliferated to the leaderboards in the back end.
+        /// Periodic refreshing of the leaderboard is one way to get up to date information.
+        /// Note that per user, you should never request stats more than 100 times a minute.
+        /// </summary>
+        public float SecondsBetweenLeaderboardRefreshes = 30;
+
+        /// <summary>
+        /// If this value is greater than 0, after a successful <see cref="IngestStatOnClick"/>, this amount of seconds will be waited before refreshing the current leaderboard.
+        /// There's no promise that a successfully ingested stat means that it is proliferated across other Epic Online Services systems, like leaderboards.
+        /// This delay is a guess at how long to reasonably wait before requerying the leaderboard to reflect the newly ingested stat.
+        /// </summary>
+        public float SecondsAfterStatIngestedToRefresh = 2;
+
+        /// <summary>
+        /// Reference to the coroutine for waiting for leaderboard refreshes.
+        /// Having a reference to it allows for slightly more powerful control of the coroutine.
+        /// </summary>
+        private Coroutine refreshLeaderboardCoroutine { get; set; }
 
         private void Start()
         {
@@ -102,6 +125,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if(result != Result.Success)
             {
                 Debug.LogErrorFormat("UILeaderboardMenu (QueryRanksCompleted): returned result error: {0}", result);
+
+                // Even if we failed, try to refresh the leaderboard again later
+                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
+
                 return;
             }
 
@@ -133,6 +161,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                         uiEntry.ScoreTxt.text = record.Score.ToString();
                     }
                 }
+
+                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
             }
         }
 
@@ -164,7 +195,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                     if (kvp.Key.Equals(currentSelectedDefinitionLeaderboardId, StringComparison.OrdinalIgnoreCase))
                     {
-                        // TODO: Update Ranks/UserScores
+                        RefreshCurrentSelectedLeaderboard();
                     }
                 }
             }
@@ -212,6 +243,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if (result != Result.Success)
             {
                 Debug.LogErrorFormat("UILeaderboardMenu (QueryUserScoresCompleted): returned result error: {0}", result);
+
+                // Even if we failed, try to refresh the leaderboard again later
+                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
+
                 return;
             }
 
@@ -266,6 +302,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                         }
                     }
                 }
+
+                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
             }
         }
 
@@ -303,7 +342,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 return;
             }
 
-            LeaderboardManager.IngestStat(currentSelectedDefinitionStatName, amount);
+            LeaderboardManager.IngestStat(currentSelectedDefinitionStatName, amount, (ref IngestStatCompleteCallbackInfo ingestedCallbackInfo) => 
+            {
+                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
+                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsAfterStatIngestedToRefresh));
+            });
         }
 
         public void ShowMenu()
@@ -334,6 +377,48 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             CurrentSelectedLeaderboardTxt.text = $"{currentSelectedDefinitionLeaderboardId} - " +
                 $"{currentSelectedDefinitionStatName} - {Enum.GetName(typeof(LeaderboardGroup), currentGroup)}";
+        }
+
+        /// <summary>
+        /// If a leaderboard is selected, re-query and re-display its values.
+        /// </summary>
+        public void RefreshCurrentSelectedLeaderboard()
+        {
+            if (string.IsNullOrEmpty(currentSelectedDefinitionLeaderboardId))
+            {
+                Debug.Log($"UILeaderboardMenu (RefreshCurrentSelectedLeaderboard): No leaderboard selected.");
+                return;
+            }
+
+            if (currentGroup == LeaderboardGroup.Friends)
+            {
+                ShowFriendsOnClick();
+            }
+            else
+            {
+                ShowGlobalOnClick();
+            }
+        }
+
+        /// <summary>
+        /// Coroutine that yields for <see cref="SecondsBetweenLeaderboardRefreshes"/>, then calls RefreshCurrentSelectedLeaderboard.
+        /// Caller needs to re-call this to refresh after delay again.
+        /// </summary>
+        private System.Collections.IEnumerator RefreshCurrentLeaderboardAfterWait(float secondsToWait)
+        {
+            if (secondsToWait <= 0)
+            {
+                // No-op
+                yield break;
+            }
+
+            Debug.Log($"UILeaderboardMenu (RefreshCurrentLeaderboardAfterWait): Waiting {secondsToWait} seconds to refresh leaderboard...");
+
+            yield return new WaitForSeconds(secondsToWait);
+
+            Debug.Log($"UILeaderboardMenu (RefreshCurrentLeaderboardAfterWait): Waiting time has passed, refreshing leaderboard.");
+
+            RefreshCurrentSelectedLeaderboard();
         }
     }
 }

--- a/Assets/Scripts/UI/Leaderboard/UILeaderboardMenu.cs
+++ b/Assets/Scripts/UI/Leaderboard/UILeaderboardMenu.cs
@@ -129,9 +129,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 // Even if we failed, try to refresh the leaderboard again later
                 if (refreshLeaderboardCoroutine != null)
                 {
-                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                    StopCoroutine(refreshLeaderboardCoroutine);
                 }
-                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
+                refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsBetweenLeaderboardRefreshes));
 
                 return;
             }
@@ -167,9 +167,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (refreshLeaderboardCoroutine != null)
                 {
-                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                    StopCoroutine(refreshLeaderboardCoroutine);
                 }
-                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
+                refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsBetweenLeaderboardRefreshes));
             }
         }
 
@@ -253,9 +253,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 // Even if we failed, try to refresh the leaderboard again later
                 if (refreshLeaderboardCoroutine != null)
                 {
-                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                    StopCoroutine(refreshLeaderboardCoroutine);
                 }
-                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
+                refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsBetweenLeaderboardRefreshes));
 
                 return;
             }
@@ -314,9 +314,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (refreshLeaderboardCoroutine != null)
                 {
-                    this.StopCoroutine(refreshLeaderboardCoroutine);
+                    StopCoroutine(refreshLeaderboardCoroutine);
                 }
-                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsBetweenLeaderboardRefreshes));
+                refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsBetweenLeaderboardRefreshes));
             }
         }
 
@@ -356,8 +356,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             LeaderboardManager.IngestStat(currentSelectedDefinitionStatName, amount, (ref IngestStatCompleteCallbackInfo ingestedCallbackInfo) => 
             {
-                if (refreshLeaderboardCoroutine != null) this.StopCoroutine(refreshLeaderboardCoroutine);
-                refreshLeaderboardCoroutine = this.StartCoroutine(RefreshCurrentLeaderboardAfterWait(this.SecondsAfterStatIngestedToRefresh));
+                if (refreshLeaderboardCoroutine != null)
+                {
+                    StopCoroutine(refreshLeaderboardCoroutine);
+                }
+                refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsAfterStatIngestedToRefresh));
             });
         }
 


### PR DESCRIPTION
EOS-1091; The leaderboards sample had a usability issue where the "Refresh" button unintuitively doesn't refresh the leaderboard rankings. This now refreshes those on press.

After using the UI to "ingest a stat", there is a configurable wait before requerying the leaderboard. This will help with reflecting changes to the leaderboard in a way that feels more responsive. Additionally there is a variable for waiting a number of seconds and requerying after the wait.