### PR TITLE
fix: Trailing `null` characters in parsing of downloaded file.

### DIFF
--- a/Assets/Scripts/EOSPlayerDataStorageManager.cs
+++ b/Assets/Scripts/EOSPlayerDataStorageManager.cs
@@ -32,6 +32,8 @@ using Epic.OnlineServices.PlayerDataStorage;
 
 namespace PlayEveryWare.EpicOnlineServices.Samples
 {
+    using Editor.Utility;
+
     /// <summary>Class <c>EOSPlayerDataStorageManager</c> is a simplified wrapper for EOS [PlayerDataStorage Interface](https://dev.epicgames.com/docs/services/en-US/Interfaces/PlayerDataStorage/index.html).</summary>
     public class EOSPlayerDataStorageManager : IEOSSubManager
     {
@@ -487,7 +489,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
                 else if (transfer.TotalSize > 0)
                 {
-                    fileData = System.Text.Encoding.UTF8.GetString(transfer.Data);
+                    fileData = System.Text.Encoding.UTF8.GetString(transfer.Data, 0, (int)transfer.TotalSize);
                 }
                 else
                 {

--- a/Assets/Scripts/EOSTitleStorageManager.cs
+++ b/Assets/Scripts/EOSTitleStorageManager.cs
@@ -261,7 +261,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             string fileData = string.Empty;
             if (transfer.TotalSize > 0)
             {
-                fileData = System.Text.Encoding.UTF8.GetString(transfer.Data);
+                fileData = System.Text.Encoding.UTF8.GetString(transfer.Data, 0, (int)transfer.TotalSize);
             }
 
             StorageData.Add(fileName, fileData);


### PR DESCRIPTION
Correct the function used to convert byte array to string by providing the start index and the number of bytes to read within the data storage sample managers.

Fixes issue #804. 