### PR TITLE
Release-3.3.2 merge

### DIFF
--- a/com.playeveryware.eos/CHANGELOG.md
+++ b/com.playeveryware.eos/CHANGELOG.md
@@ -4,6 +4,282 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [3.3.2] - 2024-08-27
+
+### Added
+
+- Git Actions
+  - feat: Create check-for-package-difference.yml
+  - feat: Add workflow to auto-update the unity version badge in README.md.
+
+- Plugin General
+  - feature (Sessions): Notifications in subregion
+  - feature (Sessions): Rearranged Functions inside Regions
+  - feature (Sessions): Organizing all functions in to #regions, unsorted otherwise
+  - feature (Sessions): Destroy session when owner destroys their session
+  - feature (Sessions): Refresh UI On Refresh Message
+  - feature (Sessions): Code review feedback implemented
+  - feature (sessions): Reworking Sample, P2P Communication Part
+  - feature(network): Implementing taskNetworkTimeoutSeconds
+  - feat: Make the EOSSettingsWindow aware of which build targets are available, showing platform-specific options for only those that are.
+  - feat: Implement function to enumerate the platforms that can be built against.
+  - feat: Add function to generate a RuntimeConfig struct from the values of an EOSConfig class.
+  - feat: Add RuntimeConfig struct that stores the totality of the configurable properties used by the plugin during runtime. Also add method to EnumUtility that supports decomposing a bitwise-operator combined enum value into it's constituent discrete components.
+  - feat: Add upm layout as upm to asset project
+  - feat: Upgrade targetted version of Unity.
+  - feat: Add ability configure the plugin to not unload the EOS SDK on shutdown.
+  - feature (Sessions): Notifications in subregion
+  - feature (Sessions): Rearranged Functions inside Regions
+  - feature (Sessions): Organizing all functions in to #regions, unsorted otherwise
+  - feature (Sessions): Destroy session when owner destroys their session
+  - feature (Session): Refresh UI On Refresh Message
+  - feature (sessions): Reworking Sample, P2P Communication Part
+
+- Unit Tests
+  - feat: Add unit tests for enum extensions.
+  - feat: Add unit tests of limited scope.
+  - tests(sessions): Create and search for sessions
+  - tests(login): Testing scene for auditing logins
+
+### Changed
+
+- Git and LFS
+  - chore(macos): Store as binary, not text!
+  - chore(macOS): Putting MacOS Binaries in Git LFS
+  - chore: Update .gitattributes
+  - chore: Update Unity version badge to 2021.3.16f1
+
+- Release & Packaging
+  - chore(tool,import) : dispose result of async task to prevent warnings
+  - chore(lib,android) : remove unused android libs
+  - chore(sdk,source) : updated managed source for 1.16.3 hotfix
+  - chore(sdk,lib) : updated binaries for 1.16.3 hotfix
+  - chore(eac,tool) : Allow anticheat integrity tool file path to recognize executables with no extension
+  - chore: Update eos_package_description.json with new location of core code
+  - chore: Update eos_package_description.json with new location of EOS SDK.
+  - chore: Update eos_package_description.json with new location of docs
+  - chore: Update eos_package_description.json with new location of PackageTemplate files
+
+- Sample Rework
+  - rework(auth): Better variable names, namespace using moved, null propagation, 0-safe division
+  - rework(auth): Fix signature of UILoginMenu call
+  - rework(auth): Retry attempt count, remove "WithDiscord", camel case variable name
+  - rework(session): Fix to Test logic
+  - rework(sessions): Renamed Tests
+  - rework(sessions): Removing unused test function
+  - rework(session): Define Session in Out Parameter of Function Call
+  - rework(sessions): Demoting Error to Warning for no local Session found on informing owner
+  - rework(sessions): SessionsManager Callbacks
+  - rework(sessions): Reset and Init
+  - rework(sessions): OnShutDown removed, no longer mentioned in code comments
+  - rework(sessions): Decapitalize "R" in "Unregister"
+  - rework(sessions): `dirtyFlag` -> `IsDirty`
+  - rework(sessions): `dirtyFlag` -> `IsDirty`
+  - rework(sessions): Decapitalize "R" in "Unregister"
+  - rework(sessions): Rearranging Manager Code into Regions
+
+- Documents and Comments
+  - chore (Sessions): Standardizing comments inside EOSSessionsManager
+  - chore (EOSSessionsManager): Change constants to SCREAMING_SNAKE_CASE per standards
+  - chore(comment) : update comment to better describe config write use cases
+  - chore (Sessions): Standardizing comments inside EOSSessionsManager
+  - chore (EOSSessionsManager): Change constants to SCREAMING_SNAKE_CASE per standards
+  - chore (documentation, Lobby): Return values for messages documented, some wording changes to params
+  - chore (documentation, Lobby): Adding clarifying documentation mentioning subscription
+  - docs(sessions): Some touchup to Session capitalization
+  - docs (sessions): Responding to PR Feedback
+  - docs (Sessions): Slight commenting tweak
+  - docs (Sessions): Some additional commenting tweaks
+  - docs (Sessions): Continued effort in commenting everything
+  - docs (Sessions): More comments
+  - docs (sessions): Writing comments for functions and regions, part one
+  - docs(sessions): Some touchup to Session capitalization
+  - docs: update links to reference new doc location
+  - docs (Sessions): Commenting Functions
+  - docs (sessions): Responding to PR Feedback
+  - docs (Sessions): Slight commenting tweak
+  - docs (Sessions): Some additional commenting tweaks
+  - docs (Sessions): Continued effort in commenting everything
+  - doc: Add unity version badge to README.md.
+  - docs (Sessions): More comments
+  - docs: update the doc with some things that were missing
+  - docs (sessions): Writing comments for functions and regions, part one
+
+- Plugin Refactor
+  - refactor(docs): Move core code to new upm layout directory
+  - refactor(sessions): Capitalizing action that is a property
+  - refactor(sessions): Some additional comment cleaning
+  - refactor(sessions): Prefab instance link fix for friendsTabUI
+  - refactor(session): Remove vestigial invite, fix ui to update properly first call
+  - refactor(sessions): Juggling joined session better
+  - refactor(sessions): Join session after search without member variable
+  - refactor(sessions): All callers to AcknowledgeEventId cleaned up
+  - refactor(sessions): AcknowledgeEventId takes in UIEventId argument
+  - refactor(sessions): Access level back!
+  - refactor(sessions): Access level change
+  - refactor(sessions): Rename to OnFriendStateChanged
+  - refactor(sessions): MarkFriendsUIDirty => SetDirtyFlag
+  - refactor(sessions): Rename UIOnPresenceAffectingChange to OnPresenceChange
+  - refactor(sessions): Review feedback, comment moving, comment grammar fix
+  - refactor(sessions): `ownInvitationState` -> `OwnInvitationState`
+  - refactor(friends ui): Standardized parent handling dirty status instead of implementors
+  - refactor(sessions): Friend UI Refreshes
+  - refactor(sessions): Basic Session Invitation for Presence Sessions
+  - refactor(sessions): Added Friends UI to Sessions Scene
+  - refactor(sessions): Addressing code review feedback
+  - refactor(sessions): Session State Management
+  - refactor(sessions): Capitalizing action that is a property
+  - refactor(sessions): Some additional comment cleaning
+  - refactor(sessions): Prefab instance link fix for friendsTabUI
+  - refactor(session): Remove vestigial invite, fix ui to update properly first call
+  - refactor(sessions): Juggling joined session better
+  - refactor(sessions): Join session after search without member variable
+  - refactor(sessions): All callers to AcknowledgeEventId cleaned up
+  - refactor(eos_sdk): Move eos_sdk to new upm layout directory
+  - refactor(sessions): AcknowledgeEventId takes in UIEventId argument
+  - refactor(sessions): Access level back!
+  - refactor(sessions): Access level change
+  - refactor(sessions): Rename to OnFriendStateChanged
+  - refactor(sessions): MarkFriendsUIDirty => SetDirtyFlag
+  - refactor(sessions): Rename UIOnPresenceAffectingChange to OnPresenceChange
+  - refactor(sessions): Review feedback, comment moving, comment grammar fix
+  - refactor(sessions): `ownInvitationState` -> `OwnInvitationState`
+  - refactor(friends ui): Standardized parent handling dirty status instead of implementors
+  - refactor(sessions): Friend UI Refreshes
+  - refactor(sessions): Basic Session Invitation for Presence Sessions
+  - refactor(sessions): Added Friends UI to Sessions Scene
+  - refactor(sessions): Session State Management Mirroring
+  - refactor(sessions): Addressing code review feedback
+  - refactor(sessions): Session State Management
+  - refactor(docs): Move docs to new upm layout directory
+  - refactor: Move PackageTemplate files to new upm layout directory
+  - refactor: switch to static bool to test if EOSManager should unload EOS SDK or not.
+  - refactor: remove `LoadDelegatesWithReflection` `LoadDelegatesByHand`
+
+
+
+
+### Fixed
+
+- Configs/File IO
+  - fix(log,config) : Using default log levels if config file doesn't exist
+  - fix(fileIO) : remove redundant code
+  - fix(native,windows) : rebuild win32 versions to remain in sync with win64
+  - fix(native,config) : Correct log config reader to use Pascal case
+  - fix(android,fileIO) : remove file check that prevent file reading on android
+  - fix(log,config) : fix renamed/capitalized config entries
+
+- Package
+  - fix(tool,import) : prevent the editor from being stuck forever after finishing the copy
+  - fix(import) : updated description according to upm folder migration
+  - fix: resolve empty asmdef file warning via dummy file.
+  - fix: Add author details to package.json file.
+  - fix: Correct minor issue within eos package description where the proper meta files were not being copied correctly.
+  - fix: Add empty .gitignore files to Editor and Images directories, in-order to prevent Unity from trying to delete the associated meta files.
+  - fix(mac,eac) : modify the execution bit for mac anticheat integrity tool
+  - fix(eac,mac) : Mac EAC Settings template
+  - fix: Correct references to version of unity that is supported.
+  - fix: Change file select extension to asterisk.
+
+- Plugin
+  - fix(service,achievement) : prevent error when fetching product user ID prematurely
+  - fix: Correct implementation of ConfigEditor so that it can be defaulted to open and work correctly within the EOSUnitTestSettingsWindow.
+  - fix: Do not set the selected item during each Update(), as doing so makes it impossible for anything but the UIFirstSelected object to have focus.
+  - fix: Change implementation of EOSFileTransfer to have size properly set so determination of size is not dependent on the contents of the Data byte array.
+  - fix: Made leaderboard menu hidden, change to have SAMPLE_MENU_DEBUG off by default.
+  - fix(eosmanager): Remove other quit function, more verbose comments
+  - fix(eosmanager): Manage application shutdown only on Application.quitting
+  - fix: Correct the implementation of the SetSelected function within SampleMenu to properly determine and set the focused control in the menu.
+  - fix: Correct implementation of the function that gets the icon texture, by making sure that things are appropriately awaited.
+  - fix: Corrected implementation of the get and cache data function within AchievementsService.
+  - fix: Change UICustomInvitesMenu OnEnable function to actually be Awake.
+  - fix: Change get achievement icon texture to return null on failure, and log a warning in all circumstances of failure.
+  - fix: Ensure that the base implementation of the 'Hide()' function is called first thing.
+  - fix: Utilize built-in log function instead.
+  - fix: Change EOSService to have a default parameter value for the constructor.
+  - fix: Return EOSSessionsManager to implement the IEOSSubManager interface.
+  - fix: Fix implementations for logging out and logging in for eos services.
+  - fix: Change implementation to override and call base implementations for Show/Hide.
+  - fix: Correct icon loading logic for achievements to better support async.
+  - fix: Change to use events instead of lists of delegate instances.
+  - fix: Add proxy call from Hide/Show to call InternalHide/InternalShow.
+  - fix: Moved various field members for UIParent into base class SampleMenu field member 'UIParent.'
+  - fix: Move functionality within Start to properly be within the InternalAwake function for UIStoreMenu.
+  - fix: Update UISessionsMatchmakingMenu to properly hide and/or show when needed.
+  - fix: Move implementation of awake to base implementation.
+  - fix: Remove Awake implementation from UITitleStorageMenu, depending instead upon the base implementation of Awake().
+  - fix: Fold InternalUpdate behavior into base class implementation.
+  - fix: Move UIFirstSelected to base class.
+  - fix: Transition to using ISampleMenu as an abstract base class.
+  - fix: Make the RuntimeConfig a readonly struct.
+  - fix(eos,disable) : missing EOS_DISABLEs for newly added function calls or files
+  - fix(test,discord) : disable discord within functions on unsupported platforms
+  - fix: Place const declaration within proper compiler conditional branch so that it does not trigger a warning about an unused variable.
+  - fix: Remove obsolete flag from flags field member of SteamConfig.
+  - fix: Remove bootstrappy config parameters from runtimeconfig.
+  - fix: Remove unused 'using' statements.
+  - fix: Add check within ConfigEditor to make sure that Button config fields are only applied to field members of type Action.
+  - fix: Populate steamApiInterfaceVersionsArray regardless of the success or failure of the parsing of the version.
+  - fix: Clarify comment on Expand and Collapse functions within ConfigEditor.
+  - fix: Add comment to Button enum value within ConfigFieldType.
+  - fix: Remove field member from EOSSettingsWindow for the SteamConfig file, and any places within that class that reference it.
+  - fix: Make field member that was errantly public private.
+  - fix: Restore implementation of SteamManager to what it was before.
+  - fix: Add comments to functions defined within IConfigEditor.
+  - fix: Add comments to field members and functions that were missing them within ConfigEditor.
+  - fix: Remove unused code paths.
+  - fix: Further improvements to the user interface for changing EOS Plugin settings.
+  - fix(android): Remove config data parameter from configuresystemoptions
+  - fix: remove extra 'gc' from path for the EOS SDK in package description
+  - fix: Update input rendering for SteamConfig to put it into the proper editor window.
+  - fix: Move SteamConfig to Assets/Plugins/Source/Editor/Configs/ directory.
+  - fix: Rename SteamWorks_Utility to SteamWorksUtility in keeping with the naming conventions used within the project.
+  - fix(authentication): Theoretical OpenId re-authorization
+  - fix(authentication): Authentication Tests
+  - fix(discord): Retry auth on failure
+  - fix(steam): Steam App and Session authentication re-attempts authentication if token is expired
+  - fix(Discord): Refresh token is utilized when re-authing
+  - fix(tests): OnShutdown during TearDown
+  - fix: Consolidate test functionality of client sessions tests.
+  - fix: Properly organize tests into mirrored namespace, resolve issues that caused tests to fail (yay! tests helped!)
+  - fix: Add to gitignore to avoid init scene being added.
+  - fix: Correct the function used to convert byte array to string by providing the start index and the number of bytes to read.
+  - fix: Change function signature in EnumUtility to 'GetEnumerator'.
+  - fix: Re-disable the new runtime config via scripting defines.
+  - fix: Connect IntegratedPlatformManagementFlags field member to the RuntimeConfig data structure.
+  - fix(network): Explicit double value as 0.0, Settings debug logs warning when string is invalid
+  - fix (sessions): Non-Owners of Sessions Cannot Manage State
+  - fix: Change SandboxId to be string instead of Guid.
+  - fix: Move conversion from EOSConfig to RuntimeConfig from within EOSConfig to being an implicit conversion operator within RuntimeConfig.
+  - fix: Add comments to enum utility function.
+  - fix: Correct order of parsing operations.
+  - fix: Correct strings for descriptions of the flag values.
+  - fix: Remove unreferenced code path and member within PlatformConfig.
+  - fix: Add comment to IsEncryptionKeyValid() method.
+  - fix: Correct the format of comments for EOSConfig field members.
+  - fix: Correct signature used for configuring the override thread affinity values.
+  - fix: Re-introduce public methods to EOSManager that were removed.
+  - fix: Remove unused function that Loads EOSConfig into memory.
+  - fix: Correct comment to properly describe GetULongFromString method.
+  - fix: Correct scripting defines to support the EOS_DISABLE flag.
+  - fix: Move functionality to parse and validate Enum string flags to dedicated place for such tasks.
+  - fix: Move SafeTranslatorUtility to Core (from Editor) to fit with new asmdef files surrounding test assemblies.
+  - fix (sessions): Non-Owners of Sessions Cannot Manage State
+  - fix: Rename window and config, move both to appropriate place within the editor assembly.
+  - fix: Rename unit test configuration window for clarity, and disabled access to the unit test results parser.
+  - fix: add discard to render async call.
+  - fix: Add Serializable attribute to PackagingConfig class.
+  - fix: Remove call to set the window title for PluginVersionWindow, as it is explicitly set during the render content step.
+  - fix: Move DLL signing utility stuff into SigningUtility, remove SigningConfigEditor, after adding RenderInput support for List<string>
+  - fix(connect,apple) : correct modified class names, and remove unwanted MonoBehaviour
+  - fix (EOSManager): Don't use authToken if it is null
+
+- Git Workflow/Action
+  - fix: Change format of README.md so that multiple GitHub badges are rendered side-by side and left-aligned.
+  - fix: Change color of Unity version badge to be blue.
+  - fix: Add conditional so that if the unity version badge is already accurate the workflow does not fail.
+  - fix: Update the version of the checkout action to avoid warnings regarding running on a deprecated version of nodejs.
+
 ## [3.3.1] - 2024-07-30
 
 ### Fixed

