### PR TITLE
Fix to package description

### DIFF
--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -13,7 +13,8 @@
         {"src": "Assets/EOS.meta",  "dest": "Runtime/"     },
         {"src": "Assets/EOS/*.png", "dest": "Runtime/EOS/" },
                              
-        {"src": "Assets/Plugins/*",                                "dest": "Runtime/"                             },
+        {"src": "Assets/Plugins/*",                                        "dest": "Runtime/"                             },
+        {"src": "com.playeveryware.eos/Runtime/*",                         "dest": "Runtime/" },
         {"src": "com.playeveryware.eos/Runtime/Core/*",                    "dest": "Runtime/Core/"                        },
         {"src": "com.playeveryware.eos/Runtime/Core/Utility/*",            "dest": "Runtime/Core/Utility/"                },
         {"src": "com.playeveryware.eos/Runtime/Core/Utility/Extensions/*", "dest": "Runtime/Core/Utility/Extensions/"     },


### PR DESCRIPTION
In the course of testing our package creation, I discovered that we have a missing entry within our `eos_package_description.json` file. This PR corrects that mistake.

#EOS-2034