### PR TITLE
fix(android,fileIO) : remove file check that prevent file reading on android

### DIFF
--- a/Assets/Plugins/Source/Core/Config.cs
+++ b/Assets/Plugins/Source/Core/Config.cs
@@ -280,22 +280,16 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         protected virtual void Read()
         {
-            bool configFileExists = File.Exists(FilePath);
-
-            if (configFileExists)
+            
+#if UNITY_EDITOR // This should only happen in Editor Runtime (Play Mode)
+            if (!File.Exists(FilePath)) 
             {
-                _lastReadJsonString = FileUtility.ReadAllText(FilePath);
-                JsonUtility.FromJsonOverwrite(_lastReadJsonString, this);
-            }
-            else
-            {
-#if UNITY_EDITOR
                 Write();
-#else
-                throw new FileNotFoundException(
-                    $"Config file \"{FilePath}\" does not exist.");
-#endif
             }
+#endif
+
+            _lastReadJsonString = FileUtility.ReadAllText(FilePath);
+            JsonUtility.FromJsonOverwrite(_lastReadJsonString, this);
         }
 
         // Functions declared below should only ever be utilized in the editor.

--- a/Assets/Plugins/Source/Core/Config.cs
+++ b/Assets/Plugins/Source/Core/Config.cs
@@ -337,9 +337,6 @@ namespace PlayEveryWare.EpicOnlineServices
             bool prettyPrint = true, 
             bool updateAssetDatabase = true)
         {
-            FileInfo configFile = new(FilePath);
-            configFile.Directory?.Create();
-
             var json = JsonUtility.ToJson(this, prettyPrint);
 
             // If the json hasn't changed since it was last read, then

--- a/Assets/Plugins/Source/Core/Config.cs
+++ b/Assets/Plugins/Source/Core/Config.cs
@@ -280,8 +280,11 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         protected virtual void Read()
         {
-            
-#if UNITY_EDITOR // This should only happen in Editor Runtime (Play Mode)
+            // This conditional exists because writing a config file is only
+            // something that should ever happen in the editor.
+            // This is the config writing for Editor Playmode
+            // Use WriteAsync instead on Editor Not-Playmode
+#if UNITY_EDITOR
             if (!File.Exists(FilePath)) 
             {
                 Write();


### PR DESCRIPTION
`File.Exist` will always return false for android files, thus this is modified.

The UNITY_EDITOR `Write` can be isolated because `Write` is only meant to happen on editor play mode.

The file check for other platforms could be omitted because they are handled in `ReadAllText` function of their respective platform.