### PR TITLE
feature (Sessions, Sample): Refresh UI, Standardized Logging

### DIFF
--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -274,7 +274,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             else
             {
-                EOSSessionsManager.Log("Session (InitFromSessionInfo): SessionDetailsInfo was null, therefore unable to determine current player count.");
+                EOSSessionsManager.Log($"{nameof(Session)} ({nameof(InitFromSessionInfo)}): SessionDetailsInfo was null, therefore unable to determine current player count.");
             }
 
             InitActiveSession();
@@ -295,7 +295,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: could not get ActiveSession for name: {0}", Name);
+                    Debug.LogError($"{nameof(Session)} ({nameof(InitActiveSession)}): could not get ActiveSession for name: {Name}");
                     return;
                 }
 
@@ -522,7 +522,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (subscribtedToGameInvites)
             {
-                Debug.LogWarning("Session Matchmaking (SubscribteToGameInvites): Already subscribed.");
+                Debug.LogWarning($"{nameof(EOSSessionsManager)} ({nameof(SubscribteToGameInvites)}): Already subscribed.");
                 return;
             }
 
@@ -546,7 +546,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (!subscribtedToGameInvites)
             {
-                Debug.LogWarning("Session Matchmaking (UnsubscribeFromGameInvites): Not subscribed yet.");
+                Debug.LogWarning($"{nameof(EOSSessionsManager)} ({nameof(UnsubscribeFromGameInvites)}): Not subscribed yet.");
                 return;
             }
 
@@ -621,7 +621,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                         }
                         else
                         {
-                            Debug.LogErrorFormat("Session Matchmaking: ActiveSessionCopyInfo failed. Errors code: {0}", result); ;
+                            Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(Update)}): ActiveSessionCopyInfo failed. Errors code: {result}");
                         }
                     }
                 }
@@ -634,7 +634,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (userLoggedIn)
             {
-                Debug.LogWarning("Session Matchmaking (OnLoggedIn): Already logged in.");
+                Debug.LogWarning($"{nameof(EOSSessionsManager)} ({nameof(OnLoggedIn)}): Already logged in.");
                 return;
             }
 
@@ -650,7 +650,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (!userLoggedIn)
             {
-                Debug.LogWarning("Session Matchmaking (OnLoggedOut): Not logged in.");
+                Debug.LogWarning($"{nameof(EOSSessionsManager)} ({nameof(OnLoggedOut)}): Not logged in.");
                 return;
             }
 
@@ -682,14 +682,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (session == null)
             {
-                Debug.LogErrorFormat("Session Matchmaking: parameter 'session' cannot be null!");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): parameter 'session' cannot be null!");
                 return false;
             }
 
             SessionsInterface sessionInterface = EOSManager.Instance.GetEOSPlatformInterface().GetSessionsInterface();
             if (sessionInterface == null)
             {
-                Debug.LogErrorFormat("Session Matchmaking: can't get sessions interface.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): can't get sessions interface.");
                 return false;
             }
 
@@ -705,7 +705,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: could not create session modification. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): could not create session modification. Error code: {result}");
                 return false;
             }
 
@@ -716,7 +716,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed to set permissions. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): failed to set permissions. Error code: {result}");
                 sessionModificationHandle.Release();
                 return false;
             }
@@ -728,7 +728,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed to set 'join in progress allowed' flag. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): failed to set 'join in progress allowed' flag. Error code: {result}");
                 sessionModificationHandle.Release();
                 return false;
             }
@@ -740,7 +740,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed to set invites allowed. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): failed to set invites allowed. Error code: {result}");
                 sessionModificationHandle.Release();
                 return false;
             }
@@ -760,7 +760,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed to set a bucket id attribute. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): failed to set a bucket id attribute. Error code: {result}");
                 sessionModificationHandle.Release();
                 return false;
             }
@@ -793,7 +793,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to set an attribute: {0}. Error code: {1}", sdAttrib.Key, result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(CreateSession)}): failed to set an attribute: {sdAttrib.Key}. Error code: {result}");
                     sessionModificationHandle.Release();
                     return false;
                 }
@@ -946,7 +946,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             else
             {
-                Debug.LogErrorFormat("Session Matchmaking: can't start session: no active session with specified name.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(StartSession)}): can't start session: no active session with specified name.");
                 return;
             }
         }
@@ -955,7 +955,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (!CurrentSessions.TryGetValue(name, out Session session))
             {
-                Debug.LogErrorFormat("Session Matchmaking: can't end session: no active session with specified name: {0}", name);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(EndSession)}): can't end session: no active session with specified name: {name}");
                 return;
             }
 
@@ -990,14 +990,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (!friendId.IsValid())
             {
-                Debug.LogError("Session Matchmaking - InviteToSession: friend's product user id is invalid!");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InviteToSession)}): friend's product user id is invalid!");
                 return;
             }
 
             ProductUserId currentUserId = EOSManager.Instance.GetProductUserId();
             if (!currentUserId.IsValid())
             {
-                Debug.LogError("Session Matchmaking - InviteToSession: current user's product user id is invalid!");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InviteToSession)}): current user's product user id is invalid!");
                 return;
             }
 
@@ -1038,7 +1038,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed to create session search. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(Search)}): failed to create session search. Error code: {result}");
                 return;
             }
 
@@ -1059,7 +1059,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed to update session search with bucket id parameter. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(Search)}): failed to update session search with bucket id parameter. Error code: {result}");
                 return;
             }
 
@@ -1090,7 +1090,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to update session search with parameter. Error code: {0}", result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(Search)}): failed to update session search with parameter. Error code: {result}");
                     return;
                 }
             }
@@ -1115,7 +1115,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if (result != Result.Success)
             {
                 AcknowledgeEventId(result);
-                Debug.LogErrorFormat("Session Matchmaking: failed create session search. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SearchById)}): failed create session search. Error code: {result}");
                 return;
             }
 
