### PR TITLE
fix(mac) : Update burst to resolve persistent login crashing issue

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.unity.burst": "1.8.16",
     "com.unity.collab-proxy": "1.17.1",
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.ide.rider": "3.0.15",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.burst": "1.8.16",
+    "com.unity.burst": "1.8.8",
     "com.unity.collab-proxy": "1.17.1",
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.ide.rider": "3.0.15",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,11 +1,12 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.6.6",
-      "depth": 2,
+      "version": "1.8.16",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1"
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -69,7 +70,7 @@
     },
     "com.unity.mathematics": {
       "version": "1.2.6",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,12 +1,11 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.16",
+      "version": "1.8.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1",
-        "com.unity.modules.jsonserialize": "1.0.0"
+        "com.unity.mathematics": "1.2.1"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Update Burst version to 1.18.8 which is latest that all platforms support.