### PR TITLE
refactor(sessions): Session State Management Mirroring

### DIFF
--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -925,7 +925,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// Even before getting a response for creating the Session, this function sets local information about the Session for use in displaying UI in <see cref="CurrentSessions"/>.
         /// This should only be called to create a Session on Epic Online Services, not to create a local copy of a joined Session.
         /// </summary>
-        /// <param name="Session">An object containing information about the Session to create.
+        /// <param name="session">An object containing information about the Session to create.
         /// Some values are expected to be set by the caller, and some values are updated when the Session is actually created.
         /// The following values should be set:
         /// - <see cref="Session.MaxPlayers"/>
@@ -2352,15 +2352,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>
         /// Saturates an attempt to modify a Session that this user is the Owner of.
         /// Assumes there is a local Session present in <see cref="CurrentSessions"/>,
-        /// which is a different object than the <paramref name="Session"/>.
+        /// which is a different object than the <paramref name="session"/>.
         /// By looking up the Session in the EOS SDK with a matching local Session name,
-        /// and comparing it to the changes in <paramref name="Session"/>,
+        /// and comparing it to the changes in <paramref name="session"/>,
         /// this calls to <see cref="SessionsInterface.UpdateSession(ref UpdateSessionOptions, object, OnUpdateSessionCallback)"/>.
         /// 
-        /// TODO: The <paramref name="Session"/> argument should be replaced with another type of object to indicate its purpose.
+        /// TODO: The <paramref name="session"/> argument should be replaced with another type of object to indicate its purpose.
         /// It is unclear and easily problematic that it looks like the same object can be used to modify the Session.
         /// </summary>
-        /// <param name="Session">
+        /// <param name="session">
         /// A new Session object that can be used to compare to the local Session to determine changes.
         /// Should be a different object than the existing local Session.
         /// </param>

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -331,6 +331,43 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             return base.GetHashCode();
         }
