### PR TITLE
Fix using statement placement to have `EOS_DISABLE` function as intended.

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -73,12 +73,13 @@ namespace PlayEveryWare.EpicOnlineServices
     using LoginCallbackInfo = Epic.OnlineServices.Auth.LoginCallbackInfo;
     using LoginOptions = Epic.OnlineServices.Auth.LoginOptions;
     using LoginStatusChangedCallbackInfo = Epic.OnlineServices.Auth.LoginStatusChangedCallbackInfo;
-#endif
+
     using Utility;
     using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
     using LogoutCallbackInfo = Epic.OnlineServices.Auth.LogoutCallbackInfo;
     using LogoutOptions = Epic.OnlineServices.Auth.LogoutOptions;
     using OnLogoutCallback = Epic.OnlineServices.Auth.OnLogoutCallback;
+#endif
 
     /// <summary>
     /// One of the responsibilities of this class is to manage the lifetime of


### PR DESCRIPTION
In the latest release (`3.2.0`) using statements were added to `EOSManager.cs` that were errantly placed outside the scripting define conditional `#if !EOS_DISABLE`. This hotfix rectifies that oversight and closes issue #693.