### PR TITLE
Fix UI meta file to have the correct casing to fix warning

### DIFF
--- a/com.playeveryware.eos/Runtime/EOS_SDK/Generated/UI.meta
+++ b/com.playeveryware.eos/Runtime/EOS_SDK/Generated/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9df45ef2a23c394a8568cbf85bceec1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Ui.meta
+++ b/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Ui.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a9df45ef2a23c394a8568cbf85bceec1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
When you import the .tgz package into a fresh Unity project there is a warning generated because Ui.meta does not match the casing of the folder (UI).

This fix just removes the Ui.meta file and re-adds it identically as UI.meta

Asset file 'Packages/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Ui.meta' and meta file 'Packages/com.playeveryware.eos/Runtime/EOS_SDK/Generated/UI.meta' has inconsistent casing.
Renaming meta file succeeded.