+
+        /// <summary>
+        /// Determines if the local user owns this Session.
+        /// This information can be used to gate some Session modifying actions.
+        /// </summary>
+        /// <returns>
+        /// True if the Session is owned by the local user.
+        /// False if either it was determined that the user doesn't own this Session,
+        /// or if the operation to query that information failed.
+        /// </returns>
+        public bool IsLocalUserOwnerOfSession()
+        {
+            ProductUserId localUserId = EOSManager.Instance?.GetProductUserId();
+
+            // If we can't even get the local user's id, that state suggests they shouldn't be owning any Sessions
+            if (localUserId == null)
+            {
+                return false;
+            }
+
+            // If the ActiveSession isn't set, then this user isn't a part of the Session
+            // Can't possibly own it
+            if (ActiveSession == null)
+            {
+                return false;
+            }
+
+            ActiveSessionCopyInfoOptions options = new ActiveSessionCopyInfoOptions() { };
+            Result copyResult = ActiveSession.CopyInfo(ref options, out ActiveSessionInfo? sessionInfo);
+
+            if (copyResult != Result.Success || !sessionInfo.HasValue || !sessionInfo.Value.SessionDetails.HasValue)
+            {
+                return false;
+            }
+
+            return sessionInfo.Value.SessionDetails.Value.OwnerUserId.Equals(localUserId);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -561,7 +561,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>
         /// Messages with this as the {2} parameter of <see cref="P2P_INFORM_SESSION_MESSAGE_FORMAT"/> indicate that a user should re-acquire and refresh Session information.
         /// Note that not every element of the Session can be re-acquired this way.
-        /// It is necessary to mirror <see cref="RegisterPlayer(string, ProductUserId)"/>, <see cref="UnRegisterPlayer(string, ProductUserId)"/>,
+        /// It is necessary to mirror <see cref="RegisterPlayer(string, ProductUserId)"/>, <see cref="UnregisterPlayer(string, ProductUserId)"/>,
         /// <see cref="StartSession(string)"/>, and <see cref="EndSession(string)"/> using their associated messages.
         /// </summary>
         private const string P2P_REFRESH_SESSION_MESSAGE_ELEMENT = "REFRESH";
@@ -2291,7 +2291,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <param name="userIdToUnRegister">
         /// The ProductUserId of the user to unregister.
         /// </param>
-        public void UnRegisterPlayer(string sessionName, ProductUserId userIdToUnRegister)
+        public void UnregisterPlayer(string sessionName, ProductUserId userIdToUnRegister)
         {
             UnregisterPlayersOptions unregisterOptions = new UnregisterPlayersOptions();
             unregisterOptions.SessionName = sessionName;
@@ -2315,7 +2315,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// The ProductUserId of the users to unregister.
         /// If this array is empty, the function exits without performing an operation.
         /// </param>
-        public void UnRegisterPlayers(string sessionName, ProductUserId[] userIdsToUnRegister)
+        public void UnregisterPlayers(string sessionName, ProductUserId[] userIdsToUnRegister)
         {
             if (userIdsToUnRegister.Length == 0)
             {
@@ -3266,7 +3266,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                         InformUserOfCurrentSessionStatus(session.Name, messagingUserId);
                         break;
                     case P2P_LEAVING_SESSION_MESSAGE_ELEMENT:
-                        UnRegisterPlayer(session.Name, messagingUserId);
+                        UnregisterPlayer(session.Name, messagingUserId);
                         break;
                     case P2P_REFRESH_SESSION_MESSAGE_ELEMENT:
                         RefreshSession(session.Name);
@@ -3414,7 +3414,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     usersToUnRegister.Add(curExistingUser);
                 }
             }
-            UnRegisterPlayers(session.Name, usersToRegister.ToArray());
+            UnregisterPlayers(session.Name, usersToRegister.ToArray());
         }
 
         #region Notifications

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionEntry.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionEntry.cs
@@ -100,12 +100,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             else
             {
+                // Names are only present for Sessions that are locally joined, so at this point it can be enabled
                 NameTxt.transform.gameObject.SetActive(true);
 
+                // If this local user owns the Session, then they might be able to run these state modifying actions
+                // Otherwise, the user shouldn't be able to use any of these buttons, so disable them
                 if (isOwner)
                 {
+                    // The Session can only be started if it is either Pending or Ended, and isn't locally processing an update
                     StartButton.interactable = !updating && (state == OnlineSessionState.Pending || state == OnlineSessionState.Ended);
+
+                    // InProgress is the only state that flows to Ending
                     EndButton.interactable = !updating && state == OnlineSessionState.InProgress;
+
+                    // The Session can be modified at any state, as long as it isn't in the middle of processing an update
                     ModifyButton.interactable = !updating;
                 }
                 else
@@ -115,6 +123,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     ModifyButton.interactable = false;
                 }
 
+                // The Session is already joined, so it can't be joined currently
+                // but the local user can always leave a joined Session
                 JoinButton.transform.gameObject.SetActive(false);
                 LeaveButton.interactable = true;
             }
@@ -208,7 +218,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 StatusTxt.text = session.SessionState.ToString();
             }
 
-            EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState, session.IsLocalUserOwnerOfSession);
+            EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState, session.DoesLocalUserOwnSession());
 
             PlayersTxt.text = string.Format("{0}/{1}", session.NumConnections, session.MaxPlayers);
             JIPTxt.text = session.AllowJoinInProgress.ToString();

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionEntry.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionEntry.cs
@@ -114,7 +114,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     EndButton.interactable = false;
                     ModifyButton.interactable = false;
                 }
-                
+
+                JoinButton.transform.gameObject.SetActive(false);
                 LeaveButton.interactable = true;
             }
         }
@@ -207,7 +208,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 StatusTxt.text = session.SessionState.ToString();
             }
 
