### PR TITLE
refactor(sessions): Adding Friends UI Tab to Sessions

### DIFF
--- a/Assets/Scenes/StandardSamples/SessionsAndMatchmaking.unity
+++ b/Assets/Scenes/StandardSamples/SessionsAndMatchmaking.unity
@@ -2312,7 +2312,7 @@ PrefabInstance:
     - target: {fileID: 3537750869854110253, guid: 11e4648022445f041b4c867ff8f3fd94,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3537750869854110254, guid: 11e4648022445f041b4c867ff8f3fd94,
         type: 3}
@@ -2954,6 +2954,21 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6814204665588104691, guid: 11e4648022445f041b4c867ff8f3fd94,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6814204665588104691, guid: 11e4648022445f041b4c867ff8f3fd94,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6814204665588104691, guid: 11e4648022445f041b4c867ff8f3fd94,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7110259970179194835, guid: 11e4648022445f041b4c867ff8f3fd94,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -3007,6 +3022,16 @@ PrefabInstance:
     - target: {fileID: 7283960144241381287, guid: 11e4648022445f041b4c867ff8f3fd94,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7521768095330256758, guid: 11e4648022445f041b4c867ff8f3fd94,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7521768095330256758, guid: 11e4648022445f041b4c867ff8f3fd94,
+        type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7908594211623330956, guid: 11e4648022445f041b4c867ff8f3fd94,
@@ -3419,6 +3444,180 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 45, y: 130, z: 90}
+--- !u!1001 &2059973813
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 722263472}
+    m_Modifications:
+    - target: {fileID: 1520068606371974356, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: CollapseOnStart
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101689, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_Name
+      value: friendsTabUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520068607348101694, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920898928547186, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920898928547186, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920898928547186, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920899026651830, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920899026651830, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920899777240475, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920899777240475, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920899777240475, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920900252865325, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211920900252865325, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6a62934fd9ee35d49bf4f84f329793d1, type: 3}
 --- !u!1001 &2111228585
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/StandardSamples/SessionsAndMatchmaking.unity
+++ b/Assets/Scenes/StandardSamples/SessionsAndMatchmaking.unity
@@ -207,6 +207,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 20.146, y: 195, z: 0}
+--- !u!114 &394508048 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1104738135800004544, guid: 838075797a3529e4380b9e9999798bb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 411392508}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 140a84e5e80be524fb872eafefdf960f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &411392508
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3456,6 +3468,11 @@ PrefabInstance:
       propertyPath: CollapseOnStart
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1520068606371974356, guid: 6a62934fd9ee35d49bf4f84f329793d1,
+        type: 3}
+      propertyPath: UIFriendInteractionSource
+      value: 
+      objectReference: {fileID: 394508048}
     - target: {fileID: 1520068607348101689, guid: 6a62934fd9ee35d49bf4f84f329793d1,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/EOSFriendsManager.cs
+++ b/Assets/Scripts/EOSFriendsManager.cs
@@ -436,20 +436,23 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 TargetUserId = data.TargetUserId
             };
 
-            Result joinInfoResult = PresenceHandle.GetJoinInfo(ref joinInfoOptions, out Utf8String joinInfo);
-            if (joinInfoResult != Result.Success)
-            {
-                joinInfo = null;
-            }
-
+            // If the user has a Presence JoinInfo, set that in this incoming Presence.
+            // NotFound just implies the user does not have an active joinable activity, it is not an error.
             PresenceInfo presenceInfo = new PresenceInfo()
             {
                 Application = presence?.ProductId,
                 Platform = presence?.Platform,
                 Status = (Status)(presence?.Status),
                 RichText = presence?.RichText,
-                JoinInfo = joinInfo
+                JoinInfo = null // Default to null until the value is determined
             };
