### PR TITLE
Revert "Fix using statement placement to have `EOS_DISABLE` function as intended."

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -73,13 +73,12 @@ namespace PlayEveryWare.EpicOnlineServices
     using LoginCallbackInfo = Epic.OnlineServices.Auth.LoginCallbackInfo;
     using LoginOptions = Epic.OnlineServices.Auth.LoginOptions;
     using LoginStatusChangedCallbackInfo = Epic.OnlineServices.Auth.LoginStatusChangedCallbackInfo;
-
+#endif
     using Utility;
     using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
     using LogoutCallbackInfo = Epic.OnlineServices.Auth.LogoutCallbackInfo;
     using LogoutOptions = Epic.OnlineServices.Auth.LogoutOptions;
     using OnLogoutCallback = Epic.OnlineServices.Auth.OnLogoutCallback;
-#endif
 
     /// <summary>
     /// One of the responsibilities of this class is to manage the lifetime of


### PR DESCRIPTION
Reverts PlayEveryWare/eos_plugin_for_unity#695

To maintain the historical fidelity of the release branch - this should more appropriately be put into a `release-3.2.1` branch.