### PR TITLE
Better data handling in file transfers

### DIFF
--- a/Assets/Scripts/EOSPlayerDataStorageManager.cs
+++ b/Assets/Scripts/EOSPlayerDataStorageManager.cs
@@ -188,16 +188,16 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             CancelCurrentTransfer();
             CurrentTransferHandle = req;
 
-            EOSTransferInProgress newTransfer = new EOSTransferInProgress();
-            newTransfer.Download = false;
-
-            newTransfer.TotalSize = (uint)fileData.Length;
-            if (newTransfer.TotalSize > 0)
+            EOSTransferInProgress newTransfer = new()
             {
-                byte[] utf8ByteArray = System.Text.Encoding.UTF8.GetBytes(fileData);
+                Download = false
+            };
 
-                newTransfer.Data = utf8ByteArray;
+            if (null != fileData)
+            {
+                newTransfer.Data = System.Text.Encoding.UTF8.GetBytes(fileData);
             }
+
             newTransfer.CurrentIndex = 0;
 
             TransfersInProgress[fileName] = newTransfer;
@@ -376,14 +376,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
 
                 // First update
-                if (transfer.CurrentIndex == 0 && transfer.TotalSize == 0)
+                if (transfer.CurrentIndex == 0)
                 {
-                    transfer.TotalSize = totalSize;
-
-                    if (transfer.TotalSize == 0)
-                    {
-                        return ReadResult.ContinueReading;
-                    }
+                    transfer.Data = new byte[totalSize];
                 }
 
                 // If more data has been received than was anticipated, fail the request

--- a/Assets/Scripts/EOSTitleStorageManager.cs
+++ b/Assets/Scripts/EOSTitleStorageManager.cs
@@ -370,14 +370,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
 
                 // First update
-                if (transfer.CurrentIndex == 0 && transfer.TotalSize == 0)
+                if (transfer.CurrentIndex == 0)
                 {
-                    transfer.TotalSize = totalSize;
-
-                    if (transfer.TotalSize == 0)
-                    {
-                        return ReadResult.RrContinuereading;
-                    }
+                    transfer.Data = new byte[totalSize];
                 }
 
                 // Make sure we have enough space

--- a/Assets/Scripts/EOSTransferInProgress.cs
+++ b/Assets/Scripts/EOSTransferInProgress.cs
@@ -26,6 +26,8 @@ using UnityEngine;
 
 namespace PlayEveryWare.EpicOnlineServices.Samples
 {
+    using Editor.Utility;
+
     /// <summary>
     /// Class <c>EOSTransferInProgress</c> is used in <c>EOSTitleStorageManager</c> and <c>EOSPlayerDataStorageManager</c> to keep track of downloaded cached file data.
     /// </summary>
@@ -37,24 +39,40 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public bool Download = true;
         public uint CurrentIndex = 0;
-        public byte[] Data;
-        private uint transferSize = 0;
+        private byte[] _data;
+
+        public byte[] Data
+        {
+            get
+            {
+                return _data;
+            }
+            set
+            {
+                // If the file sizer is larger than the maximum allowable size,
+                // then log an error, but do not throw an exception, since
+                // throwing an exception from a property setter is a little
+                // confusing, and there will be an opportunity to catch the 
+                // mistake when EOS returns an error code.
+                if (null != value && value.Length > FileMaxSizeBytes)
+                {
+                    Debug.LogError($"Maximum file size is 200MB.");
+                }
+
+                _data = value;
+            }
+        }
 
         public uint TotalSize
         {
             get
             {
-                return transferSize;
-            }
-            set
-            {
-                transferSize = value;
+                if (null == _data)
+                    return 0;
 
-                if (transferSize > FileMaxSizeBytes)
-                {
-                    Debug.LogError("[EOS SDK] Player data storage: data transfer size exceeds max file size.");
-                    transferSize = FileMaxSizeBytes;
-                }
+                _ = SafeTranslatorUtility.TryConvert(_data.Length, out uint totalSize);
+
+                return totalSize;
             }
         }
 


### PR DESCRIPTION
This PR resolves issue #833.

Previously, the data for `EOSTransferInProgress` was having it's `TotalSize` property updated independently of the `Data` byte array field.

This PR updates the implementation so that `TotalSize` is always the number of bytes in the byte array, removing the need to count the bytes being transferred based on any specific encoding.

#EOS-2028