+
+            Result joinInfoResult = PresenceHandle.GetJoinInfo(ref joinInfoOptions, out Utf8String joinInfo);
+
+            if (joinInfoResult == Result.Success)
+            {
+                presenceInfo.JoinInfo = joinInfo;
+            }
 
             if(CachedFriends.TryGetValue(data.TargetUserId, out FriendData friendData))
             {

--- a/Assets/Scripts/EOSFriendsManager.cs
+++ b/Assets/Scripts/EOSFriendsManager.cs
@@ -437,7 +437,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             };
 
             // If the user has a Presence JoinInfo, set that in this incoming Presence.
-            // NotFound just implies the user does not have an active joinable activity, it is not an error.
             PresenceInfo presenceInfo = new PresenceInfo()
             {
                 Application = presence?.ProductId,
@@ -449,6 +448,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             Result joinInfoResult = PresenceHandle.GetJoinInfo(ref joinInfoOptions, out Utf8String joinInfo);
 
+            // If the result of getting join info is "Result.NotFound", that implies the user does not have an active joinable activity.
+            // Only on a Success can the JoinInfo be used, but otherwise the JoinInfo is to be ignored.
             if (joinInfoResult == Result.Success)
             {
                 presenceInfo.JoinInfo = joinInfo;

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -37,6 +37,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
     using Epic.OnlineServices.P2P;
     using System.Text.RegularExpressions;
     using System.Text;
+    using UnityEngine.Events;
 
     /// <summary>
     /// Class represents a Session search and search results
@@ -488,6 +489,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         Queue<Action> UIOnJoinSession;
         Queue<Action> UIOnLeaveSession;
         Queue<Action> UIOnSessionSearchCompleted;
+
+        /// <summary>
+        /// Event to inform UI that it should refresh displayed Friends and Joining/Inviting buttons.
+        /// </summary>
+        public UnityEvent UIOnPresenceAffectingChange = new UnityEvent();
 
         public const ulong INVALID_NOTIFICATIONID = 0;
 
@@ -1194,6 +1200,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <returns>Returns true if there is a local Session with Presence enabled.</returns>
         public bool HasPresenceSession()
         {
+            // Can't have a presence session if we're not even logged in
+            if (!IsUserLoggedIn)
+            {
+                KnownPresenceSessionId = string.Empty;
+                return false;
+            }
+
             if (KnownPresenceSessionId.Length > 0)
             {
                 if (CurrentSessions.ContainsKey(KnownPresenceSessionId)) // TODO: validate
@@ -1716,6 +1729,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             existingLocalSession.InitFromSessionInfo(sessionDetails, sessionInfo);
 
             UIOnSessionRefresh?.Invoke(existingLocalSession, sessionDetails);
+            UIOnPresenceAffectingChange?.Invoke();
         }
 
         #endregion
@@ -1812,6 +1826,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     CurrentSessions.Remove(sessionName);
                 }
             }
+
+            UIOnPresenceAffectingChange?.Invoke();
         }
 
         /// <summary>
@@ -1937,6 +1953,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                         CurrentSessions[session.Name] = session;
                     }
 
+                    UIOnPresenceAffectingChange?.Invoke();
                     InformSessionOwnerWithMessage(session.Name, P2P_JOINING_SESSION_MESSAGE_ELEMENT);
                 }
                 callback?.Invoke(result);
@@ -2638,6 +2655,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
 
                 InformSessionMembers(sessionName, P2P_REFRESH_SESSION_MESSAGE_ELEMENT);
+                UIOnPresenceAffectingChange?.Invoke();
             }
         }
 

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -493,7 +493,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>
         /// Event to inform UI that it should refresh displayed Friends and Joining/Inviting buttons.
         /// </summary>
-        public UnityEvent UIOnPresenceAffectingChange = new UnityEvent();
+        public UnityEvent OnPresenceChange = new UnityEvent();
 
         public const ulong INVALID_NOTIFICATIONID = 0;
 
@@ -1729,7 +1729,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             existingLocalSession.InitFromSessionInfo(sessionDetails, sessionInfo);
 
             UIOnSessionRefresh?.Invoke(existingLocalSession, sessionDetails);
