### PR TITLE
feat: Add ability configure the plugin to not unload the EOS SDK on shutdown.

### DIFF
--- a/docs/c_sharp_defines.md
+++ b/docs/c_sharp_defines.md
@@ -7,4 +7,6 @@ If this is defined, the EOSManager will not unload on shutdown. This can allevia
 It is not the default because if it were, then any edits to the EOSConfig file would require a reboot of the Unity Editor. In the past, not unloading 
 the EOS SDK could also cause issues with state from the previous Unity run not being properly cleaned up.
 
+On macOS and Linux, this define is automatically enabled as on those platforms there is no reliable way to actually unload the dynamic / shared libraries.
+
 Unlike other defines, after defining this, one _must_ reboot the Unity editor.

--- a/docs/c_sharp_defines.md
+++ b/docs/c_sharp_defines.md
@@ -1,0 +1,10 @@
+## Overview
+This document lists the "public" conditional compilation directive defines ("Preprocessor" defines) that control different behavior of the Epic Online Services for Unity Plugin.
+
+## Defines
+### `EOS_DO_NOT_UNLOAD_SDK_ON_SHUTDOWN`
+If this is defined, the EOSManager will not unload on shutdown. This can alleviate issues where the Unity Editor hangs on second play.
+It is not the default because if it were, then any edits to the EOSConfig file would require a reboot of the Unity Editor. In the past, not unloading 
+the EOS SDK could also cause issues with state from the previous Unity run not being properly cleaned up.
+
+Unlike other defines, after defining this, one _must_ reboot the Unity editor.


### PR DESCRIPTION
# Overview
This feature is the result of work done to assist a plugin user that was experiencing hangs in the editor during play. In a sense, it is kind of a bug fix, but in order to fix that bug, and given that the bug shouldn't always be 'fixed', this issue is being resolved via a new 'feature'.

Enabling this define will work around issues where the Editor can hang during shutdown / startup while playing in the Unity editor. This workaround, while useful, also makes it necessary to reboot the editor if any EOS boot strap based configuration needs to be changed. It also carries with it the potential for "leaked" EOS State to carry over between play in editor runs.