### PR TITLE
refactor(sessions): Acknowledge Event

### DIFF
--- a/Assets/Prefab/friendsTabUI.prefab
+++ b/Assets/Prefab/friendsTabUI.prefab
@@ -293,7 +293,7 @@ MonoBehaviour:
   FriendOverlayContent: {fileID: 5638139344369718672}
   SearchFriendsInput: {fileID: 8536654852504131419}
   FriendsListContentParent: {fileID: 2211920899434422386}
-  UIFriendEntryPrefab: {fileID: 5374375564194558839, guid: 72716240d2b498c47bb1f155ea26e072,
+  UIFriendEntryPrefab: {fileID: 3086061603075623266, guid: 72716240d2b498c47bb1f155ea26e072,
     type: 3}
   CollapseOnStart: 0
   UIFirstSelected: {fileID: 6946016340423810877}

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -90,6 +90,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return SearchResults;
         }
 
+        /// <summary>
+        /// Looks through the Sessions stored in <see cref="SearchResults"/> for a Session with a matching id.
+        /// If found, outputs the <see cref="SessionDetails"/> handle object.
+        /// This can only find Sessions that are part of this search's results, and only if <see cref="OnSearchResultReceived(Dictionary{Session, SessionDetails})"/> has stored those values.
+        /// </summary>
+        /// <param name="sessionId">The id of the Session to find.</param>
+        /// <param name="sessionHandle">Output parameter for the SessionDetails handle.</param>
+        /// <returns>True if a Session was found with the Id. False otherwise.</returns>
         public bool TryGetSessionHandleById(string sessionId, out SessionDetails sessionHandle)
         {
             sessionHandle = null;
@@ -106,6 +114,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return false;
         }
 
+        /// <summary>
+        /// Sets the <see cref="SearchResults"/> for this search.
+        /// <see cref="runOnSearchResultReceived"/> is invoked upon calling this, and then unset.
+        /// </summary>
+        /// <param name="results">A Session-to-SessionDetails dictionary with the results.</param>
         public void OnSearchResultReceived(Dictionary<Session, SessionDetails> results)
         {
             SearchResults = results;
@@ -1854,8 +1867,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         /// <summary>
         /// Attempts to join an online Session.
-        /// The results are handled by <see cref="OnJoinSessionListener(ref JoinSessionCallbackInfo)"/>.
-        /// Sets <see cref="JoiningSessionDetails"/> with the handle, so that it can be used to inform which Session was joined.
+        /// The results are handled by <see cref="OnJoinSessionListener(ref JoinSessionCallbackInfo, SessionDetails, Action{Result})"/>.
         /// </summary>
         /// <param name="sessionHandle">A handle to the Session to join.</param>
         /// <param name="presenceSession">
@@ -1864,7 +1876,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </param>
         /// <param name="callback">
         /// Additional callback to run with the results of the operation.
-        /// Executed as ClientData in <see cref="OnJoinSessionListener(ref JoinSessionCallbackInfo)"/>.
+        /// Invoked in <see cref="OnJoinSessionListener(ref JoinSessionCallbackInfo, SessionDetails, Action{Result})"/>
         /// </param>
         public void JoinSession(SessionDetails sessionHandle, bool presenceSession, Action<Result> callback = null)
         {
@@ -1911,6 +1923,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <see cref="SessionsInterface.CopySessionHandleByUiEventId(ref CopySessionHandleByUiEventIdOptions, out SessionDetails)"/>
         /// <see cref="SessionsInterface.CopySessionHandleForPresence(ref CopySessionHandleForPresenceOptions, out SessionDetails)"/>
         /// <see cref="Epic.OnlineServices.Sessions.SessionSearch.CopySearchResultByIndex(ref SessionSearchCopySearchResultByIndexOptions, out SessionDetails)"/>
+        /// <see cref="SessionSearch.TryGetSessionHandleById(string, out SessionDetails)"/>
         /// </param>
         /// <param name="callback">Optional callback to run with the joining status, perhaps used to inform the UI to update.</param>
         private void OnJoinSessionFinished(SessionDetails joinedSessionDetailsHandle, Action<Result> callback = null)

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -53,7 +53,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// unset in <see cref="Release"/>, when a new search is set without the argument,
         /// or after <see cref="OnSearchResultReceived(Dictionary{Session, SessionDetails})"/> is called.
         /// </summary>
-        private Action<SessionSearch> runOnSearchResultReceived { get; set; }
+        private Action<SessionSearch> RunOnSearchResultReceived { get; set; }
 
         public SessionSearch()
         {
@@ -70,13 +70,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 SearchHandle = null;
             }
 
-            runOnSearchResultReceived = null;
+            RunOnSearchResultReceived = null;
         }
 
         public void SetNewSearch(Epic.OnlineServices.Sessions.SessionSearch handle, Action<SessionSearch> actionToRunOnResultsReceived = null)
         {
             Release();
-            runOnSearchResultReceived = actionToRunOnResultsReceived;
+            RunOnSearchResultReceived = actionToRunOnResultsReceived;
             SearchHandle = handle;
         }
 
@@ -116,14 +116,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         /// <summary>
         /// Sets the <see cref="SearchResults"/> for this search.
-        /// <see cref="runOnSearchResultReceived"/> is invoked upon calling this, and then unset.
+        /// <see cref="RunOnSearchResultReceived"/> is invoked upon calling this, and then unset.
         /// </summary>
         /// <param name="results">A Session-to-SessionDetails dictionary with the results.</param>
         public void OnSearchResultReceived(Dictionary<Session, SessionDetails> results)
         {
             SearchResults = results;
-            runOnSearchResultReceived?.Invoke(this);
-            runOnSearchResultReceived = null;
+            RunOnSearchResultReceived?.Invoke(this);
+            RunOnSearchResultReceived = null;
         }
     }
 

