### PR TITLE
Correct a misplaced `#endif`

### DIFF
--- a/Assets/Plugins/Source/Core/Utility/FileUtility.cs
+++ b/Assets/Plugins/Source/Core/Utility/FileUtility.cs
@@ -298,7 +298,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 await CopyFilesAsyncInternal(operations, cancellationToken);
             }
         }
-#endif
 
         /// <summary>
         /// Performs the core file copy operations.
@@ -340,7 +339,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
             await Task.WhenAll(tasks);
         }
-
+#endif
         /// <summary>
         /// Copies a single file asynchronously.
         /// </summary>


### PR DESCRIPTION
Corrects a bug in the placement of an `#endif` that cuts things off before it should have.

Thanks to @arthur740212 for discovering!