### PR TITLE
fix: Do not set the selected item during each Update()

### DIFF
--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -211,9 +211,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </summary>
         protected virtual void Update()
         {
-            // If nothing is selected, set the selected (focused) control to be
-            // UIFirstSelected (if that field has been set).
-            SetSelected();
+            // Default behavior is to take no action.
         }
 
         /// <summary>


### PR DESCRIPTION
Small error introduced in a recent merge causes the `UIFirstSelected` gameObject to continuously be focused. This was not initially discovered because it was tested mainly using menus that rely on clicking, which doesn't require a control have focus.

It was discovered when looking at scenes where focusing a text input field was required.

#EOS-2030