### PR TITLE
Handle Repeat RequestAppTicket Calls in SteamManager and Invalidate Bad Token

### DIFF
--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -73,9 +73,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
             {
                 Debug.LogError("Error occured when requesting Encrypted App Ticket");
 
-                // First set the appTicketEvent we're calling to its own variable, set the appTicketEvent to null, then invoke the variable we set aside
-                // This way if the callback for the function would add to the appTicketEvent, it isn't immediately set to null
-                // This pattern is applied to the other calls to raise appTicketEvent
+                // First set the appTicketEvent we're calling to its own variable, set the appTicketEvent to null, then invoke the variable we set aside.
+                // This way if the callback for the function would add to the appTicketEvent, it isn't immediately set to null.
+                // This pattern is applied to the other calls that raise appTicketEvent inside this function.
                 Action<string> appTicketEventLetIOFailureOrNotOkay = appTicketEvent;
                 appTicketEvent = null;
                 appTicketEventLetIOFailureOrNotOkay?.Invoke(null);

--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -72,8 +72,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
             if (ioFailure || response.m_eResult != EResult.k_EResultOK)
             {
                 Debug.LogError("Error occured when requesting Encrypted App Ticket");
-                appTicketEvent?.Invoke(null);
+
+                // First set the appTicketEvent we're calling to its own variable, set the appTicketEvent to null, then invoke the variable we set aside
+                // This way if the callback for the function would add to the appTicketEvent, it isn't immediately set to null
+                // This pattern is applied to the other calls to raise appTicketEvent
+                Action<string> appTicketEventLetIOFailureOrNotOkay = appTicketEvent;
                 appTicketEvent = null;
+                appTicketEventLetIOFailureOrNotOkay?.Invoke(null);
                 return;
             }
 
@@ -91,8 +96,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
             if (!success)
             {
                 Debug.LogError("Failed to retrieve Encrypted App Ticket");
-                appTicketEvent?.Invoke(null);
+
+                // See above in regards to raising appTicketEvent
+                Action<string> appTicketEventLetNotSuccess = appTicketEvent;
                 appTicketEvent = null;
+                appTicketEventLetNotSuccess?.Invoke(null);
+
                 return;
             }
 
@@ -101,8 +110,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
             //convert to hex string
             encryptedAppTicket = System.BitConverter.ToString(buffer).Replace("-", "");
 
-            appTicketEvent?.Invoke(encryptedAppTicket);
+            // See above in regards to raising appTicketEvent
+            Action<string> appTicketEventLetSuccess = appTicketEvent;
             appTicketEvent = null;
+            appTicketEventLetSuccess?.Invoke(encryptedAppTicket);
         }
 
         private void OnApplicationQuit()

--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -438,7 +438,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
                         if (callbackInfo.ResultCode != Epic.OnlineServices.Result.Success)
                         {
                             Debug.Log($"Connect Login failed: SteamManager successfully retrieved an app ticket from Steam, but the provided app ticket was invalid for logging in to Epic Online Services. The cached app ticket in `{nameof(encryptedAppTicket)}` will now be invalidated.");
-                            this.encryptedAppTicket = null;
+                            encryptedAppTicket = null;
                         }
 
                         // Then call the original callback we were provided, if we have one


### PR DESCRIPTION
Before this PR, when the submits a `StartConnectLoginWithSteamAppTicket` call that results in a failed app token retrieval or a failed connect login, the plugin could get in to a state where subsequent calls to this method would not be resolved properly.

There are three areas being addressed:

- `appTicketCallResult` is set to a new instance of `CallResult<EncryptedAppTicketResponse_t>`. This helps to avoid garbage collection that stomps over previous failed calls.
- When a `StartConnectLoginWithSteamAppTicket` fails, always invalidate the `encryptedAppTicket` cache. This allows the code to resolve a situation where a `RequestAppTicket` call successfully returns a token, but for some reason it is not valid for logging in. In this changeset if a repeat call to `RequestAppTicket` may get a new token, it can now possibly use that new value instead of only using the previously successful cached token.
- When preparing to run the `appTicketEvent` event inside `RequestAppTicketResponse`, pull out the current value of `appTicketEvent` in to a new variable, set the `appTicketEvent` to null, then invoke the new variable. This is to help with the scenario where a user has a callback such that it would add an event to `appTicketEvent` in a way that would have been ignored because the delegate was being set to null after invoking.

This PR resolves issue #686.