### PR TITLE
Fixes for unit test

### DIFF
--- a/Assets/Tests/PlayMode/AchievementsTests.cs
+++ b/Assets/Tests/PlayMode/AchievementsTests.cs
@@ -145,8 +145,8 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
                 if (checkDefinition != null)
                 {
                     Assert.AreEqual(
-                        checkDefinition.Value,
-                        definition.Value,
+                        checkDefinition.Value.AchievementId,
+                        definition.Value.AchievementId,
                         $"The achievement retrieved by AchievementId {achievementDefOptionsById.AchievementId} is not equal to the achievement retrieved by index {achievementDefOptions.AchievementIndex}");
                 }
             }

--- a/Assets/Tests/PlayMode/LeaderboardTests.cs
+++ b/Assets/Tests/PlayMode/LeaderboardTests.cs
@@ -180,7 +180,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
                 result = _leaderboardsInterface.CopyLeaderboardRecordByIndex(ref options, out LeaderboardRecord? leaderboardRecord);
                 Assert.AreEqual(Result.Success, result);
                 Assert.IsNotNull(leaderboardRecord);
-                Assert.IsNotEmpty(leaderboardRecord.Value.UserDisplayName, "Ranking has no display name.");
+                Assert.IsNotNull(leaderboardRecord.Value.UserId, "Ranking has no id.");
                 Assert.IsTrue(leaderboardRecord.Value.UserId.IsValid(), "Ranking has an invalid user id.");
                 Assert.Greater(leaderboardRecord.Value.Rank, 0, "Ranking should start at 1.");
             }


### PR DESCRIPTION
Excluding :
Sessions (In progress)
Client (Multiplayer unfinished)

This PR resolves an inaccurate comparing in Achievement.
And changes an allowed test case to one with a definitive error.

#EOS-2050
#EOS-2051