### PR TITLE
Correct unsigned / signed comparison

### DIFF
--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
@@ -413,7 +413,7 @@ void eos_set_loglevel(const LogLevelConfig& log_config)
 {
     if (EOS_Logging_SetLogLevel_ptr != nullptr)
     {
-        for (int i = 0; i < log_config.category.size() - 1; i++)
+        for (unsigned i = 0; i < log_config.category.size() - 1; i++)
         {
             EOS_Logging_SetLogLevel_ptr((EOS_ELogCategory)i, eos_loglevel_str_to_enum(log_config.level[i]));
         }
@@ -1338,11 +1338,11 @@ void eos_create(EOSConfig& eosConfig)
         // then add one more null terminator at the end of the array
         std::vector<char> steamApiInterfaceVersionsAsCharArray;
 
-        for (int apiInterfaceVersionIndex = 0; apiInterfaceVersionIndex < eos_steam_config.steamApiInterfaceVersionsArray.size(); apiInterfaceVersionIndex++)
+        for (unsigned apiInterfaceVersionIndex = 0; apiInterfaceVersionIndex < eos_steam_config.steamApiInterfaceVersionsArray.size(); apiInterfaceVersionIndex++)
         {
             const std::string& currentFullValue = eos_steam_config.steamApiInterfaceVersionsArray[apiInterfaceVersionIndex];
 
-            for (int characterIndex = 0; characterIndex < currentFullValue.length(); characterIndex++)
+            for (unsigned characterIndex = 0; characterIndex < currentFullValue.length(); characterIndex++)
             {
                 char currentCharacter = currentFullValue[characterIndex];
                 steamApiInterfaceVersionsAsCharArray.push_back(currentCharacter);

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
@@ -41,6 +41,7 @@
 #include <codecvt>
 #include <vector>
 #include <iostream>
+#include <limits>
 
 
 //#include "eos_minimum_includes.h"
@@ -1375,11 +1376,18 @@ void eos_create(EOSConfig& eosConfig)
         steamApiInterfaceVersionsAsCharArray.push_back('\0');
 
         steam_platform.SteamApiInterfaceVersionsArray = reinterpret_cast<char*>(steamApiInterfaceVersionsAsCharArray.data());
+                
+        auto size = steamApiInterfaceVersionsAsCharArray.size();
+
+        if (size > (std::numeric_limits<uint32_t>::max)()) {
+            log_error("Size given for SteamApiInterfaceVersionsAsCharArray exceeds the maximum value for uint32_t.");
+            throw std::overflow_error("Size exceeds the maximum value for uint32_t");
+        }
 
         // steam_platform needs to have a count of how many bytes the "array" is, stored in SteamApiInterfaceVersionsArrayBytes
         // This has some fuzzy behavior; if you set it to 0 or count it up properly, there won't be a logged problem
         // if you put a non-zero amount that is insufficient, there will be an unclear logged error message
-        steam_platform.SteamApiInterfaceVersionsArrayBytes = steamApiInterfaceVersionsAsCharArray.size();
+        steam_platform.SteamApiInterfaceVersionsArrayBytes = static_cast<uint32_t>(size);
 
         steam_integrated_platform_option.ApiVersion = EOS_INTEGRATEDPLATFORM_OPTIONS_API_LATEST;
         steam_integrated_platform_option.Type = EOS_IPT_Steam;

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/dllmain.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 // dllmain.cpp : Defines the entry point for the DLL application.
 // This file does some *magick* to load the EOS Overlay DLL.
 // This is apparently needed so that the Overlay can render properly

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/DynamicLibraryLoaderHelper_Linux.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/DynamicLibraryLoaderHelper_Linux.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 // DynamicLibraryLoaderHelper.cpp : Defines the functions for the static library.
 //
 

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/Makefile
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/Makefile
@@ -1,3 +1,23 @@
+# Copyright (c) 2021 PlayEveryWare
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in 
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 CC=clang
 CXX=clang++
 

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/Memory_Linux.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_Linux/Memory_Linux.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include <stdlib.h>
 
 #define STATIC_EXPORT(return_type) extern "C" return_type

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/DynamicLibraryLoaderHelper_macos.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/DynamicLibraryLoaderHelper_macos.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 // DynamicLibraryLoaderHelper.cpp : Defines the functions for the static library.
 //
 

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/Makefile
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/Makefile
@@ -1,3 +1,23 @@
+# Copyright (c) 2021 PlayEveryWare
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in 
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 CC=clang
 CXX=clang++
 

--- a/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/Memory_macOS.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper_macOS/Memory_macOS.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include <stdlib.h>
 
 #define STATIC_EXPORT(return_type) extern "C" return_type

--- a/lib/NativeCode/include/windows/framework.h
+++ b/lib/NativeCode/include/windows/framework.h
@@ -11,5 +11,3 @@
 #define STATIC_EXPORT(return_type) extern "C" return_type
 
 #define DLL_EXPORT(return_value) extern "C" __declspec(dllexport) return_value  __stdcall
-
-#define FUN_EXPORT(return_value) DLL_EXPORT(return_value)

--- a/lib/NativeCode/src/DynamicLibraryLoaderHelper.cpp
+++ b/lib/NativeCode/src/DynamicLibraryLoaderHelper.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 // DynamicLibraryLoaderHelper.cpp : Defines the functions for the static library.
 //
 

--- a/lib/NativeCode/src/Memory.cpp
+++ b/lib/NativeCode/src/Memory.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "pch.h"
 #include "Memory.h"
 #include <atomic>

--- a/lib/NativeCode/src/windows/DynamicLibraryLoaderHelper_Win32.cpp
+++ b/lib/NativeCode/src/windows/DynamicLibraryLoaderHelper_Win32.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "pch.h"
 
 #include "DLLHContext.h"


### PR DESCRIPTION
In rebuilding the native code libraries for the upcoming release - I discovered that changes made to the native code files introduced some code that generated compiler warnings, particularly regarding the comparison of signed and unsigned integers. 

This PR does the following:

- Changes `for` loop variables to be `unsigned` instead of `int`, so as to avoid the compiler warning.
- Remove a duplicate macro definition that was also generating a warning.
- Adds the PEW copyright comment header block to all relevant code files.