@@ -1129,7 +1129,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if (result != Result.Success)
             {
                 AcknowledgeEventId(result);
-                Debug.LogErrorFormat("Session Matchmaking: failed to update session search with session ID. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SearchById)}): failed to update session search with session ID. Error code: {result}");
                 return;
             }
 
@@ -1197,7 +1197,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (session == null)
             {
-                Debug.LogError("Session Matchmaking: pamater session is null.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): pamater session is null.");
                 return false;
             }
 
@@ -1205,13 +1205,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (sessionInterface == null)
             {
-                Debug.LogError("Session Matchmaking: can't get sessions interface.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): can't get sessions interface.");
                 return false;
             }
 
             if (!CurrentSessions.TryGetValue(session.Name, out Session currentSession))
             {
-                Debug.LogError("Session Matchmaking: can't modify session: no active session with specified name.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): can't modify session: no active session with specified name.");
                 return false;
             }
 
@@ -1222,30 +1222,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking: failed create session modification. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): failed create session modification. Error code: {result}");
                 return false;
             }
-
-            // BucketId
-            /*
-            if (session.BucketId != currentSession.BucketId)
-            {
-                SessionModificationSetBucketIdOptions bucketOptions = new SessionModificationSetBucketIdOptions();
-                bucketOptions.BucketId = session.BucketId;
-
-                result = sessionModificationHandle.SetBucketId(bucketOptions);
-
-                if (result != Result.Success)
-                {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to set bucket id. Error code: {0}", result);
-                    sessionModificationHandle.Release();
-                    return false;
-                }
-
-                //Update local cache
-                currentSession.BucketId = session.BucketId;
-            }
-            */
 
             // Max Players
             if (session.MaxPlayers != currentSession.MaxPlayers)
@@ -1257,7 +1236,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to set maxp layers. Error code:: {0}", result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): failed to set maxp layers. Error code: {result}");
                     sessionModificationHandle.Release();
                     return false;
                 }
@@ -1276,7 +1255,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to set permission level. Error code:: {0}", result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): failed to set permission level. Error code: {result}");
                     sessionModificationHandle.Release();
                     return false;
                 }
@@ -1295,7 +1274,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to set 'join in progress allowed' flag. Error code:: {0}", result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): failed to set 'join in progress allowed' flag. Error code: {result}");
                     sessionModificationHandle.Release();
                     return false;
                 }
@@ -1357,7 +1336,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 if (result != Result.Success)
                 {
-                    Debug.LogErrorFormat("Session Matchmaking: failed to set an attribute: {0}. Error code: {1}", nextAttribute.Key, result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(ModifySession)}): failed to set an attribute: {nextAttribute.Key}. Error code: {result}");
                     sessionModificationHandle.Release();
                     return false;
                 }
@@ -1422,7 +1401,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (CurrentSearch == null)
             {
-                Debug.LogError("Session Matchmaking (OnSearchResultsReceived): CurrentSearch is null");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSearchResultsReceived)}): CurrentSearch is null");
                 return;
             }
 
@@ -1430,7 +1409,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (searchHandle == null)
             {
-                Debug.LogError("Session Matchmaking (OnSearchResultsReceived): searchHandle is null");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSearchResultsReceived)}): searchHandle is null");
                 return;
             }
 
@@ -1538,7 +1517,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (userId?.IsValid() != true)
             {
-                Debug.LogError("Session Matchmaking (SetJoinInfo): Current player is invalid");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SetJoinInfo)}): Current player is invalid");
                 return;
             }
 
@@ -1552,12 +1531,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 if(onLoggingOut)
                 {
-                    Debug.LogWarning("EOSSessionsManager.SetJoininfo: Create presence modification during logOut, ignore.");
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SetJoinInfo)}): Create presence modification during logOut, ignore.");
                     return;
                 }
                 else
                 {
-                    Debug.LogErrorFormat("EOSSessionsManager.SetJoininfo: Create presence modification failed: {0}", result);
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SetJoinInfo)}): Create presence modification failed: {result}");
                     return;
                 }
             }
@@ -1577,7 +1556,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             result = presenceModification.SetJoinInfo(ref joinOptions);
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (SetJoinInfo): SetJoinInfo failed: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SetJoinInfo)}): SetJoinInfo failed: {result}");
                 return;
             }
 
@@ -1604,7 +1583,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
 
             AcknowledgeEventId(Result.UnexpectedError);
-            Debug.LogErrorFormat("Session Matchmaking (OnJoinGameAccepted): unable to parse location string: {0}", joinInfo);
+            Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnJoinGameAcceptedByJoinInfo)}): unable to parse location string: {joinInfo}");
         }
 
         private void OnJoinGameAcceptedByEventId(ulong uiEventId)
@@ -1618,14 +1597,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 JoinUiEvent = uiEventId;
                 AcknowledgeEventId(Result.UnexpectedError);
-                Debug.LogErrorFormat("Session Matchmaking (OnJoinGameAcceptedByEventId): unable to get details for event ID: {0}", uiEventId);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnJoinGameAcceptedByEventId)}): unable to get details for event ID: {uiEventId}");
             }
         }
 
         private void JoinPresenceSessionById(string sessionId)
         {
             JoinPresenceSessionId = sessionId;
-            Debug.LogFormat("Session Matchmaking (JoinPresenceSessionById): looking for session ID: {0}", JoinPresenceSessionId);
+            Log($"{nameof(EOSSessionsManager)} ({nameof(JoinPresenceSessionById)}): looking for session ID: {JoinPresenceSessionId}");
             SearchById(JoinPresenceSessionId);
         }
 
