### PR TITLE
fix: resolve empty asmdef file warning via dummy file.

### DIFF
--- a/Assets/Plugins/Dummyfile.cs
+++ b/Assets/Plugins/Dummyfile.cs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// TODO: This class only serves to remove a warning.
+//       It may be removed if when more files are added to the com.playeveryware.eos assembly.
+namespace PlayEveryWare.EpicOnlineServices
+{
+
+    public class EOSDummyClass
+    {
+    }
+}

--- a/Assets/Plugins/Dummyfile.cs.meta
+++ b/Assets/Plugins/Dummyfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8672f70db1159934ebabe4f906f992a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A better longer fix solution might be to move everything from core back into the main asmdef. But evaluating that fix might take longer so this change is more suitable for the time being.