### PR TITLE
fix: Remove extra file copy operation

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/FileUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/FileUtility.cs
@@ -393,12 +393,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                     // Only retry if there are remaining attempts.
                     await Task.Delay(delay, cancellationToken);
                 }
-                
             }
-
-            // Run the file copy asynchronously, passing on the
-            // cancellation token.
-            await Task.Run(() => File.Copy(op.SourcePath, op.DestinationPath,true), cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR remove an errantly included extra file copy operation that happens outside the try/catch block.