--- a/com.playeveryware.eos/CHANGELOG.md
+++ b/com.playeveryware.eos/CHANGELOG.md
@@ -8,277 +8,152 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Git Actions
-  - feat: Create check-for-package-difference.yml
-  - feat: Add workflow to auto-update the unity version badge in README.md.
-
-- Plugin General
-  - feature (Sessions): Notifications in subregion
-  - feature (Sessions): Rearranged Functions inside Regions
-  - feature (Sessions): Organizing all functions in to #regions, unsorted otherwise
-  - feature (Sessions): Destroy session when owner destroys their session
-  - feature (Sessions): Refresh UI On Refresh Message
-  - feature (Sessions): Code review feedback implemented
-  - feature (sessions): Reworking Sample, P2P Communication Part
-  - feature(network): Implementing taskNetworkTimeoutSeconds
-  - feat: Make the EOSSettingsWindow aware of which build targets are available, showing platform-specific options for only those that are.
-  - feat: Implement function to enumerate the platforms that can be built against.
-  - feat: Add function to generate a RuntimeConfig struct from the values of an EOSConfig class.
-  - feat: Add RuntimeConfig struct that stores the totality of the configurable properties used by the plugin during runtime. Also add method to EnumUtility that supports decomposing a bitwise-operator combined enum value into it's constituent discrete components.
-  - feat: Add upm layout as upm to asset project
-  - feat: Upgrade targetted version of Unity.
-  - feat: Add ability configure the plugin to not unload the EOS SDK on shutdown.
-  - feature (Sessions): Notifications in subregion
-  - feature (Sessions): Rearranged Functions inside Regions
-  - feature (Sessions): Organizing all functions in to #regions, unsorted otherwise
-  - feature (Sessions): Destroy session when owner destroys their session
-  - feature (Session): Refresh UI On Refresh Message
-  - feature (sessions): Reworking Sample, P2P Communication Part
-
-- Unit Tests
-  - feat: Add unit tests for enum extensions.
-  - feat: Add unit tests of limited scope.
-  - tests(sessions): Create and search for sessions
-  - tests(login): Testing scene for auditing logins
+- feature (sessions): Reworking Sample, P2P Communication Part
+- feature(network): Implementing taskNetworkTimeoutSeconds
+- feat: Make the EOSSettingsWindow aware of which build targets are available, showing platform-specific options for only those that are.
+- feat: Implement function to enumerate the platforms that can be built against.
+- feat: Add function to generate a RuntimeConfig struct from the values of an EOSConfig class.
+- feat: Add RuntimeConfig struct that stores the totality of the configurable properties used by the plugin during runtime. Also add method to EnumUtility that supports decomposing a bitwise-operator combined enum value into it's constituent discrete components.
+- feat: Add upm layout as upm to asset project
+- feat: Upgrade targetted version of Unity.
+- feat: Add ability configure the plugin to not unload the EOS SDK on shutdown.
+- feat(sample,session): Major Session sample rework
+- tests: Add unit tests for enum extensions.
+- tests: Add unit tests of limited scope.
+- tests(sessions): Create and search for sessions
+- tests(login): Testing scene for auditing logins
 
 ### Changed
 