-            EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState, session.IsLocalUserOwnerOfSession());
+            EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState, session.IsLocalUserOwnerOfSession);
 
             PlayersTxt.text = string.Format("{0}/{1}", session.NumConnections, session.MaxPlayers);
             JIPTxt.text = session.AllowJoinInProgress.ToString();

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionEntry.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionEntry.cs
@@ -72,7 +72,25 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             LeaveButton.interactable = false;
         }
 
-        public void EnableButtonsBySessionState(bool updating, OnlineSessionState state)
+        /// <summary>
+        /// Sets the UI buttons interactivity based on the parameters provided.
+        /// </summary>
+        /// <param name="updating">
+        /// Provide "true" if the Session represented by this object is mid-update.
+        /// When it's done, call this function again providing "false".
+        /// This helps with trying to perform operations before a Session is finished being created or joined.
+        /// </param>
+        /// <param name="state">
+        /// Status indicating the state of this Session.
+        /// <see cref="OnlineSessionState.NoSession"/> indicates that there is no local Session for this object yet,
+        /// suggesting that it hasn't been joined.
+        /// Otherwise indicates things such as <see cref="OnlineSessionState.InProgress"/> for setting contextual buttons.
+        /// </param>
+        /// <param name="isOwner">
+        /// Is this local user the owner of the represented Session?
+        /// If false, state-affecting buttons are disabled.
+        /// </param>
+        public void EnableButtonsBySessionState(bool updating, OnlineSessionState state, bool isOwner)
         {
             // If we aren't in this Session, then only show the buttons for joining
             // If we are in this Session, enable those buttons
@@ -84,13 +102,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 NameTxt.transform.gameObject.SetActive(true);
 
-                StartButton.interactable = !updating && (state == OnlineSessionState.Pending || state == OnlineSessionState.Ended);
-                EndButton.interactable = !updating && state == OnlineSessionState.InProgress;
+                if (isOwner)
+                {
+                    StartButton.interactable = !updating && (state == OnlineSessionState.Pending || state == OnlineSessionState.Ended);
+                    EndButton.interactable = !updating && state == OnlineSessionState.InProgress;
+                    ModifyButton.interactable = !updating;
+                }
+                else
+                {
+                    StartButton.interactable = false;
+                    EndButton.interactable = false;
+                    ModifyButton.interactable = false;
+                }
+                
                 LeaveButton.interactable = true;
-
-                // TODO: ModifyButton should only be available for users with permission to use it
-                // We should query that information and then set this intelligently
-                ModifyButton.interactable = true;
             }
         }
 
@@ -182,7 +207,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 StatusTxt.text = session.SessionState.ToString();
             }
 
-            EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState);
+            EnableButtonsBySessionState(session.UpdateInProgress, session.SessionState, session.IsLocalUserOwnerOfSession());
 
             PlayersTxt.text = string.Format("{0}/{1}", session.NumConnections, session.MaxPlayers);
             JIPTxt.text = session.AllowJoinInProgress.ToString();

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -399,6 +399,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 return;
             }
 
+            Debug.Log($"{nameof(UISessionsMatchmakingMenu)} ({nameof(OnSessionRefresh)} Instructed to refresh Session with {nameof(Session.Id)} \"{session.Id}\". Found local UI element. Refreshing now.");
+
             uiEntry.SetUIElementsFromSessionAndDetails(session, details, this);
         }
     }


### PR DESCRIPTION
- Users that are not the Owner of a Session cannot Start, Stop, or Modify a Session. The UI for those operations have been hidden in the sample.
- When a User joins a Session, the Owner sends them a message indicating the current Start/End status of the Session
- When the Owner Starts/Ends a Session, inform all users so they can mirror the status
- When the Owner Registers/UnRegisters a user, all users are sent the list of Registered users, which are then locally Registered/UnRegistered
- I capitalized "Session" and "Owner" more consistently

This has been tested with three accounts in a public Session.