@@ -1656,21 +1635,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnUpdateSessionCompleteCallback(ref UpdateSessionCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnStartSessionCompleteCallback): data is null");
-            //    return;
-            //}
-
             if (data.ResultCode != Result.Success)
             {
                 OnSessionUpdateFinished(false, data.SessionName, data.SessionId);
-                Debug.LogErrorFormat("Session Matchmaking (OnUpdateSessionCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnUpdateSessionCompleteCallback)}): error code: {data.ResultCode}");
             }
             else
             {
                 OnSessionUpdateFinished(true, data.SessionName, data.SessionId);
-                Debug.Log("Session Matchmaking: game session updated successfully.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnUpdateSessionCompleteCallback)}): game session updated successfully.");
 
                 if (UIOnSessionModified.Count > 0)
                 {
@@ -1681,12 +1654,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnUpdateSessionCompleteCallback_ForCreate(ref UpdateSessionCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnUpdateSessionCompleteCallback_ForCreate): data is null");
-            //    return;
-            //}
-
             bool removeSession = true;
             bool success = (data.ResultCode == Result.Success);
 
@@ -1702,12 +1669,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
                 else
                 {
-                    Debug.LogError("Session Matchmaking (OnUpdateSessionCompleteCallback_ForCreate): player is null, can't register yourself in created session.");
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnUpdateSessionCompleteCallback_ForCreate)}): player is null, can't register yourself in created session.");
                 }
             }
             else
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnUpdateSessionCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnUpdateSessionCompleteCallback_ForCreate)}): error code: {data.ResultCode}");
             }
 
             if (UIOnSessionCreated.Count > 0)
@@ -1720,15 +1687,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnStartSessionCompleteCallBack(ref StartSessionCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnStartSessionCompleteCallback): data is null");
-            //    return;
-            //}
-
             if (data.ClientData == null)
             {
-                Debug.LogError("Session Matchmaking (OnStartSessionCompleteCallback): data.ClientData is null");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnStartSessionCompleteCallBack)}): data.ClientData is null");
                 return;
             }
 
@@ -1736,11 +1697,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnStartSessionCompleteCallback): session name: '{0}' error code: {1}", sessionName, data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnStartSessionCompleteCallBack)}): session name: '{sessionName}' error code: {data.ResultCode}");
                 return;
             }
 
-            Debug.LogFormat("Session Matchmaking(OnStartSessionCompleteCallback): Started session: {0}", sessionName);
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnStartSessionCompleteCallBack)}): Started session: {sessionName}");
 
             //OnSessionStarted(sessionName); // Needed for C# wrapper?
 
@@ -1753,21 +1714,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnEndSessionCompleteCallback(ref EndSessionCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnEndSessionCompleteCallback): data is null!");
-            //    return;
-            //}
-
             string sessionName = (string)data.ClientData;
 
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnEndSessionCompleteCallback): session name: '{0}' error code: {1}", sessionName, data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnEndSessionCompleteCallback)}): session name: '{sessionName}' error code: {data.ResultCode}");
                 return;
             }
 
-            Debug.LogFormat("Session Matchmaking(OnEndSessionCompleteCallback): Ended session: {0}", sessionName);
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnEndSessionCompleteCallback)}): Ended session: {sessionName}");
 
             //OnSessionEnded(sessionName); // Not used in C# wrapper
 
@@ -1780,21 +1735,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnDestroySessionCompleteCallback(ref DestroySessionCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnDestroySessionCompleteCallback): data is null!");
-            //    return;
-            //}
-
             if (data.ClientData == null)
             {
-                Debug.LogError("Session Matchmaking (OnDestroySessionCompleteCallback): data.ClientData is null!");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnDestroySessionCompleteCallback)}): data.ClientData is null!");
                 return;
             }
 
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnDestroySessionCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnDestroySessionCompleteCallback)}): error code: {data.ResultCode}");
                 return;
             }
 
@@ -1805,7 +1754,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (!TryGetSession(sessionName, out localSession) || localSession.ActiveSession == null)
             {
-                Debug.LogError($"Session Matchmaking (OnDestroySessionCompleteCallback): Could not find local Session and associated ActiveSession, so could not inform owner/members of destruction.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnDestroySessionCompleteCallback)}): Could not find local Session and associated ActiveSession, so could not inform owner/members of destruction.");
                 return;
             }
 
@@ -1816,7 +1765,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // If we can't get the Owner, we can't determine who should be messaged, or if we are the owner of this Session
             if (localCopyResult != Result.Success || !outActiveSessionInfo.HasValue || !outActiveSessionInfo.Value.SessionDetails.HasValue)
             {
-                Debug.LogError($"Session Matchmaking (OnDestroySessionCompleteCallback): Failed to copy local information for session {sessionName}, so could not inform owner/members of destruction. Result code {localCopyResult}");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnDestroySessionCompleteCallback)}): Failed to copy local information for session {sessionName}, so could not inform owner/members of destruction. Result code {localCopyResult}");
                 return;
             }
 
@@ -1839,15 +1788,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnRegisterCompleteCallback(ref RegisterPlayersCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnRegisterCompleteCallback): data is null!");
-            //    return;
-            //}
-
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnRegisterCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnRegisterCompleteCallback)}): error code: {data.ResultCode}");
                 return;
             }
 
@@ -1862,15 +1805,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnUnregisterCompleteCallback(ref UnregisterPlayersCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnUnregisterCompleteCallback): data is null!");
-            //    return;
-            //}
-
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnUnregisterCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnUnregisterCompleteCallback)}): error code: {data.ResultCode}");
                 return;
             }
 
