### PR TITLE
Change `EOSManager` to use events instead of lists of delegate instances.

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -110,9 +110,9 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public delegate void OnConnectLoginCallback(Epic.OnlineServices.Connect.LoginCallbackInfo loginCallbackInfo);
 
-        protected static event OnAuthLoginCallback OnAuthLogin;
-        protected static event OnAuthLogoutCallback OnAuthLogout;
-        protected static event OnConnectLoginCallback OnConnectLogin;
+        private static event OnAuthLoginCallback OnAuthLogin;
+        private static event OnAuthLogoutCallback OnAuthLogout;
+        private static event OnConnectLoginCallback OnConnectLogin;
 
         public delegate void OnCreateConnectUserCallback(CreateUserCallbackInfo createUserCallbackInfo);
 


### PR DESCRIPTION
This PR introduces a change to `EOSManager` that implements the authentication callbacks by using `events`. 

There is no change in the API for EOSManager - the only changes made are to internal implementation of the handling of delegates.