### PR TITLE
`EOSAchievementManager` refactor (Precursor to introduction of `StatsManager`)

### DIFF
--- a/Assets/Scripts/EOSAchievementManager.cs
+++ b/Assets/Scripts/EOSAchievementManager.cs
@@ -20,7 +20,7 @@
 * SOFTWARE.
 */
 
-#define ENABLE_DEBUG_EOSACHIEVEMENTMANAGER
+//#define ENABLE_DEBUG_EOSACHIEVEMENTMANAGER
 
 using System.Collections.Generic;
 using UnityEngine;

--- a/Assets/Scripts/EOSAchievementManager.cs
+++ b/Assets/Scripts/EOSAchievementManager.cs
@@ -20,7 +20,7 @@
 * SOFTWARE.
 */
 
-//#define ENABLE_DEBUG_EOSACHIEVEMENTMANAGER
+#define ENABLE_DEBUG_EOSACHIEVEMENTMANAGER
 
 using System.Collections.Generic;
 using UnityEngine;
@@ -70,7 +70,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>
         /// Conditionally executed proxy function for Unity's log function.
         /// </summary>
-        /// <param name="toPrint"></param>
+        /// <param name="toPrint">The message to log.</param>
         [Conditional("ENABLE_DEBUG_EOSACHIEVEMENTMANAGER")]
         private static void Log(string toPrint)
         {
@@ -173,7 +173,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 if (queryStatsCompleteCallbackInfo.ResultCode != Result.Success)
                 {
                     // TODO: handle error
-                    Log("Failed to query stats: " + queryStatsCompleteCallbackInfo.ResultCode);
+                    Log($"Failed to query stats, result code: {queryStatsCompleteCallbackInfo.ResultCode}");
                 }
                 callback?.Invoke(ref queryStatsCompleteCallbackInfo);
             });
@@ -263,7 +263,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// Queries the server for the achievement definitions for the game.
         /// Note that while a ProductUserId is a required parameter, it is used
         /// exclusively for the purpose of getting Locale-specific versions of
-        /// the achievement strings.
+        /// the achievements.
         /// </summary>
         /// <param name="productUserId">
         /// The ProductUserId that corresponds to the player. This is used
@@ -286,7 +286,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 if (data.ResultCode != Result.Success)
                 {
-                    Log("unable to query achievement definitions: " + data.ResultCode.ToString());
+                    Log($"Unable to query achievement definitions. Result code: {data.ResultCode}");
                 }
 
                 callback?.Invoke(ref data);
@@ -324,7 +324,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 if (data.ResultCode != Result.Success)
                 {
-                    Log("Error after query player achievements: " + data.ResultCode);
+                    Log($"Error querying player achievements. Result code: {data.ResultCode}");
                 }
 
                 callback?.Invoke(ref data);
@@ -540,7 +540,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 var copyResult = GetEOSAchievementInterface().CopyPlayerAchievementByIndex(ref playerAchievementByIndexOptions, out PlayerAchievement? playerAchievement);
                 if (copyResult != Result.Success)
                 {
-                    Log("Failed to copy player achievement : " + copyResult);
+                    Log($"Failed to copy player achievement from the cache. Result code: {copyResult}");
                     continue; // TODO handle error
                 }
                 if (playerAchievement.HasValue)

--- a/Assets/Scripts/UI/Achievements/UIAchievementsMenu.cs
+++ b/Assets/Scripts/UI/Achievements/UIAchievementsMenu.cs
@@ -148,7 +148,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             statsInterface.IngestStat(ref ingestOptions, null, (ref IngestStatCompleteCallbackInfo info) =>
             {
                 Debug.LogFormat("Stat ingest result: {0}", info.ResultCode.ToString());
-                achievementManager.RefreshData();
+                achievementManager.Refresh();
             });
         }
 
@@ -156,26 +156,26 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         //TODO: refresh achievement data without having to log out
         public void UnlockAchievement()
         {
-            if (displayIndex < 0 || displayIndex > achievementManager.GetAchievementDefinitionCount())
+            if (displayIndex < 0 || displayIndex > EOSAchievementManager.GetAchievementsCount())
             {
                 return;
             }
 
             var definition = achievementManager.GetAchievementDefinitionAtIndex(displayIndex);
 
-            achievementManager.UnlockAchievementManually(definition.AchievementId, (ref OnUnlockAchievementsCompleteCallbackInfo info) =>
+            achievementManager.UnlockAchievement(definition.AchievementId, (ref OnUnlockAchievementsCompleteCallbackInfo info) =>
             {
                 if (info.ResultCode == Result.Success)
                 {
                     Debug.Log("UnlockAchievement Succeed"); 
-                    achievementManager.RefreshData();
+                    achievementManager.Refresh();
                 }
             });
         }
 
         public void OnRefreshDataClicked()
         {
-            achievementManager.RefreshData();
+            achievementManager.Refresh();
         }
 
         // Achievements
@@ -188,11 +188,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             achievementListItems.Clear();
             achievementDataList.Clear();
 
-            uint achievementDefCount = achievementManager.GetAchievementDefinitionCount();
+            uint achievementDefCount = EOSAchievementManager.GetAchievementsCount();
 
             if (achievementDefCount > 0)
             {
-                foreach (var achievementDef in achievementManager.EnumerateCachedAchievementDefinitions())
+                foreach (var achievementDef in achievementManager.CachedAchievements())
                 {
                     achievementDataList.Add(new AchievementData()
                     {
@@ -204,7 +204,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 var userId = EOSManager.Instance.GetProductUserId();
                 if (userId.IsValid())
                 {
-                    foreach (var playerAch in achievementManager.EnumerateCachedPlayerAchievement(userId))
+                    foreach (var playerAch in achievementManager.CachedPlayerAchievements(userId))
                     {
                         var achData = achievementDataList.Find((AchievementData data) => data.Definition.AchievementId == playerAch.AchievementId);
                         if (achData != null)
@@ -274,7 +274,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void OnDefinitionIdButtonClicked(int i)
         {
-            if (i > achievementManager.GetAchievementDefinitionCount())
+            if (i > EOSAchievementManager.GetAchievementsCount())
             {
                 return;
             }
@@ -304,7 +304,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         void DisplayPlayerAchievement(DefinitionV2 definition)
         {
             PlayerAchievement? achievementNullable = null;
-            foreach (var ach in achievementManager.EnumerateCachedPlayerAchievement(EOSManager.Instance.GetProductUserId()))
+            foreach (var ach in achievementManager.CachedPlayerAchievements(EOSManager.Instance.GetProductUserId()))
             {
                 if (ach.AchievementId == definition.AchievementId)
                 {


### PR DESCRIPTION
Preliminary to the introduction of a Stats Manager for the plugin some refactoring has been done to `EOSAchievementManager`. The purpose of making a separate PR for _just_ the `EOSAchievementManager` refactors is to maintain clarity regarding the changes that will ultimately be made to extract the stats functionality from the achievements manager and put it into its own manager.

If these changes were done all at once, it would be more difficult to understand exactly how things were changed, as GitHub would effectively render the changes as a rewrite. Doing it this way means we can properly evaluate the changes as they are made.