@@ -1885,17 +1822,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnFindSessionsCompleteCallback(ref SessionSearchFindCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    AcknowledgeEventId(Result.UnexpectedError);
-            //    Debug.LogError("Session Matchmaking (OnFindSessionsCompleteCallback): data is null!");
-            //    return;
-            //}
-
             if (data.ResultCode != Result.Success)
             {
                 AcknowledgeEventId(data.ResultCode);
-                Debug.LogErrorFormat("Session Matchmaking (OnFindSessionsCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnFindSessionsCompleteCallback)}): error code: {data.ResultCode}");
                 return;
             }
 
@@ -1904,36 +1834,24 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void OnSendInviteCompleteCallback(ref SendInviteCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnSendInviteCompleteCallback): data is null!");
-            //    return;
-            //}
-
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnSendInviteCompleteCallback): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSendInviteCompleteCallback)}): error code: {data.ResultCode}");
                 return;
             }
 
-            Debug.Log("Session Matchmaking: invite to session sent successfully.");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnSendInviteCompleteCallback)}): invite to session sent successfully.");
         }
 
         public void OnSessionInviteReceivedListener(ref SessionInviteReceivedCallbackInfo data) // OnSessionInviteReceivedCallback
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnSessionInviteReceivedListener): data is null!");
-            //    return;
-            //}
-
-            Debug.LogFormat("Session Matchmaking: invite to session received. Invite id: {0}", data.InviteId);
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnSessionInviteReceivedListener)}): invite to session received. Invite id: {data.InviteId}");
 
             SessionDetails sessionDetails = MakeSessionHandleByInviteId(data.InviteId);
 
             if (sessionDetails == null)
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnSessionInviteReceivedListener): Could not copy session information for invite id {0}", data.InviteId);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSessionInviteReceivedListener)}): Could not copy session information for invite id {data.InviteId}");
                 return;
             }
 
@@ -1943,11 +1861,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 SetInviteSession(inviteSession, sessionDetails);
 
                 // Show invite popup
-                Debug.LogFormat("Session Matchmaking (OnSessionInviteReceivedListener): Invite received id = {0}", data.InviteId);
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnSessionInviteReceivedListener)}): Invite received id =  {data.InviteId}");
             }
             else
             {
-                Debug.LogErrorFormat("Session Matchmaking (OnSessionInviteReceivedListener): Could not copy session information for invite id {0}", data.InviteId);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSessionInviteReceivedListener)}): Could not copy session information for invite id {data.InviteId}");
             }
         }
 
@@ -1969,13 +1887,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void OnSessionInviteAcceptedListener(ref SessionInviteAcceptedCallbackInfo data) // OnSessionInviteAcceptedCallback
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnSessionInviteAcceptedListener): data is null!");
-            //    return;
-            //}
-
-            Debug.Log("Session Matchmaking: joined session successfully.");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnSessionInviteAcceptedListener)}): joined session successfully.");
 
             OnJoinSessionFinished(null);
         }
@@ -1983,22 +1895,16 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private void OnJoinSessionListener(ref JoinSessionCallbackInfo data) // OnJoinSessionCallback
         {
             var callback = data.ClientData as Action<Result>;
-            //if (data == null)
-            //{
-            //    AcknowledgeEventId(Result.UnexpectedError);
-            //    Debug.LogError("Session Matchmaking (OnJoinSessionListener): data is null!");
-            //    return;
-            //}
 
             if (data.ResultCode != Result.Success)
             {
                 AcknowledgeEventId(data.ResultCode);
-                Debug.LogErrorFormat("Session Matchmaking (OnJoinSessionListener): error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnJoinSessionListener)}): error code: {data.ResultCode}");
                 callback?.Invoke(data.ResultCode);
                 return;
             }
 
-            Debug.Log("Session Matchmaking: joined session successfully.");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnJoinSessionListener)}): joined session successfully.");
 
             // Add joined session to list of current sessions
             OnJoinSessionFinished(callback);
@@ -2008,43 +1914,27 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void OnJoinGameAcceptedListener(ref JoinGameAcceptedCallbackInfo data) // OnPresenceJoinGameAcceptedListener
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnJoinGameAcceptedListener): data is null!");
-            //    return;
-            //}
-
-            Debug.Log("Session Matchmaking: join game accepted successfully.");
+            Debug.Log($"{nameof(EOSSessionsManager)} ({nameof(OnJoinGameAcceptedListener)}): join game accepted successfully.");
 
             OnJoinGameAcceptedByJoinInfo(data.JoinInfo, data.UiEventId);
         }
 
         public void OnJoinSessionAcceptedListener(ref JoinSessionAcceptedCallbackInfo data) // OnSessionsJoinSessionAcceptedCallback
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnJoinSessionAcceptedListener): data is null!");
-            //    return;
-            //}
-
-            Debug.Log("Session Matchmaking: join game accepted successfully.");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnJoinSessionAcceptedListener)}): join game accepted successfully.");
 
             OnJoinGameAcceptedByEventId(data.UiEventId);
         }
 
         private static void OnSetPresenceCompleteCallback(ref SetPresenceCallbackInfo data)
         {
-            //if (data == null)
-            //{
-            //    Debug.LogError("Session Matchmaking (OnSetPresenceCallback): EOS_Presence_SetPresenceCallbackInfo is null");
-            //}
             if (data.ResultCode != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager.OnSetPresenceCallback: error code: {0}", data.ResultCode);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSetPresenceCompleteCallback)}): error code: {data.ResultCode}");
             }
             else
             {
-                Debug.Log("EOSSessionsManager.OnSetPresenceCallback: set presence successfully.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnSetPresenceCompleteCallback)}): set presence successfully.");
             }
         }
 
@@ -2057,7 +1947,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             else
             {
-                Debug.LogError("Session Matchmaking (AcceptLobbyInvite): CurrentInvite not found.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(AcceptLobbyInvite)}): CurrentInvite not found.");
             }
         }
 
