### PR TITLE
fix(builds): Fixing changed function name on build

### DIFF
--- a/Assets/Plugins/Source/Core/EOSManager.cs
+++ b/Assets/Plugins/Source/Core/EOSManager.cs
@@ -477,7 +477,7 @@ namespace PlayEveryWare.EpicOnlineServices
 #if UNITY_EDITOR
                     PlatformFlags.LoadingInEditor;
 #else
-                configData.platformOptionsFlagsAsPlatformFlags();
+                configData.GetPlatformFlags();
 #endif
                 if (configData.IsEncryptionKeyValid())
                 {


### PR DESCRIPTION
When making a build, this was failing because the function wasn't found. Pointed it at its new home.