### PR TITLE
fix: Correct file path in `eos_package_description.json` file.

### DIFF
--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -14,9 +14,9 @@
         {"src": "Assets/EOS/*.png", "dest": "Runtime/EOS/" },
                              
         {"src": "Assets/Plugins/*",                                "dest": "Runtime/"                             },
-        {"src": "com.playeveryware.com/Runtime/Core/*",                    "dest": "Runtime/Core/"                        },
-        {"src": "com.playeveryware.com/Runtime/Core/Utility/*",            "dest": "Runtime/Core/Utility/"                },
-        {"src": "com.playeveryware.com/Runtime/Core/Utility/Extensions/*", "dest": "Runtime/Core/Utility/Extensions/"     },
+        {"src": "com.playeveryware.eos/Runtime/Core/*",                    "dest": "Runtime/Core/"                        },
+        {"src": "com.playeveryware.eos/Runtime/Core/Utility/*",            "dest": "Runtime/Core/Utility/"                },
+        {"src": "com.playeveryware.eos/Runtime/Core/Utility/Extensions/*", "dest": "Runtime/Core/Utility/Extensions/"     },
         
         {"src": "Assets/Plugins/Source/Editor/*",                  "dest": "Editor/"                },
         {"src": "Assets/Plugins/Source/Editor/Build/*",            "dest": "Editor/Build/"          },


### PR DESCRIPTION
Fixes a typo within `eos_package_description.json` that causes package creation to fail.