### PR TITLE
Observe and Use -epicdeploymentid Argument

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -610,7 +610,16 @@ namespace PlayEveryWare.EpicOnlineServices
                     loadedEOSConfig.sandboxID = epicArgs.epicSandboxID;
                 }
 
-                if (loadedEOSConfig.sandboxDeploymentOverrides != null)
+                // First try to load a specifically overridden epicDeploymentID
+                // If that is available, then use the provided argument
+                // If it is not available, then look up the deployment id using the sandbox overrides
+
+                if (!string.IsNullOrWhiteSpace(epicArgs.epicDeploymentID))
+                {
+                    Debug.Log("Deployment ID override specified: " + epicArgs.epicDeploymentID);
+                    loadedEOSConfig.deploymentID = epicArgs.epicDeploymentID;
+                }
+                else if (loadedEOSConfig.sandboxDeploymentOverrides != null)
                 {
                     //check if a deployment id override exists for sandbox id
                     foreach (var deploymentOverride in loadedEOSConfig.sandboxDeploymentOverrides)
@@ -621,12 +630,6 @@ namespace PlayEveryWare.EpicOnlineServices
                             loadedEOSConfig.deploymentID = deploymentOverride.deploymentID;
                         }
                     }
-                }
-
-                if (!string.IsNullOrWhiteSpace(epicArgs.epicDeploymentID))
-                {
-                    Debug.Log("Deployment ID override specified: " + epicArgs.epicDeploymentID);
-                    loadedEOSConfig.deploymentID = epicArgs.epicDeploymentID;
                 }
 
                 Result initResult = InitializePlatformInterface(loadedEOSConfig);
@@ -934,6 +937,10 @@ namespace PlayEveryWare.EpicOnlineServices
                         ConfigureEpicArgument(argument, ref epicLauncherArgs.epicSandboxID);
                     }
                     else if (argument.StartsWith("-eosdeploymentid="))
+                    {
+                        ConfigureEpicArgument(argument, ref epicLauncherArgs.epicDeploymentID);
+                    }
+                    else if (argument.StartsWith("-epicdeploymentid="))
                     {
                         ConfigureEpicArgument(argument, ref epicLauncherArgs.epicDeploymentID);
                     }

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
@@ -1422,11 +1422,21 @@ DLL_EXPORT(void) UnityPluginLoad(void*)
 
 #if PLATFORM_WINDOWS
     std::string deploymentArgName = "-eosdeploymentid=";
+    std::string egsDeploymentArgName = "-epicdeploymentid=";
     for (unsigned i = 0; i < argStrings.size(); ++i)
     {
+        std::string* match = nullptr;
         if (argStrings[i]._Starts_with(deploymentArgName))
         {
-            std::string deploymentArg = argStrings[i].substr(deploymentArgName.length());
+            match = &deploymentArgName;
+        }
+        else if (argStrings[i]._Starts_with(egsDeploymentArgName))
+        {
+            match = &egsDeploymentArgName;
+        }
+        if (match != nullptr)
+        {
+            std::string deploymentArg = argStrings[i].substr(match->length());
             if (!deploymentArg.empty())
             {
                 log_inform(("Deployment ID override specified: " + deploymentArg).c_str());


### PR DESCRIPTION
If an `epicdeploymentid` is provided, use it. This is observed in `dllmain.cpp` and `EOSManager.cs`. Before this set of changes, only `eosdeploymentid` was observed for setting the deployment id, but the argument that the Epic Game Store Launcher is `epicdeploymentid`, so the provided argument was ignored and the sandbox override list was used.

Possible problem: This change effectively invalidates the sandbox override id system. The EGS will always provide the arguments, and those will be used instead.

Resolves issue #705 