### PR TITLE
Correct Window Initialization & Window Title

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/CheckDeploymentWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/CheckDeploymentWindow.cs
@@ -50,7 +50,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Check Deployment")]
         public static void ShowWindow()
         {
-            GetWindow<CheckDeploymentWindow>("Deployment Checker");
+            GetWindow<CheckDeploymentWindow>();
         }
 
         protected override void Setup()

--- a/Assets/Plugins/Source/Editor/EditorWindows/CheckDeploymentWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/CheckDeploymentWindow.cs
@@ -45,6 +45,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         private string currentPath;
         Vector2 scrollPosition;
 
+        public CheckDeploymentWindow() : base("Deployment Checker") { }
+
         [MenuItem("Tools/EOS Plugin/Check Deployment")]
         public static void ShowWindow()
         {

--- a/Assets/Plugins/Source/Editor/EditorWindows/CreatePackageWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/CreatePackageWindow.cs
@@ -75,7 +75,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Create Package")]
         public static void ShowWindow()
         {
-            GetWindow<CreatePackageWindow>("Create Package");
+            GetWindow<CreatePackageWindow>();
         }
 
         protected override async Task AsyncSetup()

--- a/Assets/Plugins/Source/Editor/EditorWindows/CreatePackageWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/CreatePackageWindow.cs
@@ -60,6 +60,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         
         private bool _operationInProgress;
 
+        public CreatePackageWindow() : base("Create Package") { }
+
         #region Progress Bar Stuff
         
         private float _actualProgress;

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSEditorWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSEditorWindow.cs
@@ -97,9 +97,18 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         /// </summary>
         private bool _initialized;
 
+        /// <summary>
+        /// Static reference to a mono font, used in a variety of editor
+        /// windows.
+        /// </summary>
         protected static Font MonoFont;
 
-        protected EOSEditorWindow(float minimumHeight = 50f, float minimumWidth = 50f,
+        /// <summary>
+        /// String value for the title of the window.
+        /// </summary>
+        protected string _windowTitle;
+
+        protected EOSEditorWindow(string windowTitle, float minimumHeight = 50f, float minimumWidth = 50f,
             string preferencesOverrideKey = null)
         {
             // Set the preferences key either to the full name of the deriving type, or the provided override value.
@@ -109,6 +118,9 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
             AbsoluteMinimumWindowHeight = minimumHeight;
             AbsoluteMinimumWindowWidth = minimumWidth;
+
+            _windowTitle = windowTitle;
+            titleContent = new GUIContent(windowTitle);
         }
 
         private void OnEnable()
@@ -218,14 +230,19 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         protected void SetIsEmbedded(bool? isEmbedded = null)
         {
             // if the window has already been marked as embedded, skip
-            if (_isEmbedded != null) return;
+            //if (_isEmbedded != null) return;
 
             _isEmbedded = isEmbedded;
-            if (isEmbedded == true)
+
+            if (_isEmbedded == null)
             {
-                _isPadded = false;
-                _autoResize = false;
+                return;
             }
+
+            Debug.Log($"IsEmbedded changed to: {_isEmbedded.Value}.");
+
+            _isPadded = !_isEmbedded.Value;
+            _autoResize = !_isEmbedded.Value;
         }
 
         /// <summary>
@@ -250,6 +267,10 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
                 // Begin the padded area
                 GUILayout.BeginArea(paddedArea);
             }
+
+            // Explicitly set the window title, because sometimes Unity will
+            // change it inexplicably to be the fully-qualified class name
+            titleContent = new GUIContent(_windowTitle);
 
             // Call the implemented method to render the window
             RenderWindow();

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
@@ -46,14 +46,14 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [SettingsProvider]
         public static SettingsProvider CreateSettingsProvider()
         {
-            var eosPluginEditorConfigEditor = CreateInstance<EOSPluginSettingsWindow>();
-            eosPluginEditorConfigEditor.SetIsEmbedded(true);
-            var provider = new SettingsProvider("Preferences/EOS Plugin Configuration", SettingsScope.User)
+            var pluginSettingsWindow = CreateInstance<EOSPluginSettingsWindow>();
+            pluginSettingsWindow.SetIsEmbedded(true);
+            var provider = new SettingsProvider($"Preferences/{pluginSettingsWindow.WindowTitle}", SettingsScope.User)
             {
-                label = "EOS Plugin Configuration",
+                label = pluginSettingsWindow.WindowTitle,
                 guiHandler = (searchContext) =>
                 {
-                    eosPluginEditorConfigEditor.OnGUI();
+                    pluginSettingsWindow.OnGUI();
                 }
             };
 
@@ -63,7 +63,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Plugin Configuration")]
         public static void ShowWindow()
         {
-            var window = GetWindow<EOSPluginSettingsWindow>("EOS Plugin Configuration");
+            var window = GetWindow<EOSPluginSettingsWindow>();
             window.SetIsEmbedded(false);
         }
 

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
@@ -39,10 +39,14 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     {
         private List<IConfigEditor> configEditors;
 
+        public EOSPluginSettingsWindow() : base("EOS Plugin Settings")
+        {
+        }
+
         [SettingsProvider]
         public static SettingsProvider CreateSettingsProvider()
         {
-            var eosPluginEditorConfigEditor = ScriptableObject.CreateInstance<EOSPluginSettingsWindow>();
+            var eosPluginEditorConfigEditor = CreateInstance<EOSPluginSettingsWindow>();
             eosPluginEditorConfigEditor.SetIsEmbedded(true);
             var provider = new SettingsProvider("Preferences/EOS Plugin Configuration", SettingsScope.User)
             {
@@ -59,7 +63,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Plugin Configuration")]
         public static void ShowWindow()
         {
-            GetWindow<EOSPluginSettingsWindow>("EOS Plugin Configuration");
+            var window = GetWindow<EOSPluginSettingsWindow>("EOS Plugin Configuration");
+            window.SetIsEmbedded(false);
         }
 
         public static bool IsAsset(string configFilepath)

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -39,7 +39,6 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     [Serializable]
     public class EOSSettingsWindow : EOSEditorWindow
     {
-        private const string WindowTitle = "EOS Configuration";
         private List<IConfigEditor> platformSpecificConfigEditors;
 
         private static readonly string ConfigDirectory = Path.Combine("Assets", "StreamingAssets", "EOS");
@@ -56,22 +55,30 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
         SteamConfig steamEOSConfigFile;
 
+        public EOSSettingsWindow() : base("EOS Configuration")
+        {
+        }
+
         [MenuItem("Tools/EOS Plugin/EOS Configuration")]
         public static void ShowWindow()
         {
-            GetWindow<EOSSettingsWindow>(WindowTitle);
+            Debug.Log("Window created via the menu.");
+            var window = GetWindow<EOSSettingsWindow>("EOS Configuration", true);
+            
+            window.SetIsEmbedded(false);
         }
 
         [SettingsProvider]
         public static SettingsProvider CreateProjectSettingsProvider()
         {
+            Debug.Log("Window created via settings provider");
             var eosPluginEditorConfigEditor = CreateInstance<EOSSettingsWindow>();
             string[] keywords = {"Epic", "EOS", "Online", "Services", "PlayEveryWare"};
             // mark the editor window as being embedded, so it skips auto formatting stuff.
             eosPluginEditorConfigEditor.SetIsEmbedded(true);
-            var provider = new SettingsProvider($"Preferences/{WindowTitle}", SettingsScope.Project)
+            var provider = new SettingsProvider($"Preferences/EOS Configuration", SettingsScope.Project)
             {
-                label = WindowTitle,
+                label = "EOS Configuration",
                 keywords = keywords,
                 guiHandler = searchContext =>
                 {

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -62,27 +62,24 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/EOS Configuration")]
         public static void ShowWindow()
         {
-            Debug.Log("Window created via the menu.");
-            var window = GetWindow<EOSSettingsWindow>("EOS Configuration", true);
-            
+            var window = GetWindow<EOSSettingsWindow>();
             window.SetIsEmbedded(false);
         }
 
         [SettingsProvider]
         public static SettingsProvider CreateProjectSettingsProvider()
         {
-            Debug.Log("Window created via settings provider");
-            var eosPluginEditorConfigEditor = CreateInstance<EOSSettingsWindow>();
+            var settingsWindow = CreateInstance<EOSSettingsWindow>();
             string[] keywords = {"Epic", "EOS", "Online", "Services", "PlayEveryWare"};
             // mark the editor window as being embedded, so it skips auto formatting stuff.
-            eosPluginEditorConfigEditor.SetIsEmbedded(true);
-            var provider = new SettingsProvider($"Preferences/EOS Configuration", SettingsScope.Project)
+            settingsWindow.SetIsEmbedded(true);
+            var provider = new SettingsProvider($"Preferences/{settingsWindow.WindowTitle}", SettingsScope.Project)
             {
-                label = "EOS Configuration",
+                label = settingsWindow.WindowTitle,
                 keywords = keywords,
                 guiHandler = searchContext =>
                 {
-                    eosPluginEditorConfigEditor.OnGUI();
+                    settingsWindow.OnGUI();
                 }
             };
 

--- a/Assets/Plugins/Source/Editor/EditorWindows/InstallEOSZipWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/InstallEOSZipWindow.cs
@@ -37,7 +37,6 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     public class InstallEOSZipWindow : EOSEditorWindow
     {
         private const string PlatformImportInfoListFileName = "eos_platform_import_info_list.json";
-
         public InstallEOSZipWindow() : base("Install EOS Zip") { }
 
         [Serializable]
@@ -70,7 +69,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Install EOS zip")]
         public static void ShowWindow()
         {
-            GetWindow<InstallEOSZipWindow>("Install EOS Zip");
+            GetWindow<InstallEOSZipWindow>();
         }
 
         static public void UnzipEntry(ZipArchiveEntry zipEntry, string pathName)

--- a/Assets/Plugins/Source/Editor/EditorWindows/InstallEOSZipWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/InstallEOSZipWindow.cs
@@ -38,6 +38,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     {
         private const string PlatformImportInfoListFileName = "eos_platform_import_info_list.json";
 
+        public InstallEOSZipWindow() : base("Install EOS Zip") { }
+
         [Serializable]
         private class PlatformImportInfo
         {

--- a/Assets/Plugins/Source/Editor/EditorWindows/LogLevelWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/LogLevelWindow.cs
@@ -46,7 +46,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Log Level Configuration")]
         public static void ShowWindow()
         {
-            GetWindow<LogLevelWindow>("Log Level Configuration");
+            GetWindow<LogLevelWindow>();
         }
         protected override void Setup()
         {

--- a/Assets/Plugins/Source/Editor/EditorWindows/LogLevelWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/LogLevelWindow.cs
@@ -39,10 +39,14 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         int selectedCategoryIndex = 0;
         bool showAllCategories = false;
 
+        public LogLevelWindow() : base("Log Level Configuration")
+        {
+        }
+
         [MenuItem("Tools/EOS Plugin/Log Level Configuration")]
         public static void ShowWindow()
         {
-            GetWindow<LogLevelWindow>("Log Level");
+            GetWindow<LogLevelWindow>("Log Level Configuration");
         }
         protected override void Setup()
         {

--- a/Assets/Plugins/Source/Editor/EditorWindows/PluginVersionWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/PluginVersionWindow.cs
@@ -39,6 +39,10 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         string eos_library_version = "Not found";
         string eos_plugin_version = "Not found";
 
+        public PluginVersionWindow() : base("EOS Version Information")
+        {
+        }
+
         /// <summary>
         /// Unity Editor tool to display plug-in version information.
         /// </summary>

--- a/Assets/Plugins/Source/Editor/EditorWindows/PluginVersionWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/PluginVersionWindow.cs
@@ -57,7 +57,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         [MenuItem("Tools/EOS Plugin/Version", false, 100)]
         public static void ShowWindow()
         {
-            GetWindow<PluginVersionWindow>("EOS Version Information");
+            GetWindow<PluginVersionWindow>();
         }
 
         public string GetRepositoryRoot()


### PR DESCRIPTION
Because various `EditorWindow` classes we implement provide a means of interacting with the interface via Unity's `SettingsProvider` concept, and because `EditorWindow` classes are serialized and re-used behind the scenes, it is possible that the rendering will get confused and the settings for having the window embedded will be used when the window is in fact on it's own.

This results in a variety of things. It can cause the automatic padding and size setting stuff to function incorrectly, but most notably it can result in the window title being set to the fully-qualified class name instead of the string value that is specified.

These changes fix both issues with minimal impact to the codebase.