### PR TITLE
Make use of `async` keyword conditional on whether SteamWorks is enabled or not.

### DIFF
--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -414,21 +414,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
         /// NOTE: This conditional is here because if EOS_DISABLE is enabled, the members referenced
         ///       in this code block will not exist on EOSManager.
 #if !EOS_DISABLE
-        public
-            // NOTE: This conditional is here because the function should only
-            //       be marked as 'async' if it calls an awaitable function 
-            //       using the 'await' keyword. When SteamWorks is disabled, 
-            //       there is no such call, which results in a compiler warning.
-#if !DISABLESTEAMWORKS
-            async 
-#endif
-            void StartLoginWithSteam(EOSManager.OnAuthLoginCallback onLoginCallback)
-            {
+        public async void StartLoginWithSteam(EOSManager.OnAuthLoginCallback onLoginCallback)
+        {
 #if DISABLESTEAMWORKS
             onLoginCallback?.Invoke(new Epic.OnlineServices.Auth.LoginCallbackInfo()
             {
                 ResultCode = Epic.OnlineServices.Result.UnexpectedError
             });
+
+            await Task.Run(() => { });
 #else
 
             string steamId = GetSteamID();

--- a/Assets/Scripts/Steam/SteamManager.cs
+++ b/Assets/Scripts/Steam/SteamManager.cs
@@ -414,8 +414,16 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
         /// NOTE: This conditional is here because if EOS_DISABLE is enabled, the members referenced
         ///       in this code block will not exist on EOSManager.
 #if !EOS_DISABLE
-        public async void StartLoginWithSteam(EOSManager.OnAuthLoginCallback onLoginCallback)
-        {
+        public
+            // NOTE: This conditional is here because the function should only
+            //       be marked as 'async' if it calls an awaitable function 
+            //       using the 'await' keyword. When SteamWorks is disabled, 
+            //       there is no such call, which results in a compiler warning.
+#if !DISABLESTEAMWORKS
+            async 
+#endif
+            void StartLoginWithSteam(EOSManager.OnAuthLoginCallback onLoginCallback)
+            {
 #if DISABLESTEAMWORKS
             onLoginCallback?.Invoke(new Epic.OnlineServices.Auth.LoginCallbackInfo()
             {


### PR DESCRIPTION
In a recent PR changes were introduced to the `SteamManager` that make one of the function calls `async`. However, if SteamWorks is disabled, no function is called with the `await` keyword, and a compiler warning is generated that suggest removing the `async` keyword. 

This resolves that issue by making the use of the `async` keyword conditional on whether or not SteamWorks is enabled.