### PR TITLE
Fixes post 3.2.0 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,5 +31,3 @@
 *.asset             merge=unityyamlmerge eol=lf
 *.meta              merge=unityyamlmerge eol=lf
 *.controller        merge=unityyamlmerge eol=lf
-
-Assets/Plugins/Linux/libDynamicLibraryLoaderHelper.so filter=lfs diff=lfs merge=lfs binary

--- a/Assets/Plugins/Linux/.gitattributes
+++ b/Assets/Plugins/Linux/.gitattributes
@@ -1,1 +1,2 @@
 libEOSSDK-Linux-Shipping.so filter=lfs diff=lfs merge=lfs binary
+libDynamicLibraryLoaderHelper.so filter=lfs diff=lfs merge=lfs binary

--- a/Assets/Plugins/Source/Editor/Windows/InstallEOSZipWindow.cs
+++ b/Assets/Plugins/Source/Editor/Windows/InstallEOSZipWindow.cs
@@ -65,8 +65,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         private string pathToImportDescDirectory;
         private PlatformImportInfoList importInfoList;
 
-        // Disabling Install EOSZipWindow because it does not currently work.
-        //[MenuItem("Tools/EOS Plugin/Install EOS zip")]
+        [MenuItem("Tools/EOS Plugin/Install EOS zip")]
         public static void ShowWindow()
         {
             GetWindow<InstallEOSZipWindow>("Install EOS Zip");
@@ -126,8 +125,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
         protected override void Setup()
         {
-            pathToImportDescDirectory = Path.Combine(FileUtility.GetProjectPath(), "etc/EOSImportDesriptions/");
-            importInfoList = JsonUtility.FromJsonFile<PlatformImportInfoList>(pathToImportDescDirectory);
+            pathToImportDescDirectory = Path.Combine(FileUtility.GetProjectPath(), "etc/EOSImportDesriptions");
+            importInfoList = JsonUtility.FromJsonFile<PlatformImportInfoList>(Path.Combine(pathToImportDescDirectory, PlatformImportInfoListFileName));
         }
 
         private void DrawPresets()

--- a/Assets/Scripts/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/UI/Login/UILoginMenu.cs
@@ -319,6 +319,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <returns>True if input should be handled, false if not.</returns>
         private static bool ShouldInputBeHandled()
         {
+            if (null == EventSystem.current)
+            {
+                Debug.Log("EventSystem is null");
+                return false;
+            }
+
             bool shouldHandle = !EOSManager.Instance.IsOverlayOpenWithExclusiveInput();
 
 #if ENABLE_INPUT_SYSTEM

--- a/Assets/Scripts/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/UI/Login/UILoginMenu.cs
@@ -339,15 +339,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         }
 
 #if ENABLE_DEBUG_INPUT
-        static bool previousShouldHandle = false;
-        static void LogInputChanged(bool shouldHandle)
+        private static bool previousShouldHandle = false;
+        private static void LogInputChanged(bool shouldHandle)
         {
-            bool result = previousShouldHandle != shouldHandle ? true : false;
-            if (result)
+            if (previousShouldHandle != shouldHandle)
             {
                 Debug.LogWarning($"Input {(shouldHandle ? "enabled" : "disabled")} for main app");
+                previousShouldHandle = shouldHandle;
             }
-            previousShouldHandle = shouldHandle;
         }
 #endif
         /// <summary>

--- a/Assets/Scripts/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/UI/Login/UILoginMenu.cs
@@ -319,12 +319,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <returns>True if input should be handled, false if not.</returns>
         private static bool ShouldInputBeHandled()
         {
+            // Event System isn't found, so main app cannot handle input
             if (null == EventSystem.current)
             {
                 Debug.Log("EventSystem is null");
                 return false;
             }
 
+            // Main app handles input if overlay isn't open
             bool shouldHandle = !EOSManager.Instance.IsOverlayOpenWithExclusiveInput();
 
 #if ENABLE_INPUT_SYSTEM

--- a/Assets/Scripts/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/UI/Login/UILoginMenu.cs
@@ -330,11 +330,26 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             EventSystem.current.sendNavigationEvents = shouldHandle;
 #endif
 #endif
-            Debug.Log($"Input {(shouldHandle ? "enabled" : "disabled")} due to EOS Overlay.");
 
+#if ENABLE_DEBUG_INPUT
+            LogInputChanged(shouldHandle);
+#endif
             return shouldHandle;
+
         }
 
+#if ENABLE_DEBUG_INPUT
+        static bool previousShouldHandle = false;
+        static void LogInputChanged(bool shouldHandle)
+        {
+            bool result = previousShouldHandle != shouldHandle ? true : false;
+            if (result)
+            {
+                Debug.LogWarning($"Input {(shouldHandle ? "enabled" : "disabled")} for main app");
+            }
+            previousShouldHandle = shouldHandle;
+        }
+#endif
         /// <summary>
         /// Determines whether a GameObject needs to be set as selected.
         /// </summary>

--- a/Assets/Scripts/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/UI/Login/UILoginMenu.cs
@@ -319,27 +319,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <returns>True if input should be handled, false if not.</returns>
         private static bool ShouldInputBeHandled()
         {
-            // TODO: Clarify why this is only evaluated for PS4 and PS5
-#if UNITY_PS4 || UNITY_PS5
-            // TODO: Simplify this conditional - it's sort of confusing to read despite doing exactly what we want
-            if (null == EventSystem.current || EventSystem.current.sendNavigationEvents == !EOSManager.Instance.IsOverlayOpenWithExclusiveInput())
-            {
-                return true;
-            }
-
             bool shouldHandle = !EOSManager.Instance.IsOverlayOpenWithExclusiveInput();
-                
-            Debug.Log($"Input {(shouldHandle ? "enabled" : "disabled")} due to EOS Overlay.");
+
 #if ENABLE_INPUT_SYSTEM
             EventSystem.current.currentInputModule.enabled = shouldHandle;
+            EventSystem.current.sendNavigationEvents = shouldHandle;
 #else
+            // TODO: Clarify why this is only evaluated for PS4 and PS5
+#if UNITY_PS4 || UNITY_PS5
             EventSystem.current.sendNavigationEvents = shouldHandle;
 #endif
+#endif
+            Debug.Log($"Input {(shouldHandle ? "enabled" : "disabled")} due to EOS Overlay.");
 
             return shouldHandle;
-#else
-            return true;
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
The input login was inverted during the refactor and was causing breakages when interacting with the overlay.
This fix applies the working logic.