--- a/Assets/Scripts/EOSSessionsManager.cs
+++ b/Assets/Scripts/EOSSessionsManager.cs
@@ -803,23 +803,24 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// This event id can be used to create a <see cref="SessionDetails"/> object by calling <see cref="MakeSessionHandleByEventId(ulong)"/>.
         /// After doing so, or if the handle will not be utilized, this function must call this function to release the handle in the EOS SDK.
         /// Most of the functions in the EOS SDK that require this will mention it in the comments of the callback function. Anything with a UiEventId should have this called.
-        /// 
-        /// TODO: This is hard coded to only handle the <see cref="JoinUiEvent"/> case. It must be changed to also accept the event's id in order to function properly.
         /// </summary>
-        /// <param name="result">A result indicating the success or failure of the event id to acknowledge.</param>
-        private void AcknowledgeEventId(Result result)
+        /// <param name="UiEventId">
+        /// The id of the event to acknowledge.
+        /// All functions requiring AcknowledgeEventId to be called will return this as part of the callback info.
+        /// </param>
+        /// <param name="result">
+        /// A result indicating the success or failure of the event id to acknowledge.
+        /// Most API calls will return a Result, which can be used as this argument.
+        /// In the case where no Result has been provided by the EOS SDK, any Result code can be used in its place, such as <see cref="Result.UnexpectedError"/>.
+        /// </param>
+        private void AcknowledgeEventId(ulong UiEventId, Result result)
         {
-            if (JoinUiEvent != 0)
-            {
-                AcknowledgeEventIdOptions options = new AcknowledgeEventIdOptions();
-                options.UiEventId = JoinUiEvent;
-                options.Result = result;
+            AcknowledgeEventIdOptions options = new AcknowledgeEventIdOptions();
+            options.UiEventId = UiEventId;
+            options.Result = result;
 
-                UIInterface uiInterface = EOSManager.Instance.GetEOSPlatformInterface().GetUIInterface();
-                uiInterface.AcknowledgeEventId(ref options);
-
-                JoinUiEvent = 0;
-            }
+            UIInterface uiInterface = EOSManager.Instance.GetEOSPlatformInterface().GetUIInterface();
+            uiInterface.AcknowledgeEventId(ref options);
         }
 
         /// <summary>

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendEntry.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendEntry.cs
@@ -43,12 +43,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public Action<FriendData> FriendInteractOnClick;
         public Action<ProductUserId, String> ReportOnClick;
 
-        private void Awake()
-        {
-            FriendInteractButton.gameObject.SetActive(false);
-            friendData = null;
-        }
-
         public void SetFriendData(FriendData data)
         {
             friendData = data;

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -55,7 +55,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public UIConsoleInputField SearchFriendsInput;
 
         public GameObject FriendsListContentParent;
-        public GameObject UIFriendEntryPrefab;
+        public UIFriendEntry UIFriendEntryPrefab;
 
         public bool CollapseOnStart = false;
 
@@ -180,8 +180,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             foreach (FriendData friend in friendDataList)
             {
-                GameObject friendUIObj = Instantiate(UIFriendEntryPrefab, FriendsListContentParent.transform);
-                UIFriendEntry uiEntry = friendUIObj.GetComponent<UIFriendEntry>();
+                UIFriendEntry uiEntry = Instantiate(UIFriendEntryPrefab, FriendsListContentParent.transform);
                 uiEntry.EnableFriendButton(false);
 
                 uiEntry.SetFriendData(friend);


### PR DESCRIPTION
Whenever a call returns a UiEventId, it should be Acknowledged. Previously the AcknowledgeEventId function was hard wired to only deal with one event, now it can take any event.

Several member variables that were used to store temporary state have been reduced and removed. I disliked the way that important state information was juggled. There is still some, Invites mostly, that are still managed in a disagreeable way.

Removed the notification for "game joined". This notification was pretty misleading; it appears to be an event that fires when you invite a user over the social overlay, and they accept over the social overlay. That notification wasn't meaningfully being handled or used, so we cut it for now.

Some Action delegate pass-ins have been adjusted a bit. For example see JoinSession, which now creates a delegate that passes in additional information without needing to be as tied to the "ClientData" field. I'd like feedback on what to call what is currently `runOnSearchResultReceived`.