-- Git and LFS
-  - chore(macos): Store as binary, not text!
-  - chore(macOS): Putting MacOS Binaries in Git LFS
-  - chore: Update .gitattributes
-  - chore: Update Unity version badge to 2021.3.16f1
-
-- Release & Packaging
-  - chore(tool,import) : dispose result of async task to prevent warnings
-  - chore(lib,android) : remove unused android libs
-  - chore(sdk,source) : updated managed source for 1.16.3 hotfix
-  - chore(sdk,lib) : updated binaries for 1.16.3 hotfix
-  - chore(eac,tool) : Allow anticheat integrity tool file path to recognize executables with no extension
-  - chore: Update eos_package_description.json with new location of core code
-  - chore: Update eos_package_description.json with new location of EOS SDK.
-  - chore: Update eos_package_description.json with new location of docs
-  - chore: Update eos_package_description.json with new location of PackageTemplate files
-
-- Sample Rework
-  - rework(auth): Better variable names, namespace using moved, null propagation, 0-safe division
-  - rework(auth): Fix signature of UILoginMenu call
-  - rework(auth): Retry attempt count, remove "WithDiscord", camel case variable name
-  - rework(session): Fix to Test logic
-  - rework(sessions): Renamed Tests
-  - rework(sessions): Removing unused test function
-  - rework(session): Define Session in Out Parameter of Function Call
-  - rework(sessions): Demoting Error to Warning for no local Session found on informing owner
-  - rework(sessions): SessionsManager Callbacks
-  - rework(sessions): Reset and Init
-  - rework(sessions): OnShutDown removed, no longer mentioned in code comments
-  - rework(sessions): Decapitalize "R" in "Unregister"
-  - rework(sessions): `dirtyFlag` -> `IsDirty`
-  - rework(sessions): `dirtyFlag` -> `IsDirty`
-  - rework(sessions): Decapitalize "R" in "Unregister"
-  - rework(sessions): Rearranging Manager Code into Regions
-
-- Documents and Comments
-  - chore (Sessions): Standardizing comments inside EOSSessionsManager
-  - chore (EOSSessionsManager): Change constants to SCREAMING_SNAKE_CASE per standards
-  - chore(comment) : update comment to better describe config write use cases
-  - chore (Sessions): Standardizing comments inside EOSSessionsManager
-  - chore (EOSSessionsManager): Change constants to SCREAMING_SNAKE_CASE per standards
-  - chore (documentation, Lobby): Return values for messages documented, some wording changes to params
-  - chore (documentation, Lobby): Adding clarifying documentation mentioning subscription
-  - docs(sessions): Some touchup to Session capitalization
-  - docs (sessions): Responding to PR Feedback
-  - docs (Sessions): Slight commenting tweak
-  - docs (Sessions): Some additional commenting tweaks
-  - docs (Sessions): Continued effort in commenting everything
-  - docs (Sessions): More comments
-  - docs (sessions): Writing comments for functions and regions, part one
-  - docs(sessions): Some touchup to Session capitalization
-  - docs: update links to reference new doc location
-  - docs (Sessions): Commenting Functions
-  - docs (sessions): Responding to PR Feedback
-  - docs (Sessions): Slight commenting tweak
-  - docs (Sessions): Some additional commenting tweaks
-  - docs (Sessions): Continued effort in commenting everything
-  - doc: Add unity version badge to README.md.
-  - docs (Sessions): More comments
-  - docs: update the doc with some things that were missing
-  - docs (sessions): Writing comments for functions and regions, part one
-
-- Plugin Refactor
-  - refactor(docs): Move core code to new upm layout directory
-  - refactor(sessions): Capitalizing action that is a property
-  - refactor(sessions): Some additional comment cleaning
-  - refactor(sessions): Prefab instance link fix for friendsTabUI
-  - refactor(session): Remove vestigial invite, fix ui to update properly first call
-  - refactor(sessions): Juggling joined session better
-  - refactor(sessions): Join session after search without member variable
-  - refactor(sessions): All callers to AcknowledgeEventId cleaned up
-  - refactor(sessions): AcknowledgeEventId takes in UIEventId argument
-  - refactor(sessions): Access level back!
-  - refactor(sessions): Access level change
-  - refactor(sessions): Rename to OnFriendStateChanged
-  - refactor(sessions): MarkFriendsUIDirty => SetDirtyFlag
-  - refactor(sessions): Rename UIOnPresenceAffectingChange to OnPresenceChange
-  - refactor(sessions): Review feedback, comment moving, comment grammar fix
-  - refactor(sessions): `ownInvitationState` -> `OwnInvitationState`
-  - refactor(friends ui): Standardized parent handling dirty status instead of implementors
-  - refactor(sessions): Friend UI Refreshes
-  - refactor(sessions): Basic Session Invitation for Presence Sessions
-  - refactor(sessions): Added Friends UI to Sessions Scene
-  - refactor(sessions): Addressing code review feedback
-  - refactor(sessions): Session State Management
-  - refactor(sessions): Capitalizing action that is a property
-  - refactor(sessions): Some additional comment cleaning
-  - refactor(sessions): Prefab instance link fix for friendsTabUI
-  - refactor(session): Remove vestigial invite, fix ui to update properly first call
-  - refactor(sessions): Juggling joined session better
-  - refactor(sessions): Join session after search without member variable
-  - refactor(sessions): All callers to AcknowledgeEventId cleaned up
-  - refactor(eos_sdk): Move eos_sdk to new upm layout directory
-  - refactor(sessions): AcknowledgeEventId takes in UIEventId argument
-  - refactor(sessions): Access level back!
-  - refactor(sessions): Access level change
-  - refactor(sessions): Rename to OnFriendStateChanged
-  - refactor(sessions): MarkFriendsUIDirty => SetDirtyFlag
-  - refactor(sessions): Rename UIOnPresenceAffectingChange to OnPresenceChange
-  - refactor(sessions): Review feedback, comment moving, comment grammar fix
-  - refactor(sessions): `ownInvitationState` -> `OwnInvitationState`
-  - refactor(friends ui): Standardized parent handling dirty status instead of implementors
-  - refactor(sessions): Friend UI Refreshes
-  - refactor(sessions): Basic Session Invitation for Presence Sessions
-  - refactor(sessions): Added Friends UI to Sessions Scene
-  - refactor(sessions): Session State Management Mirroring
-  - refactor(sessions): Addressing code review feedback
-  - refactor(sessions): Session State Management
-  - refactor(docs): Move docs to new upm layout directory
-  - refactor: Move PackageTemplate files to new upm layout directory
-  - refactor: switch to static bool to test if EOSManager should unload EOS SDK or not.
-  - refactor: remove `LoadDelegatesWithReflection` `LoadDelegatesByHand`
-
-
-
+- chore(tool,import) : dispose result of async task to prevent warnings
+- chore(lib,android) : remove unused android libs
+- chore(sdk) : updated managed source for 1.16.3 hotfix
+- chore (documentation, Lobby): Adding clarifying documentation mentioning subscription
+- chore: add additional commenting
+- refactor(sessions): Capitalizing action that is a property
+- refactor(sessions): Some additional comment cleaning
+- refactor(sessions): Prefab instance link fix for friendsTabUI
+- refactor(session): Remove vestigial invite, fix ui to update properly first call
+- refactor(sessions): Juggling joined session better
+- refactor(sessions): Join session after search without member variable
+- refactor(sessions): All callers to AcknowledgeEventId cleaned up
+- refactor(sessions): AcknowledgeEventId takes in UIEventId argument
+- refactor(sessions): Rename to OnFriendStateChanged
+- refactor(sessions): MarkFriendsUIDirty => SetDirtyFlag
+- refactor(sessions): Rename UIOnPresenceAffectingChange to OnPresenceChange
+- refactor(sessions): `ownInvitationState` -> `OwnInvitationState`
+- refactor(friends ui): Standardized parent handling dirty status instead of implementors
+- refactor(sessions): Friend UI Refreshes
+- refactor(sessions): Basic Session Invitation for Presence Sessions
+- refactor(sessions): Added Friends UI to Sessions Scene
+- refactor(sessions): Addressing code review feedback
+- refactor(sessions): Session State Management
+- refactor(eos_sdk): Move eos_sdk to new upm layout directory
+- refactor: switch to static bool to test if EOSManager should unload EOS SDK or not.
+- refactor: remove `LoadDelegatesWithReflection` `LoadDelegatesByHand`
 
 ### Fixed
 