-            UIOnPresenceAffectingChange?.Invoke();
+            OnPresenceChange?.Invoke();
         }
 
         #endregion
@@ -1827,7 +1827,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
             }
 
-            UIOnPresenceAffectingChange?.Invoke();
+            OnPresenceChange?.Invoke();
         }
 
         /// <summary>
@@ -1953,7 +1953,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                         CurrentSessions[session.Name] = session;
                     }
 
-                    UIOnPresenceAffectingChange?.Invoke();
+                    OnPresenceChange?.Invoke();
                     InformSessionOwnerWithMessage(session.Name, P2P_JOINING_SESSION_MESSAGE_ELEMENT);
                 }
                 callback?.Invoke(result);
@@ -2655,7 +2655,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
 
                 InformSessionMembers(sessionName, P2P_REFRESH_SESSION_MESSAGE_ELEMENT);
-                UIOnPresenceAffectingChange?.Invoke();
+                OnPresenceChange?.Invoke();
             }
         }
 

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -1301,6 +1301,38 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return null;
         }
 
+        /// <summary>
+        /// Attempts to get a locally joined Presence enabled Session.
+        /// Users can only be in one Presence enabled Session at a time.
+        /// The current Id is stored in <see cref="KnownPresenceSessionId"/>.
+        /// </summary>
+        /// <param name="foundSession">Out parameter with the Session, if found.</param>
+        /// <returns>True if a Presence Session is found. False otherwise.</returns>
+        public bool TryGetPresenceSession(out Session foundSession)
+        {
+            foundSession = null;
+
+            // This function will determine which Session is the active Presence Session
+            if (!HasPresenceSession())
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(KnownPresenceSessionId))
+            {
+                // No known presence session, so exit
+                return false;
+            }
+
+            if (TryGetSessionById(KnownPresenceSessionId, out foundSession))
+            {
+                return true;
+            }
+
+            // If this has been reached, then none was found
+            return false;
+        }
+
         #endregion
 
         #region Online Session Lookup and Search

--- a/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
+++ b/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
@@ -64,7 +64,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         private EOSTransportManager transportManager = null;
         private bool isHost = false;
         private bool isClient = false;
-        private bool uiDirty = false;
         private bool controllingCharacter = false;
 
         private ulong joinGameAcceptedNotifyHandle = 0;
@@ -278,16 +277,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
         }
 
-        public override bool IsDirty()
-        {
-            return uiDirty;
-        }
-
-        public override void ResetDirtyFlag()
-        {
-            uiDirty = false;
-        }
-
         public void StartHostOnClick()
         {
             if (isHost)
@@ -301,7 +290,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 isHost = true;
                 SetSessionUIActive(true);
                 SetJoinInfo(EOSManager.Instance.GetProductUserId());
-                uiDirty = true;
+                MarkFriendsUIDirty();
             }
             else
             {
@@ -329,7 +318,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             isClient = false;
             SetSessionUIActive(false);
             EOSSessionsManager.SetJoinInfo(null);
-            uiDirty = true;
+            MarkFriendsUIDirty();
         }
 
         public void TakeControlOnClick()
@@ -395,7 +384,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             isClient = false;
             SetSessionUIActive(false);
             EOSSessionsManager.SetJoinInfo(null);
-            uiDirty = true;
+            MarkFriendsUIDirty();
             NetworkSamplePlayer.UnregisterDisconnectCallback(OnDisconnect);
         }
 
@@ -410,7 +399,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     SetSessionUIActive(true);
                     isClient = true;
                     SetJoinInfo(hostId);
