### PR TITLE
Upgrade Android Gradle Dependencies

### DIFF
--- a/etc/PlatformSpecificAssets/EOS/Android/eos_dependencies.androidlib/build.gradle
+++ b/etc/PlatformSpecificAssets/EOS/Android/eos_dependencies.androidlib/build.gradle
@@ -30,9 +30,9 @@ android {
     }
 }
 dependencies {
-        implementation 'com.android.support:appcompat-v7:28.0.0'
-        implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-        implementation 'androidx.security:security-crypto:1.0.0-rc01'
-        implementation 'androidx.browser:browser:1.0.0'
+        implementation 'androidx.appcompat:appcompat:1.5.1'
+        implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+        implementation 'androidx.security:security-crypto:1.0.0'
+        implementation 'androidx.browser:browser:1.4.0'
     //api fileTree(dir: 'libs', include: ['*.aar'])
 }


### PR DESCRIPTION
Upgrades the indicated dependencies in the `.gradle` file for the Android platform, per EOS SDK v1.16.2 release notes.

Thanks again goes to @mohumohu-corp for making note of it while filing another issue. EOS SDK release notes for version 1.16.2 indicate that the android gradle dependencies were upgraded, but previously we had failed to specify the upgrade in the plugin.