### PR TITLE
Fixes for the latest development branch

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -284,10 +284,10 @@ _WIN32 || _WIN64
             {
                 taskNetworkTimeoutSecondsAsString = mainEOSConfigFile.taskNetworkTimeoutSeconds.ToString();
             }
-
+#if !EOS_DISABLE
             GUIEditorUtility.AssigningTextField("Task Network Timeout Seconds", ref taskNetworkTimeoutSecondsAsString,
                 tooltip: $"(Optional) Define the maximum amount of time network calls will run in the EOS SDK before timing out while the {nameof(Epic.OnlineServices.Platform.NetworkStatus)} is not {nameof(Epic.OnlineServices.Platform.NetworkStatus.Online)}. Defaults to 30 seconds if not set or less than or equal to zero.");
-
+#endif
             if (taskNetworkTimeoutSecondsAsString.Length != 0)
             {
                 try

--- a/com.playeveryware.eos/Runtime/Core/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformConfig.cs
@@ -22,7 +22,9 @@
 
 namespace PlayEveryWare.EpicOnlineServices
 {
+#if !EOS_DISABLE
     using Epic.OnlineServices.IntegratedPlatform;
+#endif
     using Extensions;
     using System;
     using System.Collections.Generic;
@@ -72,6 +74,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// integratedPlatformManagementFlags flags on this config.
         /// </summary>
         /// <returns>An IntegratedPlatformManagementFlags enum value.</returns>
+#if !EOS_DISABLE
         public IntegratedPlatformManagementFlags GetIntegratedPlatformManagementFlags()
         {
             return StringsToEnum<IntegratedPlatformManagementFlags>(
@@ -79,5 +82,6 @@ namespace PlayEveryWare.EpicOnlineServices
                 IntegratedPlatformManagementFlagsExtensions.TryParse
             );
         }
+#endif
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/RuntimeConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/RuntimeConfig.cs
@@ -24,6 +24,7 @@
 
 namespace PlayEveryWare.EpicOnlineServices
 {
+#if !EOS_DISABLE
     using Epic.OnlineServices.Auth;
     using Epic.OnlineServices.Platform;
     using System;
@@ -48,7 +49,7 @@ namespace PlayEveryWare.EpicOnlineServices
     /// </summary>
     public readonly struct RuntimeConfig
     {
-        #region EOS SDK Configuration Values
+    #region EOS SDK Configuration Values
 
         /*
          * The following region contains values that are required in order to
@@ -119,7 +120,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         public readonly bool IsServer;
 
-        #endregion
+    #endregion
 
         public RuntimeConfig(
             Guid productId,
@@ -193,5 +194,6 @@ namespace PlayEveryWare.EpicOnlineServices
                 config.isServer);
         }
     }
+#endif
 #endif
 }


### PR DESCRIPTION
fix(test,discord) : Disable Discord within StartConnectLogin for unsupported platforms
`AuthenticationExpirationTestManager` call `DiscordManager.StartConnectLogin` on all platforms, including unsupported ones.
This is to make it compile and return an error log if not supported

fix(eos,disable) : missing EOS_DISABLEs for newly added function calls and files 