-                    uiDirty = true;
+                    MarkFriendsUIDirty();
                 }
                 else
                 {

--- a/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
+++ b/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
@@ -290,7 +290,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 isHost = true;
                 SetSessionUIActive(true);
                 SetJoinInfo(EOSManager.Instance.GetProductUserId());
-                MarkFriendsUIDirty();
+                SetDirtyFlag();
             }
             else
             {
@@ -318,7 +318,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             isClient = false;
             SetSessionUIActive(false);
             EOSSessionsManager.SetJoinInfo(null);
-            MarkFriendsUIDirty();
+            SetDirtyFlag();
         }
 
         public void TakeControlOnClick()
@@ -384,7 +384,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             isClient = false;
             SetSessionUIActive(false);
             EOSSessionsManager.SetJoinInfo(null);
-            MarkFriendsUIDirty();
+            SetDirtyFlag();
             NetworkSamplePlayer.UnregisterDisconnectCallback(OnDisconnect);
         }
 
@@ -399,7 +399,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     SetSessionUIActive(true);
                     isClient = true;
                     SetJoinInfo(hostId);
-                    MarkFriendsUIDirty();
+                    SetDirtyFlag();
                 }
                 else
                 {

--- a/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
@@ -167,7 +167,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 CustomInvitesManager.SetPayload(payloadText);
                 PayloadSet = true;
             }
-            MarkFriendsUIDirty();
+            SetDirtyFlag();
         }
 
         public override FriendInteractionState GetFriendInteractionState(FriendData friendData)

--- a/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
@@ -42,7 +42,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private EOSFriendsManager FriendsManager;
         private List<UICustomInviteEntry> PendingInviteEntries;
         private bool PayloadSet = false;
-        private bool UIDirty = false;
 
         private void Awake()
         {
@@ -168,7 +167,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 CustomInvitesManager.SetPayload(payloadText);
                 PayloadSet = true;
             }
-            UIDirty = true;
+            MarkFriendsUIDirty();
         }
 
         public override FriendInteractionState GetFriendInteractionState(FriendData friendData)
@@ -179,16 +178,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public override string GetFriendInteractButtonText()
         {
             return "Invite";
-        }
-
-        public override bool IsDirty()
-        {
-            return UIDirty;
-        }
-
-        public override void ResetDirtyFlag()
-        {
-            UIDirty = false;
         }
 
         public override void OnFriendInteractButtonClicked(FriendData friendData)

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
@@ -37,6 +37,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             Enabled
         }
 
+        /// <summary>
+        /// Indicates that this object needs to refresh its UI.
+        /// When this is true, the next time <see cref="UIFriendsMenu.Update"/> runs,
+        /// <see cref="UIFriendsMenu.RefreshFriendUI"/> will be called.
+        /// </summary>
+        protected bool dirtyFlag { get; private set; } = true;
+
         public virtual FriendInteractionState GetFriendInteractionState(FriendData friendData)
         {
             return FriendInteractionState.Hidden;
@@ -52,18 +59,19 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         }
 
         //Should the friend UI update interaction state from this source?
-        public virtual bool IsDirty()
+        public virtual bool IsFriendsUIDirty()
         {
-            return false;
+            return dirtyFlag;
         }
 
-        public virtual void ResetDirtyFlag()
+        public virtual void ResetFriendsUIDirtyFlag()
         {
+            dirtyFlag = false;
         }
 
-        public virtual void MarkDirty()
+        public virtual void MarkFriendsUIDirty()
         {
-
+            dirtyFlag = true;
         }
 
         /// <summary>

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
@@ -60,5 +60,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public virtual void ResetDirtyFlag()
         {
         }
+
+        public virtual void MarkDirty()
+        {
+
+        }
+
+        /// <summary>
+        /// This function is called before refreshing the <see cref="UIFriendsMenu"/>.
+        /// This is an opportunity to refresh any caches or do processing work that should be done once,
+        /// instead of processed for each call of <see cref="GetFriendInteractionState(FriendData)"/>.
+        /// </summary>
+        public virtual void ProcessInformationBeforeFriendsRefresh()
+        {
+
+        }
     }
 }

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
@@ -74,7 +74,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// This is an opportunity to refresh any caches or do processing work that should be done once,
         /// instead of processed for each call of <see cref="GetFriendInteractionState(FriendData)"/>.
         /// </summary>
