### PR TITLE
fix: Correct implementation of `ReadAllTextAsync` for Android

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/FileUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/FileUtility.cs
@@ -479,7 +479,13 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// <returns>Task</returns>
         public static async Task<string> ReadAllTextAsync(string path)
         {
-            return await File.ReadAllTextAsync(path);
+            string text = string.Empty;
+#if UNITY_ANDROID && !UNITY_EDITOR
+            text = AndroidFileIOHelper.ReadAllText(path);
+#else
+            text = await File.ReadAllTextAsync(path);
+#endif
+            return await Task.FromResult(text);
         }
 
         public static void NormalizePath(ref string path)


### PR DESCRIPTION
This PR fixes an issue where the wrong IO method is used when reading a fily asynchronously on the Android platform.