### PR TITLE
Fix warnings when Steamworks.NET is not setup

### DIFF
--- a/Assets/Scripts/StandardSamples/Steam/SteamManager.cs
+++ b/Assets/Scripts/StandardSamples/Steam/SteamManager.cs
@@ -454,11 +454,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
 
         private void StartConnectLoginWithSteamSessionTicket(EOSManager.OnConnectLoginCallback onLoginCallback, int retryAttemptNumber = 0)
         {
-            const int MaximumNumberOfRetries = 1;
-
 #if DISABLESTEAMWORKS
             onLoginCallback?.Invoke(new Epic.OnlineServices.Connect.LoginCallbackInfo() { ResultCode = Epic.OnlineServices.Result.UnexpectedError });
 #else
+            const int MaximumNumberOfRetries = 1;
+
             string steamToken = GetSessionTicket();
             EOSManager.Instance.StartConnectLoginWithOptions(Epic.OnlineServices.ExternalCredentialType.SteamSessionTicket, steamToken, onloginCallback: (Epic.OnlineServices.Connect.LoginCallbackInfo callbackInfo) =>
             {
@@ -487,11 +487,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Steam
 
         private void StartConnectLoginWithSteamAppTicket(EOSManager.OnConnectLoginCallback onLoginCallback, int retryAttemptNumber = 0)
         {
-            const int MaximumNumberOfRetries = 1;
-
 #if DISABLESTEAMWORKS
             onLoginCallback?.Invoke(new Epic.OnlineServices.Connect.LoginCallbackInfo() { ResultCode = Epic.OnlineServices.Result.UnexpectedError });
 #else
+            const int MaximumNumberOfRetries = 1;
+
             RequestAppTicket((string token) => {
                 if (token == null)
                 {


### PR DESCRIPTION
Place const declaration within proper compiler conditional branch so that it does not trigger a warning about an unused variable.

Resolves an issue where the Unity Editor generates warnings when Steamworks.NET is not enabled.