### PR TITLE
Hotfixes for Release `3.2.1` 

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -73,12 +73,13 @@ namespace PlayEveryWare.EpicOnlineServices
     using LoginCallbackInfo = Epic.OnlineServices.Auth.LoginCallbackInfo;
     using LoginOptions = Epic.OnlineServices.Auth.LoginOptions;
     using LoginStatusChangedCallbackInfo = Epic.OnlineServices.Auth.LoginStatusChangedCallbackInfo;
-#endif
+
     using Utility;
     using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
     using LogoutCallbackInfo = Epic.OnlineServices.Auth.LogoutCallbackInfo;
     using LogoutOptions = Epic.OnlineServices.Auth.LogoutOptions;
     using OnLogoutCallback = Epic.OnlineServices.Auth.OnLogoutCallback;
+#endif
 
     /// <summary>
     /// One of the responsibilities of this class is to manage the lifetime of

--- a/Assets/Plugins/Source/Core/EOSPackageInfo.cs
+++ b/Assets/Plugins/Source/Core/EOSPackageInfo.cs
@@ -35,7 +35,7 @@ namespace PlayEveryWare.EpicOnlineServices
          * not involve editing source code files.
          */
 
-        public const string Version = "3.2.0";
+        public const string Version = "3.2.1";
 
         public const string PackageName = "com.playeveryware.eos";
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.2.1] - 2024-06-24
+
+- ### Fixes
+- **Release Binary Fixes**:
+  - Corrects an error that was made when generating the binary package for the `3.2.0` release.
+  - Corrects an issue where the presence of the scripting define `EOS_DISABLE` caused compilation errors.
+
 # [3.2.0] - 2024-05-16
 
 ### New Features

--- a/etc/PackageTemplate/CHANGELOG.md
+++ b/etc/PackageTemplate/CHANGELOG.md
@@ -2,6 +2,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.2.1] - 2024-06-24
+
+- ### Fixes
+- **Release Binary Fixes**:
+  - Corrects an error that was made when generating the binary package for the `3.2.0` release.
+  - Corrects an issue where the presence of the scripting define `EOS_DISABLE` caused compilation errors.
+
 # [3.2.0] - 2024-05-16
 
 ### New Features

--- a/etc/PackageTemplate/package.json
+++ b/etc/PackageTemplate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.playeveryware.eos",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "unity": "2021.3",
     "unityRelease": "8f1",
     "displayName": "Epic Online Services Plugin for Unity",


### PR DESCRIPTION
This PR addresses the following issues with release `3.2.0`:

- Corrects an error that was made when generating the binary package for the `3.2.0` release.
- Corrects an issue where the presence of the scripting define `EOS_DISABLE` caused compilation errors.

The first item listed is not actually affected by these changes but will be accomplished in a subsequent step in our release process where the binary file is generated and attached to our `3.2.1` release.