### PR TITLE
Relocate `TryGetTempDirectory` function to `FileUtility` from `PackageFileUtility`

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/FileUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/FileUtility.cs
@@ -33,26 +33,80 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
     public static class FileUtility
     {
         /// <summary>
-        /// Generates a unique and new temporary directory inside the Temporary Cache Path as determined by Unity,
-        /// and returns the fully-qualified path to the newly created directory.
+        /// Generates a unique and new temporary directory inside the Temporary
+        /// Cache Path as determined by Unity, and returns the fully-qualified
+        /// path to the newly created directory. The directory name will be
+        /// "Temp-" appended with a GUID.
         /// </summary>
-        /// <returns>Fully-qualified file path to the newly generated directory.</returns>
-        public static string GenerateTempDirectory()
+        /// <param name="path">
+        /// Fully-qualified path to the newly generated directory if one was
+        /// created, otherwise path is set to default System.String value.
+        /// </param>
+        /// <returns>
+        /// True if the temporary directory was created, false otherwise.
+        /// </returns>
+        public static bool TryGetTempDirectory(out string path)
         {
-            // Generate a temporary directory path.
-            string tempDirectory = Path.Combine(Application.temporaryCachePath, $"/Output-{Guid.NewGuid()}/");
-
-            // If (by some crazy miracle) the directory path already exists, keep generating until there is a new one.
-            while (Directory.Exists(tempDirectory))
+            path = default;
+            
+            // Nested local function to reduce repetitive code.
+            string GenerateTempPath()
             {
-                tempDirectory = Path.Combine(Application.temporaryCachePath, $"/Output-{Guid.NewGuid()}/");
+                return Path.Combine(
+                    Application.temporaryCachePath,
+                    $"Temp-{Guid.NewGuid()}");
             }
 
-            // Create the directory.
-            Directory.CreateDirectory(tempDirectory);
+            // Generate a temporary directory path.
+            string tempPath = GenerateTempPath();
+
+            // If (by some crazy miracle) the directory path already exists,
+            // try once more.
+            if (Directory.Exists(tempPath))
+            {
+                Debug.LogWarning(
+                    $"The temporary directory created collided with " +
+                    $"an existing temporary directory of the same name. This " +
+                    $"is very unlikely.");
+
+                tempPath = GenerateTempPath();
+
+                if (Directory.Exists(tempPath))
+                {
+                    Debug.LogError(
+                        $"When generating a temporary directory, the " +
+                        $"temporary directory generated collided twice with " +
+                        $"already existing directories of the same name. " +
+                        $"This is very unlikely.");
+
+                    return false;
+                }
+            }
+
+            try
+            {
+                // Create the directory.
+                var dInfo = Directory.CreateDirectory(tempPath);
+
+                // Make sure the directory exists.
+                if (!dInfo.Exists)
+                {
+                    Debug.LogError(
+                        $"Could not generate temporary directory.");
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(
+                    $"Could not generate temporary directory: " +
+                    $"{e.Message}");
+                return false;
+            }
 
             // return the fully-qualified path to the newly created directory.
-            return Path.GetFullPath(tempDirectory);
+            path = Path.GetFullPath(tempPath);
+            return true;
         }
 
         /// <summary>
@@ -131,7 +185,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// <returns>Task</returns>
         public static async Task<string> ReadAllTextAsync(string path)
         {
-            
             return await File.ReadAllTextAsync(path);
         }
 

--- a/Assets/Plugins/Source/Editor/Utility/BuildUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/BuildUtility.cs
@@ -738,7 +738,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
         /// <returns>The path to the temporary directory in which to store the files temporarily.</returns>
         private static string CacheExistingBinaries(IEnumerable<string> files)
         {
-            if (!PackageFileUtility.TryGetTempDirectory(out string temporaryDirectory))
+            if (!FileUtility.TryGetTempDirectory(out string temporaryDirectory))
             {
                 Debug.LogWarning("Could not create temporary directory to cache existing binaries.");
                 return string.Empty;

--- a/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
@@ -43,58 +43,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         private const double UpdateProgressIntervalInSeconds = 1.5;
 
         /// <summary>
-        /// Generates a unique and new temporary directory inside the Temporary Cache Path as determined by Unity,
-        /// and returns the fully-qualified path to the newly created directory.
-        /// </summary>
-        /// <returns>Fully-qualified file path to the newly generated directory.</returns>
-        public static bool TryGetTempDirectory(out string path)
-        {
-            // Generate a temporary directory path.
-            string tempPath = Path.Combine(Application.temporaryCachePath, $"Output-{Guid.NewGuid()}/");
-
-            // If (by some crazy miracle) the directory path already exists, keep generating until there is a new one.
-            if (Directory.Exists(tempPath))
-            {
-                Debug.LogWarning(
-                    $"The temporary directory created collided with an existing temporary directory of the same name. This is very unlikely.");
-                tempPath = Path.Combine(Application.temporaryCachePath, $"Output-{Guid.NewGuid()}/");
-
-                if (Directory.Exists(tempPath))
-                {
-                    Debug.LogError(
-                        $"When generating a temporary directory, the temporary directory generated collided twice with already existing directories of the same name. This is very unlikely.");
-                    path = null;
-                    return false;
-                }
-            }
-
-            try
-            {
-                // Create the directory.
-                var dInfo = Directory.CreateDirectory(tempPath);
-
-                // Make sure the directory exists.
-                if (!dInfo.Exists)
-                {
-                    Debug.LogError($"Could not generate temporary directory.");
-                    path = null;
-                    return false;
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"Could not generate temporary directory: {e.Message}");
-                path = null;
-                return false;
-            }
-
-            // return the fully-qualified path to the newly created directory.
-            path = Path.GetFullPath(tempPath);
-            return true;
-        }
-
-
-        /// <summary>
         /// Generates a list of FileInfoMatchingResults that represent the contents of the package to create.
         /// </summary>
         /// <param name="root">Where to search for the files to create the package out of.</param>

--- a/Assets/Plugins/Source/Editor/Utility/UnityPackageCreationUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/UnityPackageCreationUtility.cs
@@ -143,7 +143,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
         private static async Task CreateUPMTarball(string outputPath, string json_file,
             IProgress<CreatePackageProgressInfo> progress, CancellationToken cancellationToken)
         {
-            if (!PackageFileUtility.TryGetTempDirectory(out string tempOutput))
+            if (!FileUtility.TryGetTempDirectory(out string tempOutput))
             {
                 throw new BuildFailedException(
                     "Could not create temporary directory into which to place files for compression.");

--- a/Assets/Plugins/Source/Editor/Windows/InstallEOSZipWindow.cs
+++ b/Assets/Plugins/Source/Editor/Windows/InstallEOSZipWindow.cs
@@ -208,7 +208,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             GUILayout.Label(pathToZipFile);
             GUILayout.EndHorizontal();
 
-            if (GUILayout.Button("Install") && PackageFileUtility.TryGetTempDirectory(out string tmpDir))
+            if (GUILayout.Button("Install") && FileUtility.TryGetTempDirectory(out string tmpDir))
             {
                 try
                 {


### PR DESCRIPTION
This PR moves the `TryGetTempDirectory` function from `PackageFileUtility` to `FileUtility`, as its functionality is utilized in contexts other than package creation.

Some minor improvements to the implementation were made to reduce repeated code. Places that called the function were updated accordingly.