-- Configs/File IO
-  - fix(log,config) : Using default log levels if config file doesn't exist
-  - fix(fileIO) : remove redundant code
-  - fix(native,windows) : rebuild win32 versions to remain in sync with win64
-  - fix(native,config) : Correct log config reader to use Pascal case
-  - fix(android,fileIO) : remove file check that prevent file reading on android
-  - fix(log,config) : fix renamed/capitalized config entries
-
-- Package
-  - fix(tool,import) : prevent the editor from being stuck forever after finishing the copy
-  - fix(import) : updated description according to upm folder migration
-  - fix: resolve empty asmdef file warning via dummy file.
-  - fix: Add author details to package.json file.
-  - fix: Correct minor issue within eos package description where the proper meta files were not being copied correctly.
-  - fix: Add empty .gitignore files to Editor and Images directories, in-order to prevent Unity from trying to delete the associated meta files.
-  - fix(mac,eac) : modify the execution bit for mac anticheat integrity tool
-  - fix(eac,mac) : Mac EAC Settings template
-  - fix: Correct references to version of unity that is supported.
-  - fix: Change file select extension to asterisk.
-
-- Plugin
-  - fix(service,achievement) : prevent error when fetching product user ID prematurely
-  - fix: Correct implementation of ConfigEditor so that it can be defaulted to open and work correctly within the EOSUnitTestSettingsWindow.
-  - fix: Do not set the selected item during each Update(), as doing so makes it impossible for anything but the UIFirstSelected object to have focus.
-  - fix: Change implementation of EOSFileTransfer to have size properly set so determination of size is not dependent on the contents of the Data byte array.
-  - fix: Made leaderboard menu hidden, change to have SAMPLE_MENU_DEBUG off by default.
-  - fix(eosmanager): Remove other quit function, more verbose comments
-  - fix(eosmanager): Manage application shutdown only on Application.quitting
-  - fix: Correct the implementation of the SetSelected function within SampleMenu to properly determine and set the focused control in the menu.
-  - fix: Correct implementation of the function that gets the icon texture, by making sure that things are appropriately awaited.
-  - fix: Corrected implementation of the get and cache data function within AchievementsService.
-  - fix: Change UICustomInvitesMenu OnEnable function to actually be Awake.
-  - fix: Change get achievement icon texture to return null on failure, and log a warning in all circumstances of failure.
-  - fix: Ensure that the base implementation of the 'Hide()' function is called first thing.
-  - fix: Utilize built-in log function instead.
-  - fix: Change EOSService to have a default parameter value for the constructor.
-  - fix: Return EOSSessionsManager to implement the IEOSSubManager interface.
-  - fix: Fix implementations for logging out and logging in for eos services.
-  - fix: Change implementation to override and call base implementations for Show/Hide.
-  - fix: Correct icon loading logic for achievements to better support async.
-  - fix: Change to use events instead of lists of delegate instances.
-  - fix: Add proxy call from Hide/Show to call InternalHide/InternalShow.
-  - fix: Moved various field members for UIParent into base class SampleMenu field member 'UIParent.'
-  - fix: Move functionality within Start to properly be within the InternalAwake function for UIStoreMenu.
-  - fix: Update UISessionsMatchmakingMenu to properly hide and/or show when needed.
-  - fix: Move implementation of awake to base implementation.
-  - fix: Remove Awake implementation from UITitleStorageMenu, depending instead upon the base implementation of Awake().
-  - fix: Fold InternalUpdate behavior into base class implementation.
-  - fix: Move UIFirstSelected to base class.
-  - fix: Transition to using ISampleMenu as an abstract base class.
-  - fix: Make the RuntimeConfig a readonly struct.
-  - fix(eos,disable) : missing EOS_DISABLEs for newly added function calls or files
-  - fix(test,discord) : disable discord within functions on unsupported platforms
-  - fix: Place const declaration within proper compiler conditional branch so that it does not trigger a warning about an unused variable.
-  - fix: Remove obsolete flag from flags field member of SteamConfig.
-  - fix: Remove bootstrappy config parameters from runtimeconfig.
-  - fix: Remove unused 'using' statements.
-  - fix: Add check within ConfigEditor to make sure that Button config fields are only applied to field members of type Action.
-  - fix: Populate steamApiInterfaceVersionsArray regardless of the success or failure of the parsing of the version.
-  - fix: Clarify comment on Expand and Collapse functions within ConfigEditor.
-  - fix: Add comment to Button enum value within ConfigFieldType.
-  - fix: Remove field member from EOSSettingsWindow for the SteamConfig file, and any places within that class that reference it.
-  - fix: Make field member that was errantly public private.
-  - fix: Restore implementation of SteamManager to what it was before.
-  - fix: Add comments to functions defined within IConfigEditor.
-  - fix: Add comments to field members and functions that were missing them within ConfigEditor.
-  - fix: Remove unused code paths.
-  - fix: Further improvements to the user interface for changing EOS Plugin settings.
-  - fix(android): Remove config data parameter from configuresystemoptions
-  - fix: remove extra 'gc' from path for the EOS SDK in package description
-  - fix: Update input rendering for SteamConfig to put it into the proper editor window.
-  - fix: Move SteamConfig to Assets/Plugins/Source/Editor/Configs/ directory.
-  - fix: Rename SteamWorks_Utility to SteamWorksUtility in keeping with the naming conventions used within the project.
-  - fix(authentication): Theoretical OpenId re-authorization
-  - fix(authentication): Authentication Tests
-  - fix(discord): Retry auth on failure
-  - fix(steam): Steam App and Session authentication re-attempts authentication if token is expired
-  - fix(Discord): Refresh token is utilized when re-authing
-  - fix(tests): OnShutdown during TearDown
-  - fix: Consolidate test functionality of client sessions tests.
-  - fix: Properly organize tests into mirrored namespace, resolve issues that caused tests to fail (yay! tests helped!)
-  - fix: Add to gitignore to avoid init scene being added.
-  - fix: Correct the function used to convert byte array to string by providing the start index and the number of bytes to read.
-  - fix: Change function signature in EnumUtility to 'GetEnumerator'.
-  - fix: Re-disable the new runtime config via scripting defines.
-  - fix: Connect IntegratedPlatformManagementFlags field member to the RuntimeConfig data structure.
-  - fix(network): Explicit double value as 0.0, Settings debug logs warning when string is invalid
-  - fix (sessions): Non-Owners of Sessions Cannot Manage State
-  - fix: Change SandboxId to be string instead of Guid.
-  - fix: Move conversion from EOSConfig to RuntimeConfig from within EOSConfig to being an implicit conversion operator within RuntimeConfig.
-  - fix: Add comments to enum utility function.
-  - fix: Correct order of parsing operations.
-  - fix: Correct strings for descriptions of the flag values.
-  - fix: Remove unreferenced code path and member within PlatformConfig.
-  - fix: Add comment to IsEncryptionKeyValid() method.
-  - fix: Correct the format of comments for EOSConfig field members.
-  - fix: Correct signature used for configuring the override thread affinity values.
-  - fix: Re-introduce public methods to EOSManager that were removed.
-  - fix: Remove unused function that Loads EOSConfig into memory.
-  - fix: Correct comment to properly describe GetULongFromString method.
-  - fix: Correct scripting defines to support the EOS_DISABLE flag.
-  - fix: Move functionality to parse and validate Enum string flags to dedicated place for such tasks.
-  - fix: Move SafeTranslatorUtility to Core (from Editor) to fit with new asmdef files surrounding test assemblies.
-  - fix (sessions): Non-Owners of Sessions Cannot Manage State
-  - fix: Rename window and config, move both to appropriate place within the editor assembly.
-  - fix: Rename unit test configuration window for clarity, and disabled access to the unit test results parser.
-  - fix: add discard to render async call.
-  - fix: Add Serializable attribute to PackagingConfig class.
-  - fix: Remove call to set the window title for PluginVersionWindow, as it is explicitly set during the render content step.
-  - fix: Move DLL signing utility stuff into SigningUtility, remove SigningConfigEditor, after adding RenderInput support for List<string>
-  - fix(connect,apple) : correct modified class names, and remove unwanted MonoBehaviour
-  - fix (EOSManager): Don't use authToken if it is null
-
-- Git Workflow/Action
-  - fix: Change format of README.md so that multiple GitHub badges are rendered side-by side and left-aligned.
-  - fix: Change color of Unity version badge to be blue.
-  - fix: Add conditional so that if the unity version badge is already accurate the workflow does not fail.
-  - fix: Update the version of the checkout action to avoid warnings regarding running on a deprecated version of nodejs.
+- fix(log,config) : Using default log levels if config file doesn't exist
+- fix(fileIO) : remove redundant code
+- fix(native,windows) : rebuild win32 versions to remain in sync with win64
+- fix(native,config) : Correct log config reader to use Pascal case
+- fix(android,fileIO) : remove file check that prevent file reading on android
+- fix(log,config) : fix renamed/capitalized config entries
+- fix(tool,import) : prevent the editor from being stuck forever after finishing the copy
+- fix(import) : updated description according to upm folder migration
+- fix: resolve empty asmdef file warning via dummy file.
+- fix: Add author details to package.json file.
+- fix: Correct minor issue within eos package description where the proper meta files were not being copied correctly.
+- fix: Add empty .gitignore files to Editor and Images directories, in-order to prevent Unity from trying to delete the associated meta files.
+- fix(mac,eac) : modify the execution bit for mac anticheat integrity tool
+- fix(eac,mac) : Mac EAC Settings template
+- fix: Correct references to version of unity that is supported.
+- fix: Change file select extension to asterisk.
+- fix(sample,achievement): General fixes on achievement scene
+- fix(eac,tool) : Allow anticheat integrity tool file path to recognize executables with no extension
+- fix(service,achievement) : prevent error when fetching product user ID prematurely
+- fix: Correct implementation of ConfigEditor so that it can be defaulted to open and work correctly within the EOSUnitTestSettingsWindow.
+- fix: Do not set the selected item during each Update(), as doing so makes it impossible for anything but the UIFirstSelected object to have focus.
+- fix: Change implementation of EOSFileTransfer to have size properly set so determination of size is not dependent on the contents of the Data byte array.
+- fix: Made leaderboard menu hidden, change to have SAMPLE_MENU_DEBUG off by default.
+- fix(eosmanager): Manage application shutdown only on Application.quitting
+- fix: Correct the implementation of the SetSelected function within SampleMenu to properly determine and set the focused control in the menu.
+- fix: Correct implementation of the function that gets the icon texture, by making sure that things are appropriately awaited.
+- fix: Corrected implementation of the get and cache data function within AchievementsService.
+- fix: Change UICustomInvitesMenu OnEnable function to actually be Awake.
+- fix: Change get achievement icon texture to return null on failure, and log a warning in all circumstances of failure.
+- fix: Ensure that the base implementation of the 'Hide()' function is called first thing.
+- fix: Utilize built-in log function instead.
+- fix: Change EOSService to have a default parameter value for the constructor.
+- fix: Return EOSSessionsManager to implement the IEOSSubManager interface.
+- fix: Fix implementations for logging out and logging in for eos services.
+- fix: Change implementation to override and call base implementations for Show/Hide.
+- fix: Correct icon loading logic for achievements to better support async.
+- fix: Change to use events instead of lists of delegate instances.
+- fix: Add proxy call from Hide/Show to call InternalHide/InternalShow.
+- fix: Moved various field members for UIParent into base class SampleMenu field member 'UIParent.'
+- fix: Move functionality within Start to properly be within the InternalAwake function for UIStoreMenu.
+- fix: Update UISessionsMatchmakingMenu to properly hide and/or show when needed.
+- fix: Move implementation of awake to base implementation.
+- fix: Remove Awake implementation from UITitleStorageMenu, depending instead upon the base implementation of Awake().
+- fix: Fold InternalUpdate behavior into base class implementation.
+- fix: Move UIFirstSelected to base class.
+- fix: Transition to using ISampleMenu as an abstract base class.
+- fix: Make the RuntimeConfig a readonly struct.
+- fix(eos,disable) : missing EOS_DISABLEs for newly added function calls or files
+- fix(test,discord) : disable discord within functions on unsupported platforms
+- fix: Place const declaration within proper compiler conditional branch so that it does not trigger a warning about an unused variable.
+- fix: Remove obsolete flag from flags field member of SteamConfig.
+- fix: Remove bootstrappy config parameters from runtimeconfig.
+- fix: Remove unused 'using' statements.
+- fix: Add check within ConfigEditor to make sure that Button config fields are only applied to field members of type Action.
+- fix: Populate steamApiInterfaceVersionsArray regardless of the success or failure of the parsing of the version.
+- fix: Remove field member from EOSSettingsWindow for the SteamConfig file, and any places within that class that reference it.
+- fix: Make field member that was errantly public private.
+- fix: Restore implementation of SteamManager to what it was before.
+- fix: Remove unused code paths.
+- fix: Further improvements to the user interface for changing EOS Plugin settings.
+- fix(android): Remove config data parameter from configuresystemoptions
+- fix: remove extra 'gc' from path for the EOS SDK in package description
+- fix: Update input rendering for SteamConfig to put it into the proper editor window.
+- fix: Move SteamConfig to Assets/Plugins/Source/Editor/Configs/ directory.
+- fix: Rename SteamWorks_Utility to SteamWorksUtility in keeping with the naming conventions used within the project.
+- fix(authentication): Theoretical OpenId re-authorization
+- fix(authentication): Authentication Tests
+- fix(discord): Retry auth on failure
+- fix(steam): Steam App and Session authentication re-attempts authentication if token is expired
+- fix(Discord): Refresh token is utilized when re-authing
+- fix(tests): OnShutdown during TearDown
+- fix: Consolidate test functionality of client sessions tests.
+- fix: Properly organize tests into mirrored namespace, resolve issues that caused tests to fail (yay! tests helped!)
+- fix: Add to gitignore to avoid init scene being added.
+- fix: Correct the function used to convert byte array to string by providing the start index and the number of bytes to read.
+- fix: Change function signature in EnumUtility to 'GetEnumerator'.
+- fix: Re-disable the new runtime config via scripting defines.
+- fix: Connect IntegratedPlatformManagementFlags field member to the RuntimeConfig data structure.
+- fix(network): Explicit double value as 0.0, Settings debug logs warning when string is invalid
+- fix (sessions): Non-Owners of Sessions Cannot Manage State
+- fix: Change SandboxId to be string instead of Guid.
+- fix: Move conversion from EOSConfig to RuntimeConfig from within EOSConfig to being an implicit conversion operator within RuntimeConfig.
+- fix: Correct order of parsing operations.
+- fix: Correct strings for descriptions of the flag values.
+- fix: Remove unreferenced code path and member within PlatformConfig.
+- fix: Correct signature used for configuring the override thread affinity values.
+- fix: Re-introduce public methods to EOSManager that were removed.
+- fix: Remove unused function that Loads EOSConfig into memory.
+- fix: Correct scripting defines to support the EOS_DISABLE flag.
+- fix: Move functionality to parse and validate Enum string flags to dedicated place for such tasks.
+- fix: Move SafeTranslatorUtility to Core (from Editor) to fit with new asmdef files surrounding test assemblies.
+- fix (sessions): Non-Owners of Sessions Cannot Manage State
+- fix: Rename window and config, move both to appropriate place within the editor assembly.
+- fix: Rename unit test configuration window for clarity, and disabled access to the unit test results parser.
+- fix: add discard to render async call.
+- fix: Add Serializable attribute to PackagingConfig class.
+- fix: Remove call to set the window title for PluginVersionWindow, as it is explicitly set during the render content step.
+- fix: Move DLL signing utility stuff into SigningUtility, remove SigningConfigEditor, after adding RenderInput support for List<string>
+- fix(connect,apple) : correct modified class names, and remove unwanted MonoBehaviour
+- fix (EOSManager): Don't use authToken if it is null
 
 ## [3.3.1] - 2024-07-30
 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -752,6 +752,12 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 var logLevelList = LogLevelUtility.LogLevelList;
 
