### PR TITLE
fix: Make `Config.Get` and `Config.GetAsync` compatible with Android

### DIFF
--- a/Assets/Plugins/Source/Core/Config.cs
+++ b/Assets/Plugins/Source/Core/Config.cs
@@ -33,6 +33,7 @@ namespace PlayEveryWare.EpicOnlineServices
     using System.Text;
     using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
     using System.Runtime.CompilerServices;
+    using Utility;
 
     /// <summary>
     /// Represents a set of configuration data for use by the EOS Plugin for
@@ -269,8 +270,7 @@ namespace PlayEveryWare.EpicOnlineServices
 #endif
             }
 
-            using StreamReader reader = new(FilePath);
-            _lastReadJsonString = await reader.ReadToEndAsync();
+            _lastReadJsonString = await FileUtility.ReadAllTextAsync(FilePath);
             JsonUtility.FromJsonOverwrite(_lastReadJsonString, this);
         }
 
@@ -284,8 +284,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
             if (configFileExists)
             {
-                using StreamReader reader = new(FilePath);
-                _lastReadJsonString = reader.ReadToEnd();
+                _lastReadJsonString = FileUtility.ReadAllText(FilePath);
                 JsonUtility.FromJsonOverwrite(_lastReadJsonString, this);
             }
             else


### PR DESCRIPTION
This PR addresses an issue where (when running on the Android platform) the `Config.Get<T>` and `Config.GetAsync<T>` functions cause a crash. The problem was that ultimately, those code execution paths were not making use of our `FileUtility` class - which accounts for the oddities of the Android platform to deal with this appropriately.

Kudos to @arthur740212 for discovering this issue in the process of his work making our Logging configuration better!