### PR TITLE
Correct `!EOS_DISABLE` scripting defines

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -73,13 +73,14 @@ namespace PlayEveryWare.EpicOnlineServices
     using LoginCallbackInfo = Epic.OnlineServices.Auth.LoginCallbackInfo;
     using LoginOptions = Epic.OnlineServices.Auth.LoginOptions;
     using LoginStatusChangedCallbackInfo = Epic.OnlineServices.Auth.LoginStatusChangedCallbackInfo;
-#endif
+
     using Utility;
     using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
     using LogoutCallbackInfo = Epic.OnlineServices.Auth.LogoutCallbackInfo;
     using LogoutOptions = Epic.OnlineServices.Auth.LogoutOptions;
     using OnLogoutCallback = Epic.OnlineServices.Auth.OnLogoutCallback;
-
+#endif
+    
     /// <summary>
     /// One of the responsibilities of this class is to manage the lifetime of
     /// the EOS SDK and to be the interface for getting all the managed EOS interfaces.

--- a/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
+++ b/Assets/Plugins/Windows/Editor/WindowsBuilder.cs
@@ -22,7 +22,9 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Build
 {
+#if !EOS_DISABLE
     using Epic.OnlineServices.Platform;
+#endif
     using PlayEveryWare.EpicOnlineServices.Editor.Config;
     using System.IO;
     using UnityEditor;
@@ -80,6 +82,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
 
         private static async void ConfigureAndInstallBootstrapper(BuildReport report)
         {
+#if !EOS_DISABLE
             // Determine if 'DisableOverlay' is set in Platform Flags. If it is, then the EOSBootstrapper.exe is not included in the build,
             // because without needing the overlay, the EOSBootstrapper.exe is not useful to users of the plugin
             EOSConfig configuration = await Config.GetAsync<EOSConfig>();
@@ -89,7 +92,7 @@ namespace PlayEveryWare.EpicOnlineServices.Build
                 Debug.Log($"The '{nameof(PlatformFlags.DisableOverlay)}' flag has been configured, EOSBootstrapper.exe will not be included in this build.");
                 return;
             }
-
+#endif
             /*
              * NOTE:
              *


### PR DESCRIPTION
A few recently introduced changes to the `development` branch introduced some regressions when the `EOS_DISABLE` scripting define exists. This rectifies those issues so that when `EOS_DISABLE` _is_ defined, there are no scripting compile errors.