### PR TITLE
fix(editor,rtc) : remove ifdef that breaks lobby creation on editor

### DIFF
--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -140,9 +140,8 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 var rtcOptions = new WindowsRTCOptions();
                 rtcOptions.PlatformSpecificOptions = rtcPlatformSpecificOptions;
-#if !UNITY_EDITOR
                 createOptions.options.RTCOptions = rtcOptions;
-#endif
+
                 // This code seems to commonly cause hangs in the editor, so until those can be resolved this code is being 
                 // disabled in the editor
 #if !UNITY_EDITOR && ENABLE_CONFIGURE_STEAM_FROM_MANAGED


### PR DESCRIPTION
Platform RTC doesn't enable on editor, which prevents lobby creation if lobby RTC options is enabled.
This PR removes the ifdef guarding the option from assigning.