@@ -2079,17 +1969,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // First ensure that we have this local session
             if (!TryGetSession(localSessionName, out Session localSession))
             {
-                Log($"EOSSessionsManager (RefreshSession): Asked to refresh a Session with {nameof(localSessionName)} \"{localSessionName}\", but could not find a local Session with that name. Unable to refresh.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(RefreshSession)}): Asked to refresh a Session with {nameof(localSessionName)} \"{localSessionName}\", but could not find a local Session with that name. Unable to refresh.");
                 return;
             }
 
             if (string.IsNullOrEmpty(localSession.Id))
             {
-                Log($"EOSSessionsManager (RefreshSession): Asked to refresh a Session with {nameof(localSessionName)} \"{localSessionName}\", but the found local Session did not have an {nameof(Session.Id)} assigned. Unable to refresh.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(RefreshSession)}): Asked to refresh a Session with {nameof(localSessionName)} \"{localSessionName}\", but the found local Session did not have an {nameof(Session.Id)} assigned. Unable to refresh.");
                 return;
             }
 
-            Log($"EOSSessionsManager (RefreshSession): Requested to refresh session with local name {localSessionName} and {nameof(Session.Id)} {localSession.Id}.");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(RefreshSession)}): Requested to refresh session with local name {localSessionName} and {nameof(Session.Id)} {localSession.Id}.");
 
             // Clear previous search
             P2PSessionRefreshSessionSearch.Release();
@@ -2103,7 +1993,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (RefreshSession): Failed create Session search. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(RefreshSession)}): Failed create Session search. Error code: {result}");
                 AcknowledgeEventId(result);
                 return;
             }
@@ -2117,7 +2007,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (RefreshSession): Failed to update Session search with Session ID. Error code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(RefreshSession)}): Failed to update Session search with Session ID. Error code: {result}");
                 AcknowledgeEventId(result);
                 return;
             }
@@ -2137,13 +2027,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (info.ClientData is not string localSessionName)
             {
-                Debug.LogError($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): When constructing the search, the local Session name should be included in the ClientData of the Find method. Without it, the Session that should be updated cannot be determined.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): When constructing the search, the local Session name should be included in the ClientData of the Find method. Without it, the Session that should be updated cannot be determined.");
                 return;
             }
 
             if (P2PSessionRefreshSessionSearch == null)
             {
-                Debug.LogError($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): {nameof(P2PSessionRefreshSessionSearch)} is null. This callback should not be run without this search being set.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): {nameof(P2PSessionRefreshSessionSearch)} is null. This callback should not be run without this search being set.");
                 return;
             }
 
@@ -2151,7 +2041,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (searchHandle == null)
             {
-                Debug.LogError("EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): searchHandle is null");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): searchHandle is null");
                 return;
             }
 
@@ -2160,13 +2050,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (numSearchResult == 0)
             {
-                Log($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): Search for refresh completed successfully, but found no sessions with the associated id.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): Search for refresh completed successfully, but found no sessions with the associated id.");
                 return;
             }
 
             if (numSearchResult > 1)
             {
-                Log($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): Search for refresh completed successfully, but somehow found multiple Sessions. Only the first Session in the list will be used.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): Search for refresh completed successfully, but somehow found multiple Sessions. Only the first Session in the list will be used.");
             }
 
 
@@ -2179,7 +2069,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success || sessionDetails == null)
             {
-                Debug.LogError($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): Failed to copy search results. Result code {result}.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): Failed to copy search results. Result code {result}.");
                 return;
             }
 
@@ -2188,18 +2078,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success || !sessionInfo.HasValue)
             {
-                Debug.LogError($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): Failed to copy information out of the Session handle. Result code {result}.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): Failed to copy information out of the Session handle. Result code {result}.");
                 return;
             }
 
             // Now that we have the back-end session information, update the existing session
             if (!TryGetSessionById(sessionInfo.Value.SessionId, out Session existingLocalSession))
             {
-                Log($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): Successfully queried Epic Online Services for Session, but was unable to find a local session with {nameof(Session.Id)} \"{sessionInfo.Value.SessionId}\".");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): Successfully queried Epic Online Services for Session, but was unable to find a local session with {nameof(Session.Id)} \"{sessionInfo.Value.SessionId}\".");
                 return;
             }
 
-            Log($"EOSSessionsManager (OnRefreshSessionFindSessionsCompleteCallback): Successfully queried Epic Online Services for Session. Attempting to update found local Session with {nameof(Session.Name)} \"{existingLocalSession.Name}\".");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(OnRefreshSessionFindSessionsCompleteCallback)}): Successfully queried Epic Online Services for Session. Attempting to update found local Session with {nameof(Session.Name)} \"{existingLocalSession.Name}\".");
             existingLocalSession.InitFromSessionInfo(sessionDetails, sessionInfo);
 
             UIOnSessionRefresh?.Invoke(existingLocalSession, sessionDetails);
@@ -2232,7 +2122,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (P2PSessionPeerRequestConnectionNotificationId == 0)
             {
-                Debug.Log("EOSSessionsManager (SubscribeToSessionMessageConnectionRequests): Failed to subscribe to P2P Messages, bad Notification Id was returned.");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(SubscribeToSessionMessageConnectionRequests)}): Failed to subscribe to P2P Messages, bad Notification Id was returned.");
             }
 
             AddNotifyPeerConnectionClosedOptions closedOptions = new AddNotifyPeerConnectionClosedOptions()
@@ -2283,7 +2173,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (data.SocketId?.SocketName != P2P_SESSION_STATUS_SOCKET_NAME)
             {
-                Debug.LogError($"EOSSessionsManager (OnIncomingSessionsConnectionRequest): This function should not be handling this message, its socket is not '{P2P_SESSION_STATUS_SOCKET_NAME}'. Socket name is '{(data.SocketId?.SocketName)}'.");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnIncomingSessionsConnectionRequest)}): This function should not be handling this message, its socket is not '{P2P_SESSION_STATUS_SOCKET_NAME}'. Socket name is '{(data.SocketId?.SocketName)}'.");
                 return;
             }
 