-        protected virtual void OnFriendStateChanged()
+        public virtual void OnFriendStateChanged()
         {
 
         }

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
@@ -64,14 +64,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return IsDirty;
         }
 
-        public virtual void ResetFriendsUIDirtyFlag()
+        public virtual void SetDirtyFlag(bool isDirty = true)
         {
-            IsDirty = false;
-        }
-
-        public virtual void MarkFriendsUIDirty()
-        {
-            IsDirty = true;
+            IsDirty = isDirty;
         }
 
         /// <summary>

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
@@ -74,7 +74,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// This is an opportunity to refresh any caches or do processing work that should be done once,
         /// instead of processed for each call of <see cref="GetFriendInteractionState(FriendData)"/>.
         /// </summary>
-        public virtual void ProcessInformationBeforeFriendsRefresh()
+        protected virtual void OnFriendStateChanged()
         {
 
         }

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendInteractionSource.cs
@@ -42,7 +42,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// When this is true, the next time <see cref="UIFriendsMenu.Update"/> runs,
         /// <see cref="UIFriendsMenu.RefreshFriendUI"/> will be called.
         /// </summary>
-        protected bool dirtyFlag { get; private set; } = true;
+        protected bool IsDirty { get; private set; } = true;
 
         public virtual FriendInteractionState GetFriendInteractionState(FriendData friendData)
         {
@@ -61,17 +61,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         //Should the friend UI update interaction state from this source?
         public virtual bool IsFriendsUIDirty()
         {
-            return dirtyFlag;
+            return IsDirty;
         }
 
         public virtual void ResetFriendsUIDirtyFlag()
         {
-            dirtyFlag = false;
+            IsDirty = false;
         }
 
         public virtual void MarkFriendsUIDirty()
         {
-            dirtyFlag = true;
+            IsDirty = true;
         }
 
         /// <summary>

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -143,7 +143,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 if (UIFriendInteractionSource != null && UIFriendInteractionSource.IsFriendsUIDirty())
                 {
                     RenderFriendsList(true);
-                    UIFriendInteractionSource.ResetFriendsUIDirtyFlag();
+                    UIFriendInteractionSource.SetDirtyFlag(false);
                 }
                 else
                 {

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -176,7 +176,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 GameObject.Destroy(child.gameObject);
             }
 
-            UIFriendInteractionSource?.ProcessInformationBeforeFriendsRefresh();
+            UIFriendInteractionSource?.OnFriendStateChanged();
 
             foreach (FriendData friend in friendDataList)
             {

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -176,6 +176,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 GameObject.Destroy(child.gameObject);
             }
 
+            UIFriendInteractionSource?.ProcessInformationBeforeFriendsRefresh();
+
             foreach (FriendData friend in friendDataList)
             {
                 GameObject friendUIObj = Instantiate(UIFriendEntryPrefab, FriendsListContentParent.transform);

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -140,10 +140,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             else
             {
-                if (UIFriendInteractionSource != null && UIFriendInteractionSource.IsDirty())
+                if (UIFriendInteractionSource != null && UIFriendInteractionSource.IsFriendsUIDirty())
                 {
                     RenderFriendsList(true);
-                    UIFriendInteractionSource.ResetDirtyFlag();
+                    UIFriendInteractionSource.ResetFriendsUIDirtyFlag();
                 }
                 else
                 {

--- a/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
@@ -95,8 +95,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private EOSFriendsManager FriendsManager;
         private EOSEACLobbyManager AntiCheatLobbyManager;
 
-        private bool UIDirty = false;
-
 #if UNITY_ANDROID && !UNITY_EDITOR //TODO: this should be in a centralized class to reduce clutter, and like an enum if other platforms are to be included
         const bool ONANDROIDPLATFORM = true;
 #else
@@ -536,16 +534,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return "Invite";
         }
 
-        public override bool IsDirty()
-        {
-            return UIDirty;
-        }
-
-        public override void ResetDirtyFlag()
-        {
-            UIDirty = false;
-        }
-
         public override FriendInteractionState GetFriendInteractionState(FriendData friendData)
         {
             if (friendData.IsFriend() && friendData.IsOnline() && IsCurrentLobbyValid())
@@ -636,7 +624,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             LeaveLobbyButton.gameObject.SetActive(true);
             AddMemberAttributeButton.gameObject.SetActive(true);
 
-            UIDirty = true;
+            MarkFriendsUIDirty();
         }
 
         private void UIOnLeaveLobby(Result result)

--- a/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
@@ -624,7 +624,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             LeaveLobbyButton.gameObject.SetActive(true);
             AddMemberAttributeButton.gameObject.SetActive(true);
 
-            MarkFriendsUIDirty();
+            SetDirtyFlag();
         }
 
         private void UIOnLeaveLobby(Result result)

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -61,7 +61,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         /// <summary>
         /// Cached state that indicates if the local user can send invitations for a Session.
-        /// Processed in <see cref="ProcessInformationBeforeFriendsRefresh"/>,
+        /// Processed in <see cref="OnFriendStateChanged"/>,
         /// and utilized in <see cref="GetFriendInteractionState(FriendData)"/>.
         /// </summary>
         protected OwnSessionInvitationAbilityState OwnInvitationState { get; set; } = OwnSessionInvitationAbilityState.NoSessionToInviteTo;
@@ -492,7 +492,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return FriendInteractionState.Enabled;
         }
 
-        public override void ProcessInformationBeforeFriendsRefresh()
+        public override void OnFriendStateChanged()
         {
             // Determine if the local user has an active, presence-enabled Session
             if (!GetEOSSessionsManager.TryGetPresenceSession(out Session foundSession) || foundSession.ActiveSession == null)

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -492,7 +492,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return FriendInteractionState.Enabled;
         }
 
-        protected override void OnFriendStateChanged()
+        public override void OnFriendStateChanged()
         {
             // Determine if the local user has an active, presence-enabled Session
             if (!GetEOSSessionsManager.TryGetPresenceSession(out Session foundSession) || foundSession.ActiveSession == null)

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -443,7 +443,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
          * The UIFriendsMenu popout uses the base class UIFriendInteractionSource to facilitate interactions.
          * 
          * NOTE: This current implementation is not complete.
-         * There is functionality suggested by the existance of this window that need to be added.
+         * There is functionality suggested by the existance of this window that needs to be added.
          * 
          * - Users should be able to Join Sessions their friends are in, if that friend is in a Session, and that Session has invites enabled.
          * - Users that are in a Session who want to interact with a friend that is also in a Session should have UX for choosing Invite or Join

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -376,7 +376,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public void ShowMenu()
         {
             GetEOSSessionsManager.OnLoggedIn();
-            GetEOSSessionsManager.UIOnPresenceAffectingChange.AddListener(MarkFriendsUIDirty);
+            GetEOSSessionsManager.OnPresenceChange.AddListener(MarkFriendsUIDirty);
 
             SessionsMatchmakingUIParent.gameObject.SetActive(true);
 
@@ -391,7 +391,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (GetEOSSessionsManager.IsUserLoggedIn)//check to prevent warnings when done unnecessarily during Sessions & Matchmaking startup
             {
-                GetEOSSessionsManager.UIOnPresenceAffectingChange.RemoveListener(MarkFriendsUIDirty);
+                GetEOSSessionsManager.OnPresenceChange.RemoveListener(MarkFriendsUIDirty);
                 GetEOSSessionsManager.OnLoggedOut();
             }
 

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -39,7 +39,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
     {
         /// <summary>
         /// An enum to record the local state of whether the local user can invite users to their Session.
-        /// <see cref="ownInvitationState"/>
+        /// <see cref="OwnInvitationState"/>
         /// </summary>
         protected enum OwnSessionInvitationAbilityState
         {
@@ -64,7 +64,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// Processed in <see cref="ProcessInformationBeforeFriendsRefresh"/>,
         /// and utilized in <see cref="GetFriendInteractionState(FriendData)"/>.
         /// </summary>
-        protected OwnSessionInvitationAbilityState ownInvitationState { get; set; } = OwnSessionInvitationAbilityState.NoSessionToInviteTo;
+        protected OwnSessionInvitationAbilityState OwnInvitationState { get; set; } = OwnSessionInvitationAbilityState.NoSessionToInviteTo;
 
         public GameObject SessionsMatchmakingUIParent;
 
@@ -478,12 +478,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 return FriendInteractionState.Hidden;
             }
 
-            if (ownInvitationState == OwnSessionInvitationAbilityState.NoSessionToInviteTo)
+            if (OwnInvitationState == OwnSessionInvitationAbilityState.NoSessionToInviteTo)
             {
                 return FriendInteractionState.Hidden;
             }
 
-            if (ownInvitationState == OwnSessionInvitationAbilityState.InvalidSessionToInviteTo)
+            if (OwnInvitationState == OwnSessionInvitationAbilityState.InvalidSessionToInviteTo)
             {
                 return FriendInteractionState.Disabled;
             }
@@ -498,14 +498,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if (!GetEOSSessionsManager.TryGetPresenceSession(out Session foundSession) || foundSession.ActiveSession == null)
             {
                 // Didn't find a presence session, so nothing to invite to
-                ownInvitationState = OwnSessionInvitationAbilityState.NoSessionToInviteTo;
+                OwnInvitationState = OwnSessionInvitationAbilityState.NoSessionToInviteTo;
                 return;
             }
 
             // Does this Session allow for invites? If not, you can't invite users to it.
             if (!foundSession.InvitesAllowed)
             {
-                ownInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
+                OwnInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
                 return;
             }
 
@@ -516,7 +516,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (copyResult != Result.Success || !foundInfo.HasValue || !foundInfo.Value.SessionDetails.HasValue)
             {
-                ownInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
+                OwnInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
                 return;
             }
 
@@ -524,7 +524,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if (!foundSession.AllowJoinInProgress && (foundInfo.Value.State == OnlineSessionState.Starting || foundInfo.Value.State == OnlineSessionState.InProgress))
             {
                 EOSSessionsManager.Log($"{nameof(UISessionsMatchmakingMenu)} ({nameof(GetFriendInteractionState)}): The current Presence-enabled Session cannot be invited to because it is {foundInfo.Value.State} and {nameof(Session.AllowJoinInProgress)} is false.");
-                ownInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
+                OwnInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
                 return;
             }
 
@@ -532,11 +532,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             if (foundInfo.Value.SessionDetails.Value.NumOpenPublicConnections == 0)
             {
                 EOSSessionsManager.Log($"{nameof(UISessionsMatchmakingMenu)} ({nameof(GetFriendInteractionState)}): The current Presence-enabled Session cannot be invited to because the Session already has reached its {nameof(Session.MaxPlayers)} count.");
-                ownInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
+                OwnInvitationState = OwnSessionInvitationAbilityState.InvalidSessionToInviteTo;
                 return;
             }
 
-            ownInvitationState = OwnSessionInvitationAbilityState.ValidSessionToInviteTo;
+            OwnInvitationState = OwnSessionInvitationAbilityState.ValidSessionToInviteTo;
             return;
         }
 

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -492,7 +492,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return FriendInteractionState.Enabled;
         }
 
-        public override void OnFriendStateChanged()
+        protected override void OnFriendStateChanged()
         {
             // Determine if the local user has an active, presence-enabled Session
             if (!GetEOSSessionsManager.TryGetPresenceSession(out Session foundSession) || foundSession.ActiveSession == null)

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -376,7 +376,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public void ShowMenu()
         {
             GetEOSSessionsManager.OnLoggedIn();
-            GetEOSSessionsManager.OnPresenceChange.AddListener(MarkFriendsUIDirty);
+            GetEOSSessionsManager.OnPresenceChange.AddListener(SetDirtyFlagAction);
 
             SessionsMatchmakingUIParent.gameObject.SetActive(true);
 
@@ -391,7 +391,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (GetEOSSessionsManager.IsUserLoggedIn)//check to prevent warnings when done unnecessarily during Sessions & Matchmaking startup
             {
-                GetEOSSessionsManager.OnPresenceChange.RemoveListener(MarkFriendsUIDirty);
+                GetEOSSessionsManager.OnPresenceChange.RemoveListener(SetDirtyFlagAction);
                 GetEOSSessionsManager.OnLoggedOut();
             }
 
@@ -538,6 +538,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             OwnInvitationState = OwnSessionInvitationAbilityState.ValidSessionToInviteTo;
             return;
+        }
+
+        /// <summary>
+        /// <see cref="EOSSessionsManager.OnPresenceChange"/> accepts a function with zero arguments.
+        /// This methods gives a consistent method to AddListener and RemoveListener to that event.
+        /// </summary>
+        private void SetDirtyFlagAction()
+        {
+            SetDirtyFlag();
         }
 
         #endregion

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -96,12 +96,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         [Header("Controller")]
         public GameObject UIFirstSelected;
 
-        /// <summary>
-        /// Indicates to the parent class through <see cref="IsDirty"/> that a visual update of the Friends UI is needed.
-        /// Set any time a Session is joined, left, or its state is modified.
-        /// </summary>
-        private bool UIDirty { get; set; } = true;
-
         private EOSSessionsManager GetEOSSessionsManager
         {
             get { return EOSManager.Instance.GetOrCreateManager<EOSSessionsManager>(); }
@@ -382,7 +376,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public void ShowMenu()
         {
             GetEOSSessionsManager.OnLoggedIn();
-            GetEOSSessionsManager.UIOnPresenceAffectingChange.AddListener(MarkDirty);
+            GetEOSSessionsManager.UIOnPresenceAffectingChange.AddListener(MarkFriendsUIDirty);
 
             SessionsMatchmakingUIParent.gameObject.SetActive(true);
 
@@ -397,7 +391,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (GetEOSSessionsManager.IsUserLoggedIn)//check to prevent warnings when done unnecessarily during Sessions & Matchmaking startup
             {
-                GetEOSSessionsManager.UIOnPresenceAffectingChange.RemoveListener(MarkDirty);
+                GetEOSSessionsManager.UIOnPresenceAffectingChange.RemoveListener(MarkFriendsUIDirty);
                 GetEOSSessionsManager.OnLoggedOut();
             }
 
@@ -461,16 +455,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public override string GetFriendInteractButtonText()
         {
             return "Invite";
-        }
-
-        public override bool IsDirty()
-        {
-            return UIDirty;
-        }
-
-        public override void ResetDirtyFlag()
-        {
-            UIDirty = false;
         }
 
         public override void OnFriendInteractButtonClicked(FriendData friendData)
@@ -554,11 +538,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             ownInvitationState = OwnSessionInvitationAbilityState.ValidSessionToInviteTo;
             return;
-        }
-
-        public override void MarkDirty()
-        {
-            UIDirty = true;
         }
 
         #endregion


### PR DESCRIPTION
Added the Friends Tab to the Sessions scene. You can invite friends from that menu if your friend is online, and you're in a Presence Enabled Session. The invitation button is disabled if the Session you're in isn't applicable to invitations, such as rooms that are full or are marked as not allowing joining in progress.

Minor touchup of `UIFriendInteractionSource` to make it manage the dirty flag.