### PR TITLE
Ignore .gitattributes files when exporting package files.

### DIFF
--- a/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/PackageFileUtility.cs
@@ -209,7 +209,11 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
                 FileInfo destInfo = new(destPath);
 
-                if (file.originalSrcDestPair.dest.Contains('~') && !file.originalSrcDestPair.dest.Contains("Samples~"))
+                if (src.Name == ".gitattributes") // Ignore .gitattributes as these should not be in the package
+                {
+                    continue;
+                }
+                else if (file.originalSrcDestPair.dest.Contains('~') && !file.originalSrcDestPair.dest.Contains("Samples~"))
                 {
                     // When generating a upm package, all directories that contain a 
                     // tilde character at the end of the name are ignored by Unity's


### PR DESCRIPTION
Simple fix to ignore .gitattributes files when exporting plugin.

Ideally the package does not contain .gitattributes because there is no guarantee whoever imports this package is even using git or may not have git lfs.

I was going to add to this that the package json files did have support for a blacklist, but that field seemed never to be referenced. I suppose that might be a cleaner fix for blacklisted files, but sometimes simple might be best.