+                if (logLevelList == null)
+                {
+                    SetLogLevel(LogCategory.AllCategories, LogLevel.Info);
+                    return;
+
+                }
                 for (int logCategoryIndex = 0; logCategoryIndex < logLevelList.Count; logCategoryIndex++)
                 {
                     SetLogLevel((LogCategory)logCategoryIndex, logLevelList[logCategoryIndex]);

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -756,8 +756,8 @@ namespace PlayEveryWare.EpicOnlineServices
                 {
                     SetLogLevel(LogCategory.AllCategories, LogLevel.Info);
                     return;
-
                 }
+
                 for (int logCategoryIndex = 0; logCategoryIndex < logLevelList.Count; logCategoryIndex++)
                 {
                     SetLogLevel((LogCategory)logCategoryIndex, logLevelList[logCategoryIndex]);

--- a/com.playeveryware.eos/Runtime/Core/Utility/LogLevelUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/LogLevelUtility.cs
@@ -43,7 +43,22 @@ namespace PlayEveryWare.EpicOnlineServices
         {
             get
             {
-                LogLevelConfig logLevelConfig = Config.Get<LogLevelConfig>();
+                LogLevelConfig logLevelConfig = null;
+                try
+                {
+                    logLevelConfig = Config.Get<LogLevelConfig>();
+                }
+                catch (System.IO.FileNotFoundException)
+                {
+                    Debug.Log($"Log level config does not exist, using default");
+                    return null; 
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogWarning($"{exception}");
+                    Debug.Log($"Exception when reading log level config, using default");
+                    return null;
+                }
 
                 List<LogLevel> logLevels = new List<LogLevel>();
                 for (int i = 0; i < LogCategoryStringArray.Length - 1; i++)

--- a/com.playeveryware.eos/Runtime/Core/Utility/LogLevelUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/LogLevelUtility.cs
@@ -55,7 +55,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 catch (Exception exception)
                 {
-                    Debug.LogWarning($"{exception}");
+                    Debug.LogException(exception);
                     Debug.Log($"Exception when reading log level config, using default");
                     return null;
                 }

--- a/com.playeveryware.eos/package.json
+++ b/com.playeveryware.eos/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.playeveryware.eos",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "unity": "2021.3",
     "unityRelease": "16f1",
     "author": {
@@ -36,6 +36,6 @@
         }
     ],
     "com_playeveryware": {
-        "git_build_sha": "9b9229325c93dd7e81461fde387ed5ef012349ec"
+        "git_build_sha": "74e64b0b0a78d9c7e428508d68eb97d2af8e0836"
     }
 }


### PR DESCRIPTION
fix(log,config) : Using default log levels if config file doesn't exist
User were met with initialize errors when log level configs don't exist. It is caused by uncaught exceptions during file reading, leading to EOSManager.Init ceasing to complete. This fix catches those exceptions and continues the init using default log levels


#EOS-2037