### PR TITLE
chore(native) : Restoring gitattributes with eol=lf instructions

### DIFF
--- a/lib/NativeCode/.gitattributes
+++ b/lib/NativeCode/.gitattributes
@@ -1,0 +1,4 @@
+*.cs diff=csharp text eol=lf
+*.h text eol=lf
+*.c text eol=lf
+*.cpp text eol=lf


### PR DESCRIPTION
Adds a .gitattributes file back to the NativeCode section. Only the file types that are actually in NativeCode are inside this. Added `eol=lf` to `*.cs`, which wasn't present before.

Having a more specific .gitattributes file will increase the likelihood that the Native library is following a consistent set of rules for all users of the plugin. The highest level .gitattributes file in the repository didn't include the C++ types, `.h` `.cpp` and `.c`, so this needs to have those rules. The `eol=lf` makes the line endings consistent regardless of client used to write/upload it.