@@ -2303,11 +2193,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (OnIncomingSessionsConnectionRequest): Error while accepting connection, code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnIncomingSessionsConnectionRequest)}): Error while accepting connection, code: {result}");
             }
             else
             {
-                Log($"EOSSessionsManager (OnIncomingSessionsConnectionRequest): Successfully accepted connection from {options.RemoteUserId} on socket {P2P_SESSION_STATUS_SOCKET_NAME}");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnIncomingSessionsConnectionRequest)}): Successfully accepted connection from {options.RemoteUserId} on socket {P2P_SESSION_STATUS_SOCKET_NAME}");
             }
         }
 
@@ -2333,11 +2223,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (OnIncomingSessionsDisconnect): Error while closing connection, code: {0}", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnIncomingSessionsDisconnect)}): Error while closing connection, code: {result}");
             }
             else
             {
-                Log($"EOSSessionsManager (OnIncomingSessionsDisconnect): Successfully closed connection with {closeOptions.RemoteUserId} on socket {P2P_SESSION_STATUS_SOCKET_NAME}");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(OnIncomingSessionsDisconnect)}): Successfully closed connection with {closeOptions.RemoteUserId} on socket {P2P_SESSION_STATUS_SOCKET_NAME}");
             }
         }
         
@@ -2356,7 +2246,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (!TryGetSession(localSessionName, out localSession))
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionOwnerWithMessage): No local session with name \"{0}\" was found.", localSessionName);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionOwnerWithMessage)}): No local session with name \"{localSessionName}\" was found.");
                 return;
             }
 
@@ -2364,7 +2254,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (activeSession == null)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionOwnerWithMessage): Found local session with name \"{0}\", but there was no corresponding ActiveSession. An ActiveSession should be populated in InitActiveSession.", localSessionName);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionOwnerWithMessage)}): Found local session with name \"{localSessionName}\", but there was no corresponding ActiveSession. An ActiveSession should be populated in InitActiveSession.");
                 return;
             }
 
@@ -2376,13 +2266,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (activeSessionInfoCopyResult != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionOwnerWithMessage): Found local and active session with name \"{0}\", but failed to copy its info. Result code {1}", localSessionName, activeSessionInfoCopyResult);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionOwnerWithMessage)}): Found local and active session with name \"{localSessionName}\", but failed to copy its info. Result code {activeSessionInfoCopyResult}");
                 return;
             }
 
             if (!copiedInfo.Value.SessionDetails.HasValue)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionOwnerWithMessage): Found local and active session with name \"{0}\", but the SessionDetails in the object is null. Cannot determine session owner or session id.", localSessionName, activeSessionInfoCopyResult);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionOwnerWithMessage)}): Found local and active session with name \"{localSessionName}\", but the SessionDetails in the object is null. Cannot determine session owner or session id.");
                 return;
             }
 
@@ -2421,7 +2311,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (!TryGetSession(localSessionName, out localSession))
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionMembersToRefresh): No local session with name \"{0}\" was found.", localSessionName);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionMembers)}): No local session with name \"{localSessionName}\" was found.");
                 return;
             }
 
@@ -2429,7 +2319,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (activeSession == null)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionMembersToRefresh): Found local session with name \"{0}\", but there was no corresponding ActiveSession. An ActiveSession should be populated in InitActiveSession.", localSessionName);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionMembers)}): Found local session with name \"{localSessionName}\", but there was no corresponding ActiveSession. An ActiveSession should be populated in InitActiveSession.");
                 return;
             }
 
@@ -2441,13 +2331,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (activeSessionInfoCopyResult != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionMembersToRefresh): Found local and active session with name \"{0}\", but failed to copy its info. Result code {1}", localSessionName, activeSessionInfoCopyResult);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionMembers)}): Found local and active session with name \"{localSessionName}\", but failed to copy its info. Result code {activeSessionInfoCopyResult}.");
                 return;
             }
 
             if (!copiedInfo.Value.SessionDetails.HasValue)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (InformSessionMembersToRefresh): Found local and active session with name \"{0}\", but the SessionDetails in the object is null. Cannot determine session id.", localSessionName, activeSessionInfoCopyResult);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(InformSessionMembers)}): Found local and active session with name \"{localSessionName}\", but the SessionDetails in the object is null. Cannot determine session id.");
                 return;
             }
 
@@ -2461,7 +2351,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ActiveSessionGetRegisteredPlayerCountOptions countOptions = new ActiveSessionGetRegisteredPlayerCountOptions() { };
             uint playerCount = activeSession.GetRegisteredPlayerCount(ref countOptions);
 
-            Log($"EOSSessionsManager (InformSessionMembers): There are {playerCount} registered members in {localSession.Name}, informing users of {messageDetail} (excluding self)");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(InformSessionMembers)}): There are {playerCount} registered members in {localSession.Name}, informing users of {messageDetail} (excluding self)");
 
             string messageToSend = string.Format(P2P_INFORM_SESSION_MESSAGE_FORMAT, copiedInfo.Value.SessionDetails.Value.SessionId, EOSManager.Instance.GetProductUserId(), messageDetail);
             for (uint ii = 0; ii < playerCount; ii++)
@@ -2508,11 +2398,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (result != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (SendP2PMessage): Error while sending data, code: {0}.", result);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(SendP2PMessage)}): Error while sending data, code: {result}.");
             }
             else
             {
-                Log($"EOSSessionsManager (SendP2PMessage): Sending \"{message}\" to {userToSendTo}");
+                Log($"{nameof(EOSSessionsManager)} ({nameof(SendP2PMessage)}): Sending \"{message}\" to {userToSendTo}");
             }
         }
 
