### PR TITLE
Relocate file copy operations from `PackageFileUtility` to `FileUtility`

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/Extensions/ListExtensions.cs
+++ b/Assets/Plugins/Source/Core/Utility/Extensions/ListExtensions.cs
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PlayEveryWare.EpicOnlineServices.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    /// <summary>
+    /// Threadsafe Random class.
+    /// </summary>
+    internal static class ThreadSafeRandom
+    {
+        private static readonly ThreadLocal<Random> threadLocalRandom = new(() => new Random());
+
+        public static Random Instance => threadLocalRandom.Value;
+    }
+
+    /// <summary>
+    /// Contains extension methods for lists.
+    /// </summary>
+    public static class ListExtensions
+    {
+        /// <summary>
+        /// Uses the Fisher-Yates algorithm to efficiently and uniformly shuffle
+        /// the contents of an object that implements the generic list
+        /// interface.
+        /// </summary>
+        /// <typeparam name="T">The template parameter for the list.</typeparam>
+        /// <param name="list">List to shuffle the contents of.</param>
+        public static void Shuffle<T>(this IList<T> list)
+        {
+            int n = list.Count;
+            for (int i = 0; i < n; i++)
+            {
+                // Lock to ensure things work as expected in threaded
+                // circumstances.
+                lock (ThreadSafeRandom.Instance)
+                {
+                    // Get the next random index to shuffle
+                    int j = ThreadSafeRandom.Instance.Next(i, n);
+                    // Use deconstruction syntax to perform the swap.
+                    (list[i], list[j]) = (list[j], list[i]);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Plugins/Source/Core/Utility/Extensions/ListExtensions.cs.meta
+++ b/Assets/Plugins/Source/Core/Utility/Extensions/ListExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ab6792594e84ac45a42366034774deb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Source/Core/Utility/FileUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/FileUtility.cs
@@ -26,10 +26,15 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using UnityEngine;
+
+    // This compile conditional exists to ensure that the Linq namespace is
+    // not utilized during runtime operations.
+#if UNITY_EDITOR
+    using System.Linq;
+#endif
 
     /// <summary>
     /// Utility class used for a variety of File tasks.
@@ -51,13 +56,13 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             /// <summary>
             /// The fully-qualified path of the source file.
             /// </summary>
-            public string From;
+            public string SourcePath;
 
             /// <summary>
             /// The fully-qualified path to copy the file to. The path does not
             /// have to exist, and in fact might not.
             /// </summary>
-            public string To;
+            public string DestinationPath;
 
             /// <summary>
             /// The number of bytes in the file to copy.
@@ -115,6 +120,12 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             return Path.GetFullPath(tempDirectory);
         }
 
+        // This compile conditional exists because the following functions 
+        // make use of the System.Linq namespace which is undesirable to use
+        // during runtime. Since these functions are currently only ever 
+        // utilized in areas of the code that run in the editor, it is
+        // appropriate to use compile conditionals to include / exclude them.
+#if UNITY_EDITOR
         /// <summary>
         /// Get a list of the directories that are represented by the filepaths
         /// provided. The list is unique, and is ordered by smallest path first,
@@ -124,12 +135,12 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// <param name="filepaths">
         /// The filepaths to get the directories for.
         /// </param>
-        /// <param name="inOrder">
-        /// If true, return the list of directories by order shortest path
-        /// first.
+        /// <param name="creationOrder">
+        /// If true, return the list of directories in such an order that they
+        /// do not rely on the existence of directories further down the list.
         /// </param>
         /// <returns></returns>
-        private static IEnumerable<string> GetDirectories(IEnumerable<string> filepaths, bool inOrder = true)
+        private static IEnumerable<string> GetDirectories(IEnumerable<string> filepaths, bool creationOrder = true)
         {
             // For each filepath, determine the immediate parent directory of
             // the file. Make a unique set of these by utilizing a HashSet.
@@ -147,7 +158,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
             // Return the list of directories to create in ascending order of
             // string length.
-            if (inOrder)
+            if (creationOrder)
             {
                 return directoriesToCreate.OrderBy(s => s.Length);
             }
@@ -181,7 +192,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         public static async Task CopyFilesAsync(IList<CopyFileOperation> operations, CancellationToken cancellationToken = default, IProgress<CopyFileProgressInfo> progress = null, int updateIntervalMS = DefaultUpdateIntervalMS)
         {
             // Create each directory
-            foreach (var directory in GetDirectories(operations.Select(o => o.To)))
+            foreach (var directory in GetDirectories(operations.Select(o => o.DestinationPath)))
             {
                 Directory.CreateDirectory(directory);
             }
@@ -218,6 +229,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 await CopyFilesAsyncInternal(operations, cancellationToken);
             }
         }
+#endif
 
         /// <summary>
         /// Performs the core file copy operations.
@@ -262,7 +274,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
             // Run the file copy asynchronously, passing on the
             // cancellation token.
-            await Task.Run(() => File.Copy(op.From, op.To,true), cancellationToken);
+            await Task.Run(() => File.Copy(op.SourcePath, op.DestinationPath,true), cancellationToken);
         }
 
         /// <summary>

--- a/Assets/Plugins/Source/Core/Utility/FileUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/FileUtility.cs
@@ -33,6 +33,32 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
     public static class FileUtility
     {
         /// <summary>
+        /// Contains information about the progress of a copy file operation.
+        /// </summary>
+        public struct CopyFileProgressInfo
+        {
+            /// <summary>
+            /// The number of files that have been copied.
+            /// </summary>
+            public int FilesCopied;
+
+            /// <summary>
+            /// The total number of files being copied.
+            /// </summary>
+            public int TotalFilesToCopy;
+
+            /// <summary>
+            /// The size in bytes of the files that have been copied.
+            /// </summary>
+            public long BytesCopied;
+
+            /// <summary>
+            /// The total size in bytes of all the files being copied.
+            /// </summary>
+            public long TotalBytesToCopy;
+        }
+
+        /// <summary>
         /// Generates a unique and new temporary directory inside the Temporary Cache Path as determined by Unity,
         /// and returns the fully-qualified path to the newly created directory.
         /// </summary>

--- a/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
@@ -232,6 +232,11 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
                 string destPath = isDestinationADirectory ? Path.Combine(finalDestinationPath, src.Name) : finalDestinationPath;
 
+                if (file.originalSrcDestPair.copy_identical)
+                {
+                    Debug.LogWarning("ASDF");
+                }
+
                 if (file.originalSrcDestPair.copy_identical || !src.AreContentsSemanticallyEqual(new FileInfo(destPath)))
                 {
                     filesToCopy.Add(new()
@@ -275,7 +280,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 out List<FileUtility.CopyFileOperation> copyOperations);
 
             // Copy the files
-            await FileUtility.ExecuteCopyFileOperationsAsync(copyOperations, cancellationToken, progress);
+            await FileUtility.CopyFilesAsync(copyOperations, cancellationToken, progress);
             
             // Execute callback
             postProcessCallback?.Invoke(destination);

--- a/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
@@ -37,58 +37,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
     public class PackageFileUtility
     {
         /// <summary>
-        /// Generates a unique and new temporary directory inside the Temporary Cache Path as determined by Unity,
-        /// and returns the fully-qualified path to the newly created directory.
-        /// </summary>
-        /// <returns>Fully-qualified file path to the newly generated directory.</returns>
-        public static bool TryGetTempDirectory(out string path)
-        {
-            // Generate a temporary directory path.
-            string tempPath = Path.Combine(Application.temporaryCachePath, $"Output-{Guid.NewGuid()}/");
-
-            // If (by some crazy miracle) the directory path already exists, keep generating until there is a new one.
-            if (Directory.Exists(tempPath))
-            {
-                Debug.LogWarning(
-                    $"The temporary directory created collided with an existing temporary directory of the same name. This is very unlikely.");
-                tempPath = Path.Combine(Application.temporaryCachePath, $"Output-{Guid.NewGuid()}/");
-
-                if (Directory.Exists(tempPath))
-                {
-                    Debug.LogError(
-                        $"When generating a temporary directory, the temporary directory generated collided twice with already existing directories of the same name. This is very unlikely.");
-                    path = null;
-                    return false;
-                }
-            }
-
-            try
-            {
-                // Create the directory.
-                var dInfo = Directory.CreateDirectory(tempPath);
-
-                // Make sure the directory exists.
-                if (!dInfo.Exists)
-                {
-                    Debug.LogError($"Could not generate temporary directory.");
-                    path = null;
-                    return false;
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"Could not generate temporary directory: {e.Message}");
-                path = null;
-                return false;
-            }
-
-            // return the fully-qualified path to the newly created directory.
-            path = Path.GetFullPath(tempPath);
-            return true;
-        }
-
-
-        /// <summary>
         /// Generates a list of FileInfoMatchingResults that represent the contents of the package to create.
         /// </summary>
         /// <param name="root">Where to search for the files to create the package out of.</param>

--- a/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
@@ -232,11 +232,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
                 string destPath = isDestinationADirectory ? Path.Combine(finalDestinationPath, src.Name) : finalDestinationPath;
 
-                if (file.originalSrcDestPair.copy_identical)
-                {
-                    Debug.LogWarning("ASDF");
-                }
-
                 if (file.originalSrcDestPair.copy_identical || !src.AreContentsSemanticallyEqual(new FileInfo(destPath)))
                 {
                     filesToCopy.Add(new()

--- a/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
@@ -236,8 +236,8 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 {
                     filesToCopy.Add(new()
                     {
-                        From = src.FullName,
-                        To = destPath,
+                        SourcePath = src.FullName,
+                        DestinationPath = destPath,
                         Bytes = src.Length
                     });
                 }

--- a/Assets/Plugins/Source/Editor/Utility/UnityPackageCreationUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/UnityPackageCreationUtility.cs
@@ -81,15 +81,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
             return JsonUtility.FromJsonFile<PackageDescription>(pathToJSONPackageDescription);
         }
 
-        public struct CreatePackageProgressInfo
-        {
-            public int FilesCopied;
-            public int TotalFilesToCopy;
-            public long SizeOfFilesCopied;
-            public long TotalSizeOfFilesToCopy;
-        }
-
-        public static async Task CreatePackage(PackageType packageType, IProgress<CreatePackageProgressInfo> progress = null, CancellationToken cancellationToken = default)
+        public static async Task CreatePackage(PackageType packageType, IProgress<FileUtility.CopyFileProgressInfo> progress = null, CancellationToken cancellationToken = default)
         {
             var packagingConfig = await Config.GetAsync<PackagingConfig>();
 
@@ -112,7 +104,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
             ValidatePackage(packagingConfig.pathToOutput);
         }
 
-        private static async Task CreateUPM(string outputPath, string json_file, IProgress<CreatePackageProgressInfo> progress, CancellationToken cancellationToken)
+        private static async Task CreateUPM(string outputPath, string json_file, IProgress<FileUtility.CopyFileProgressInfo> progress, CancellationToken cancellationToken)
         {
             /*
              * NOTES:
@@ -141,7 +133,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
         }
 
         private static async Task CreateUPMTarball(string outputPath, string json_file,
-            IProgress<CreatePackageProgressInfo> progress, CancellationToken cancellationToken)
+            IProgress<FileUtility.CopyFileProgressInfo> progress, CancellationToken cancellationToken)
         {
             if (!PackageFileUtility.TryGetTempDirectory(out string tempOutput))
             {

--- a/Assets/Plugins/Source/Editor/Utility/UnityPackageCreationUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/UnityPackageCreationUtility.cs
@@ -76,11 +76,6 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
         /// </summary>
         public static CoroutineExecutor executorInstance;
         
-        private static PackageDescription ReadPackageDescription(string pathToJSONPackageDescription)
-        {
-            return JsonUtility.FromJsonFile<PackageDescription>(pathToJSONPackageDescription);
-        }
-
         public static async Task CreatePackage(PackageType packageType, IProgress<FileUtility.CopyFileProgressInfo> progress = null, CancellationToken cancellationToken = default)
         {
             var packagingConfig = await Config.GetAsync<PackagingConfig>();
@@ -122,8 +117,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
                 return;
             }
 
-            PackageDescription packageDescription = ReadPackageDescription(json_file);
-            
+            PackageDescription packageDescription = JsonUtility.FromJsonFile<PackageDescription>(json_file);
+
             var filesToCopy = PackageFileUtility.FindPackageFiles(
                 FileUtility.GetProjectPath(),
                 packageDescription

--- a/Assets/Plugins/Source/Editor/Windows/CreatePackageWindow.cs
+++ b/Assets/Plugins/Source/Editor/Windows/CreatePackageWindow.cs
@@ -262,14 +262,14 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             _createPackageCancellationTokenSource = new();
             _operationInProgress = true;
 
-            var progressHandler = new Progress<UnityPackageCreationUtility.CreatePackageProgressInfo>(value =>
+            var progressHandler = new Progress<FileUtility.CopyFileProgressInfo>(value =>
             {
                 var fileCountStrSize = value.TotalFilesToCopy.ToString().Length;
                 string filesCopiedStrFormat = "{0," + fileCountStrSize + "}";
                 var filesCopiedCountStr = String.Format(filesCopiedStrFormat, value.FilesCopied);
                 var filesToCopyCountStr = String.Format(filesCopiedStrFormat, value.TotalFilesToCopy);
 
-                _progress = value.SizeOfFilesCopied / (float)value.TotalSizeOfFilesToCopy;
+                _progress = value.BytesCopied / (float)value.TotalBytesToCopy;
                 _progressText = $"{filesCopiedCountStr} out of {filesToCopyCountStr} files copied";
                 Repaint();
             });

--- a/Assets/Plugins/Source/Editor/Windows/CreatePackageWindow.cs
+++ b/Assets/Plugins/Source/Editor/Windows/CreatePackageWindow.cs
@@ -269,7 +269,9 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
                 var filesCopiedCountStr = String.Format(filesCopiedStrFormat, value.FilesCopied);
                 var filesToCopyCountStr = String.Format(filesCopiedStrFormat, value.TotalFilesToCopy);
 
-                _progress = value.BytesCopied / (float)value.TotalBytesToCopy;
+                // Ternary statement here to prevent a divide by zero problem
+                // ever happening, despite how odd it would be in this case.
+                _progress = (0.0f >= value.TotalBytesToCopy) ? value.BytesCopied / (float)value.TotalBytesToCopy : 0;
                 _progressText = $"{filesCopiedCountStr} out of {filesToCopyCountStr} files copied";
                 Repaint();
             });


### PR DESCRIPTION
This PR moves the asynchronous copy file operation functions from `PackageFileUtility.cs` to `FileUtility.cs` and makes clearer how the functions operate by renaming some of the signatures and data structures involved.

Corresponding places in the code where those functions and data structures are referenced have been updated.