### PR TITLE
With the DisableOverlay Platform Flag set, do not include EOSBootstrapper.exe

### DIFF
--- a/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
+++ b/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
@@ -5,7 +5,8 @@
         "GUID:2ced8f3cc58f63843bc26c7591a35628",
         "GUID:478a2357cc57436488a56e564b08d223",
         "GUID:3a63500f0eef43a438c0553491f7c5da",
-        "GUID:4a3cd13b0378c984c9688988d6a41c57"
+        "GUID:4a3cd13b0378c984c9688988d6a41c57",
+        "GUID:be1f6e9efffcfce41aeb5c2f4c27cf75"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -22,6 +22,7 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
+    using Epic.OnlineServices.Platform;
     using PlayEveryWare.EpicOnlineServices.Editor.Config;
     using System.IO;
     using UnityEditor;
@@ -79,6 +80,16 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
         private static async void ConfigureAndInstallBootstrapper(BuildReport report)
         {
+            // Determine if 'DisableOverlay' is set in Platform Flags. If it is, then the EOSBootstrapper.exe is not included in the build,
+            // because without needing the overlay, the EOSBootstrapper.exe is not useful to users of the plugin
+            EOSConfig configuration = await Config.GetAsync<EOSConfig>();
+            PlatformFlags configuredFlags = configuration.platformOptionsFlagsAsPlatformFlags();
+            if (configuredFlags.HasFlag(PlatformFlags.DisableOverlay))
+            {
+                Debug.Log($"The '{nameof(PlatformFlags.DisableOverlay)}' flag has been configured, EOSBootstrapper.exe will not be included in this build.");
+                return;
+            }
+
             /*
              * NOTE:
              *

--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -21,6 +21,7 @@
   - [Why am I getting Overlay Errors?](#why-am-i-getting-overlay-errors)
   - [Missing Native Libraries?](#missing-native-libraries)
   - [How do I debug the native DLL?](#how-do-i-debug-the-native-dll)
+  - [How do I disable the Overlay?](#how-do-i-disable-the-overlay)
 
 ## Why does the plugin fail to work after changing configuration?
 
@@ -146,3 +147,9 @@ Or to install the libraries manually, go to the `lib/NativeCode` folder, find th
 2. Build the Visual Studio project.
 3. Copy the DLL to a version of the exported project to debug.
 4. After launch, attach to the project after the dialog box appears.
+
+## How do I disable the Overlay?
+
+On the EOS Configuration Editor Window there is a setting for `Platform Flags`. By adding `DisableOverlay` to your list of Platform Flags, the Epic Overlay will not be initialized during runtime. When this is configured the `EOSBootstrapper.exe` will not be included in Windows builds.
+
+See [`PlatformFlags.cs`](\Assets\Plugins\Source\EOS_SDK\Generated\Platform\PlatformFlags.cs)

--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -152,4 +152,4 @@ Or to install the libraries manually, go to the `lib/NativeCode` folder, find th
 
 On the EOS Configuration Editor Window there is a setting for `Platform Flags`. By adding `DisableOverlay` to your list of Platform Flags, the Epic Overlay will not be initialized during runtime. When this is configured the `EOSBootstrapper.exe` will not be included in Windows builds.
 
-See [`PlatformFlags.cs`](\Assets\Plugins\Source\EOS_SDK\Generated\Platform\PlatformFlags.cs)
+See [`PlatformFlags.cs`](\..\Assets\Plugins\Source\EOS_SDK\Generated\Platform\PlatformFlags.cs)

--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -152,4 +152,4 @@ Or to install the libraries manually, go to the `lib/NativeCode` folder, find th
 
 On the EOS Configuration Editor Window there is a setting for `Platform Flags`. By adding `DisableOverlay` to your list of Platform Flags, the Epic Overlay will not be initialized during runtime. When this is configured the `EOSBootstrapper.exe` will not be included in Windows builds.
 
-See [`PlatformFlags.cs`](\..\Assets\Plugins\Source\EOS_SDK\Generated\Platform\PlatformFlags.cs)
+See [`PlatformFlags.cs`](/Assets/Plugins/Source/EOS_SDK/Generated/Platform/PlatformFlags.cs)


### PR DESCRIPTION
In the EOS Configuration pane, with the `DisableOverlay` Platform Flag set, EOSBootstrapper.exe will not be included in Windows builds.

`DisableOverlay` already disabled the Overlay correctly. This change just makes it so that the EOSBootstrapper.exe won't be included in the build artifacts.

Resolves issue #679