@@ -2545,7 +2435,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (nextPacketSizeResult != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (HandleReceivedP2PMessages): error while reading received packet data, code: {0}.", nextPacketSizeResult);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): error while reading received packet data, code: {nextPacketSizeResult}.");
                 return;
             }
 
@@ -2563,23 +2453,23 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (receivePacketResult != Result.Success)
             {
-                Debug.LogErrorFormat("EOSSessionsManager (HandleReceivedP2PMessages): error while reading received packet data, code: {0}.", nextPacketSizeResult);
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): error while reading received packet data, code: {nextPacketSizeResult}.");
                 return;
             }
 
             if (!peerId.IsValid())
             {
-                Debug.LogErrorFormat("EOSSessionsManager (HandleReceivedP2PMessages): ProductUserId peerId is not valid!");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): ProductUserId peerId is not valid!");
                 return;
             }
 
             string message = System.Text.Encoding.UTF8.GetString(data);
 
-            Log($"EOSSessionsManager (HandleReceivedP2PMessages): Received a message: {message}");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): Received a message: {message}");
 
             if (!message.StartsWith(P2P_INFORM_SESSION_MESSAGE_BASE))
             {
-                Debug.LogError($"EOSSessionsManager (HandleReceivedP2PMessages): This function is handling a received message that it wasn't intended to. Perhaps there's a socket or channel conflict? Message: {message}");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): This function is handling a received message that it wasn't intended to. Perhaps there's a socket or channel conflict? Message: {message}");
                 return;
             }
 
@@ -2588,7 +2478,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (regexMatchOfMessage.Groups.Count != 4)
             {
-                Debug.LogError($"EOSSessionsManager (HandleReceivedP2PMessages): Message received, but it didn't contain the expected three parts. Message: {message}");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): Message received, but it didn't contain the expected three parts. Message: {message}");
                 return;
             }
 
@@ -2596,11 +2486,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             string userId = regexMatchOfMessage.Groups[2].Value;
             string messageElement = regexMatchOfMessage.Groups[3].Value;
 
-            Log($"EOSSessionsManager (HandleReceivedP2PMessages): Message parts: [{nameof(sessionId)}: {sessionId}] [{nameof(userId)}: {userId}] [{nameof(messageElement)}: {messageElement}]");
+            Log($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): Message parts: [{nameof(sessionId)}: {sessionId}] [{nameof(userId)}: {userId}] [{nameof(messageElement)}: {messageElement}]");
 
             if (!TryGetSessionById(sessionId, out Session session))
             {
-                Debug.LogError($"EOSSessionsManager (HandleReceivedP2PMessages): Message received regarding sessionId {sessionId}, but no local sessions have that id. Message: {message}");
+                Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): Message received regarding sessionId {sessionId}, but no local sessions have that id. Message: {message}");
                 return;
             }
 
@@ -2621,7 +2511,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     DestroySession(session.Name);
                     break;
                 default:
-                    Debug.LogError($"EOSSessionsManager (HandleReceivedP2PMessages): Unrecognized message element, unclear what action to take. Message: {message}");
+                    Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(HandleReceivedP2PMessages)}): Unrecognized message element, unclear what action to take. Message: {message}");
                     break;
             }
         }

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -2618,7 +2618,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     RefreshSession(session.Name);
                     break;
                 case P2P_SESSION_OWNER_DESTROYED_SESSION_MESSAGE_ELEMENT:
-                    // TODO: This is where a user would leave a session because it was destroyed
+                    DestroySession(session.Name);
                     break;
                 default:
                     Debug.LogError($"EOSSessionsManager (HandleReceivedP2PMessages): Unrecognized message element, unclear what action to take. Message: {message}");

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -373,12 +373,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 UISessionEntry thisEntry = childTransform.GetComponent<UISessionEntry>();
 
-                if (thisEntry == null)
-                {
-                    continue;
-                }
-
-                if (thisEntry.RepresentedSession == null || thisEntry.RepresentedSession.Id != sessionId)
+                if (null == thisEntry || null == thisEntry.RepresentedSession || thisEntry.RepresentedSession.Id != sessionId)
                 {
                     continue;
                 }

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -79,6 +79,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             InviteFromVal.text = string.Empty;
 
             HideMenu();
