### PR TITLE
Make `EOSSettingsWindow` aware of available build targets

### DIFF
--- a/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs
@@ -22,9 +22,6 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Editor
 {
-    using System;
-    using System.Threading.Tasks;
-
     // Interface for allowing adding additional config files to the Config editor
     public interface IPlatformConfigEditor : IConfigEditor
     {
@@ -32,7 +29,9 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         /// Determines if the platform for which the config editor is
         /// configuring values for is available as a build target.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// True if the platform can be targetted by the Unity Editor.
+        /// </returns>
         bool IsPlatformAvailable();
     }
 }

--- a/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2024 PlayEveryWare
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+namespace PlayEveryWare.EpicOnlineServices.Editor
+{
+    using System;
+    using System.Threading.Tasks;
+
+    // Interface for allowing adding additional config files to the Config editor
+    public interface IPlatformConfigEditor : IConfigEditor
+    {
+        /// <summary>
+        /// Determines if the platform for which the config editor is
+        /// configuring values for is available as a build target.
+        /// </summary>
+        /// <returns></returns>
+        bool IsPlatformAvailable();
+    }
+}

--- a/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs.meta
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7517c9c2498a6d6469872b077a0b2947
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Source/Editor/ConfigEditors/PlatformConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/PlatformConfigEditor.cs
@@ -21,6 +21,7 @@
 */
 namespace PlayEveryWare.EpicOnlineServices.Editor
 {
+    using System.Linq;
     using UnityEditor;
     using UnityEngine;
     using Utility;
@@ -29,7 +30,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
     /// Contains implementations of IConfigEditor that are common to all ConfigEditors that represent the configuration options for a specific platform.
     /// </summary>
     /// <typeparam name="T">Intended to be a type accepted by the templated class ConfigHandler.</typeparam>
-    public abstract class PlatformConfigEditor<T> : ConfigEditor<T> where T : PlatformConfig
+    public abstract class PlatformConfigEditor<T> : ConfigEditor<T>, IPlatformConfigEditor where T : PlatformConfig
     {
         /// <summary>
         /// The platform that this PlatformConfigEditor represents.
@@ -66,6 +67,11 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
             GUIEditorUtility.AssigningULongToStringField("Thread Affinity: P2PIO", ref config.overrideValues.ThreadAffinity_P2PIO);
             GUIEditorUtility.AssigningULongToStringField("Thread Affinity: HTTPRequestIO", ref config.overrideValues.ThreadAffinity_HTTPRequestIO);
             GUIEditorUtility.AssigningULongToStringField("Thread Affinity: RTCIO", ref config.overrideValues.ThreadAffinity_RTCIO);
+        }
+
+        public bool IsPlatformAvailable()
+        {
+            return PlatformManager.GetAvailableBuildTargets().Contains(Platform);
         }
 
         public virtual void RenderPlatformSpecificOptions() { }

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -39,7 +39,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     [Serializable]
     public class EOSSettingsWindow : EOSEditorWindow
     {
-        private List<IConfigEditor> platformSpecificConfigEditors;
+        private List<IPlatformConfigEditor> platformSpecificConfigEditors;
 
         private static readonly string ConfigDirectory = Path.Combine("Assets", "StreamingAssets", "EOS");
 
@@ -133,12 +133,13 @@ _WIN32 || _WIN64
 
             mainEOSConfigFile = await Config.GetAsync<EOSConfig>();
 
-            platformSpecificConfigEditors ??= new List<IConfigEditor>();
+            platformSpecificConfigEditors ??= new List<IPlatformConfigEditor>();
             var configEditors = ReflectionUtility.CreateInstancesOfDerivedGenericClasses(typeof(PlatformConfigEditor<>));
 
             foreach (var editor in configEditors)
             {
-                platformSpecificConfigEditors.Add(editor as IConfigEditor);
+                if (editor is IPlatformConfigEditor platformConfigEditor && platformConfigEditor.IsPlatformAvailable())
+                    platformSpecificConfigEditors.Add(platformConfigEditor);
             }
 
             toolbarTitleStrings = new string[1 + platformSpecificConfigEditors.Count];

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -156,6 +156,30 @@ namespace PlayEveryWare.EpicOnlineServices
             };
 
         /// <summary>
+        /// Returns an IEnumerable of the platforms for which the current Unity
+        /// Editor is able to build projects for.
+        /// </summary>
+        /// <returns>
+        /// IEnumerable of the platforms for which the current Unity Editor is
+        /// able to build projects for.
+        /// </returns>
+        public static IEnumerable<Platform> GetAvailableBuildTargets()
+        {
+            foreach (BuildTarget target in Enum.GetValues(typeof(BuildTarget)))
+            {
+                var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(target);
+
+                if (!BuildPipeline.IsBuildTargetSupported(buildTargetGroup, target))
+                    continue;
+
+                if (!TargetToPlatformsMap.TryGetValue(target, out Platform supportedPlatform))
+                    continue;
+
+                yield return supportedPlatform;
+            }
+        }
+
+        /// <summary>
         /// Get the platform that matches the given build target.
         /// </summary>
         /// <param name="target">The build target being built for.</param>


### PR DESCRIPTION
~This PR is opened as a draft, as it is built upon `fix/steam-config-relocation` which already has a PR open for it. Once the `fix/steam-config-relocation` branch has been merged in, the target of this PR will change to `development`, and will be converted from draft to pull request.~

This PR makes the `EOSSettingsWindow` aware of which platforms can be built against and limits the displayed configurations to that set. This prevents users from setting config values for platforms their installation of Unity does not support.