### PR TITLE
fix(log,config) : Using default log levels if config file doesn't exist

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -752,6 +752,12 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 var logLevelList = LogLevelUtility.LogLevelList;
 
+                if (logLevelList == null)
+                {
+                    SetLogLevel(LogCategory.AllCategories, LogLevel.Info);
+                    return;
+
+                }
                 for (int logCategoryIndex = 0; logCategoryIndex < logLevelList.Count; logCategoryIndex++)
                 {
                     SetLogLevel((LogCategory)logCategoryIndex, logLevelList[logCategoryIndex]);

--- a/com.playeveryware.eos/Runtime/Core/Utility/LogLevelUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/LogLevelUtility.cs
@@ -43,7 +43,22 @@ namespace PlayEveryWare.EpicOnlineServices
         {
             get
             {
-                LogLevelConfig logLevelConfig = Config.Get<LogLevelConfig>();
+                LogLevelConfig logLevelConfig = null;
+                try
+                {
+                    logLevelConfig = Config.Get<LogLevelConfig>();
+                }
+                catch (System.IO.FileNotFoundException)
+                {
+                    Debug.Log($"Log level config does not exist, using default");
+                    return null; 
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogWarning($"{exception}");
+                    Debug.Log($"Exception when reading log level config, using default");
+                    return null;
+                }
 
                 List<LogLevel> logLevels = new List<LogLevel>();
                 for (int i = 0; i < LogCategoryStringArray.Length - 1; i++)


### PR DESCRIPTION
User were met with initialize errors when log level configs don't exist. It is caused by uncaught exceptions during file reading, leading to EOSManager.Init ceasing to complete. This fix catches those exceptions and continues the Init using default log levels