+
+            GetEOSSessionsManager.UIOnSessionRefresh = OnSessionRefresh;
         }
 
         /*private void Start()
@@ -160,45 +162,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                     GameObject sessionUiObj = Instantiate(UISessionEntryPrefab, SessionContentParent.transform);
                     UISessionEntry uiEntry = sessionUiObj.GetComponent<UISessionEntry>();
+
                     if (uiEntry != null)
                     {
-                        uiEntry.NameTxt.text = sessionResult.Name;
-
-                        if (sessionResult.UpdateInProgress)
-                        {
-                            uiEntry.StatusTxt.text = "*Updating*";
-                        }
-                        else
-                        {
-                            uiEntry.StatusTxt.text = sessionResult.SessionState.ToString();
-                        }
-
-                        uiEntry.PlayersTxt.text = string.Format("{0}/{1}", sessionResult.NumConnections, sessionResult.MaxPlayers);
-                        uiEntry.JIPTxt.text = sessionResult.AllowJoinInProgress.ToString();
-                        uiEntry.PermissionTxt.text = sessionResult.PermissionLevel.ToString();
-                        uiEntry.InvitesTxt.text = sessionResult.InvitesAllowed.ToString();
-
-                        uiEntry.JoinOnClick = JoinButtonOnClick;
-                        uiEntry.JoinSessionDetails = kvp.Value;
-
-                        uiEntry.OnlyEnableSearchResultButtons();
-
-                        bool levelAttributeFound = false;
-                        foreach (SessionAttribute sessionAttr in sessionResult.Attributes)
-                        {
-                            if (sessionAttr.Key.Equals("Level", StringComparison.OrdinalIgnoreCase))
-                            {
-                                uiEntry.LevelTxt.text = sessionAttr.AsString;
-                                levelAttributeFound = true;
-                                break;
-                            }
-                        }
-
-                        if (!levelAttributeFound)
-                        {
-                            Debug.LogErrorFormat("UISessionsMatchmakingMenu: Attribute 'Level' not found for session '{0}'", sessionResult.Name);
-                            uiEntry.LevelTxt.text = "-NA-";
-                        }
+                        uiEntry.SetUIElementsFromSessionAndDetails(sessionResult, kvp.Value, this);
                     }
                 }
             }
@@ -239,46 +206,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                     GameObject sessionUiObj = Instantiate(UISessionEntryPrefab, SessionContentParent.transform);
                     UISessionEntry uiEntry = sessionUiObj.GetComponent<UISessionEntry>();
+
                     if (uiEntry != null)
                     {
-                        uiEntry.NameTxt.text = kvp.Key;
-
-                        if (session.UpdateInProgress)
-                        {
-                            uiEntry.StatusTxt.text = "*Updating*";
-                        }
-                        else
-                        {
-                            uiEntry.StatusTxt.text = session.SessionState.ToString();
-                        }
-                        uiEntry.EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState);
-
-                        uiEntry.PlayersTxt.text = string.Format("{0}/{1}", session.NumConnections, session.MaxPlayers);
-                        uiEntry.JIPTxt.text = session.AllowJoinInProgress.ToString();
-                        uiEntry.PermissionTxt.text = session.PermissionLevel.ToString();
-                        uiEntry.InvitesTxt.text = session.InvitesAllowed.ToString();
-
-                        uiEntry.StartOnClick = StartButtonOnClick;
-                        uiEntry.EndOnClick = EndButtonOnClick;
-                        uiEntry.ModifyOnClick = ModifyButtonOnClick;
-                        uiEntry.LeaveOnClick = LeaveButtonOnClick;
-
-                        bool levelAttributeFound = false;
-                        foreach (SessionAttribute sessionAttr in session.Attributes)
-                        {
-                            if (sessionAttr.Key.Equals("Level", StringComparison.OrdinalIgnoreCase))
-                            {
-                                uiEntry.LevelTxt.text = sessionAttr.AsString;
-                                levelAttributeFound = true;
-                                break;
-                            }
-                        }
-
-                        if (!levelAttributeFound)
-                        {
-                            Debug.LogErrorFormat("UISessionsMatchmakingMenu: Attribute 'Level' not found for session '{0}'", session.Name);
-                            uiEntry.LevelTxt.text = "-NA-";
-                        }
+                        uiEntry.SetUIElementsFromSession(session, this);
                     }
                 }
             }
@@ -311,7 +242,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         }
 
         //Search Result
-        private void JoinButtonOnClick(SessionDetails sessionHandle)
+        public void JoinButtonOnClick(SessionDetails sessionHandle)
         {
             GetEOSSessionsManager.JoinSession(sessionHandle, true, OnJoinSessionFinished); // Default Presence True
         }
@@ -421,6 +352,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             // Controller
             EventSystem.current.SetSelectedGameObject(UIFirstSelected);
+
+            EOSManager.Instance.SetLogLevel(Epic.OnlineServices.Logging.LogCategory.AllCategories, Epic.OnlineServices.Logging.LogLevel.Warning);
+            EOSManager.Instance.SetLogLevel(Epic.OnlineServices.Logging.LogCategory.Sessions, Epic.OnlineServices.Logging.LogLevel.Verbose);
         }
 
         public void HideMenu()
@@ -431,6 +365,46 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
 
             SessionsMatchmakingUIParent.gameObject.SetActive(false);
+        }
+
+        public bool TryGetExistingUISessionEntryById(string sessionId, out UISessionEntry entry)
+        {
+            foreach (Transform childTransform in SessionContentParent.transform)
+            {
+                UISessionEntry thisEntry = childTransform.GetComponent<UISessionEntry>();
+
+                if (thisEntry == null)
+                {
+                    continue;
+                }
+
+                if (thisEntry.RepresentedSession == null || thisEntry.RepresentedSession.Id != sessionId)
+                {
+                    continue;
+                }
+
+                entry = thisEntry;
+                return true;
+            }
+
+            entry = null;
+            return false;
+        }
+
+        /// <summary>
+        /// After a Session is successfully refreshed, this is run to update the UI with the new information about the local Session.
+        /// </summary>
+        /// <param name="session">Information about the Session from the EOS C# SDK.</param>
+        /// <param name="details">Additional information about the Session from the EOS C SDK.</param>
+        public void OnSessionRefresh(Session session, SessionDetails details)
+        {
+            if (!TryGetExistingUISessionEntryById(session.Id, out UISessionEntry uiEntry))
+            {
+                Debug.Log($"UISessionsMatchmakingMenu (OnSessionRefresh): Requested refresh of a Session with {nameof(Session.Id)} \"{session.Id}\", but did not have a UI Entry for that currently. Cannot refresh it.");
+                return;
+            }
+
+            uiEntry.SetUIElementsFromSessionAndDetails(session, details, this);
         }
     }
 }


### PR DESCRIPTION
The main feature of this pull request is the UI refresh. When a member has received an appropriate message to refresh their UI, then it will now search up the associated ID and update it in the UI by running a callback. Is this callback made in a way that is compliant and appropriate with our samples?

Additionally per a conversation with Paul, I've standardized all the logging in the function. I'm trying out a stylistic choice; logs look like this:

`Debug.LogError($"{nameof(EOSSessionsManager)} ({nameof(OnSearchResultsReceived)}): searchHandle is null");`

Using `nameof(CLASSNAME)` and `nameof(FUNCTIONNAME)` makes it crystal clear where the logs come from at a glance, and feels more coherent than just saying "Sessions Matchmaking" or other phrases that were in use.