### PR TITLE
feat(lobby): Indicate lobby changed event kind

### DIFF
--- a/Assets/Scripts/EOSEACLobbyManager.cs
+++ b/Assets/Scripts/EOSEACLobbyManager.cs
@@ -233,7 +233,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
         }
 
-        private void OnLobbyChanged()
+        private void OnLobbyChanged(LobbyChangedEvent lobbyChangedEvent)
         {
             string previousLobbyId = CurrentLobbyId;
             var currentLobby = LobbyManager.GetCurrentLobby();

--- a/Assets/Scripts/EOSEACLobbyManager.cs
+++ b/Assets/Scripts/EOSEACLobbyManager.cs
@@ -62,7 +62,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (AntiCheatManager.IsAntiCheatAvailable())
             {
-                LobbyManager.AddNotifyLobbyChange(OnLobbyChanged);
+                LobbyManager.OnLobbyChanged += OnLobbyChanged;
                 LobbyManager.AddNotifyLobbyUpdate(OnLobbyUpdated);
                 LobbyManager.AddNotifyMemberUpdateReceived(OnMemberUpdated);
 
@@ -233,7 +233,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
         }
 
-        private void OnLobbyChanged(LobbyChangedEvent lobbyChangedEvent)
+        private void OnLobbyChanged(string lobbyId, LobbyChangeType lobbyChangedEvent)
         {
             string previousLobbyId = CurrentLobbyId;
             var currentLobby = LobbyManager.GetCurrentLobby();

--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -29,6 +29,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
     using Epic.OnlineServices.Lobby;
     using Epic.OnlineServices.RTC;
     using Epic.OnlineServices.RTCAudio;
+    public enum LobbyChangedEvent { Create, Join, Leave, Kicked }
 
     /// <summary>
     /// Class represents all Lobby properties
@@ -473,7 +474,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public delegate void OnMemberUpdateCallback(string LobbyId, ProductUserId MemberId);
 
         private List<OnMemberUpdateCallback> MemberUpdateCallbacks;
-        private List<Action> LobbyChangeCallbacks;
+        private List<Action<LobbyChangedEvent>> LobbyChangeCallbacks;
         private List<Action> LobbyUpdateCallbacks;
 
         private EOSUserInfoManager UserInfoManager;
@@ -497,7 +498,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             LobbySearchCallback = null;
 
             MemberUpdateCallbacks = new List<OnMemberUpdateCallback>();
-            LobbyChangeCallbacks = new List<Action>();
+            LobbyChangeCallbacks = new List<Action<LobbyChangedEvent>>();
             LobbyUpdateCallbacks = new List<Action>();
         }
 
@@ -1338,11 +1339,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 LobbyCreatedCallback?.Invoke(Result.Success);
 
-                OnCurrentLobbyChanged();
+                OnCurrentLobbyChanged(LobbyChangedEvent.Create);
             }
         }
 
-        private void OnCurrentLobbyChanged()
+        private void OnCurrentLobbyChanged(LobbyChangedEvent lobbyChangedEvent)
         {
             if (CurrentLobby.IsValid())
             {
@@ -1350,7 +1351,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
             foreach (var callback in LobbyChangeCallbacks)
             {
-                callback?.Invoke();
+                callback?.Invoke(lobbyChangedEvent);
             }
         }
 
@@ -1920,7 +1921,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 CurrentLobby.Clear();
                 _Dirty = true;
 
-                OnCurrentLobbyChanged();
+                OnCurrentLobbyChanged(LobbyChangedEvent.Kicked);
             }
         }
 
@@ -2066,12 +2067,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// The callback will only run if a listener is subscribed, which is done in <see cref="SubscribeToLobbyUpdates"/>.
         /// </summary>
         /// <param name="Callback">Callback to receive notification when lobby is changed</param>
-        public void AddNotifyLobbyChange(Action Callback)
+        public void AddNotifyLobbyChange(Action<LobbyChangedEvent> Callback)
         {
             LobbyChangeCallbacks.Add(Callback);
         }
 
-        public void RemoveNotifyLobbyChange(Action Callback)
+        public void RemoveNotifyLobbyChange(Action<LobbyChangedEvent> Callback)
         {
             LobbyChangeCallbacks.Remove(Callback);
         }
@@ -2574,7 +2575,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             JoinLobbyCallback?.Invoke(Result.Success);
 
-            OnCurrentLobbyChanged();
+            OnCurrentLobbyChanged(LobbyChangedEvent.Join);
         }
 
         private void OnLeaveLobbyCompleted(ref LeaveLobbyCallbackInfo data)
@@ -2601,7 +2602,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
                 LeaveLobbyCallback?.Invoke(Result.Success);
 
-                OnCurrentLobbyChanged();
+                OnCurrentLobbyChanged(LobbyChangedEvent.Leave);
             }
         }
 

--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -483,13 +483,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private List<OnMemberUpdateCallback> MemberUpdateCallbacks;
 
 
-        public delegate void LobbyChangedEventHandler(string lobbyId, LobbyChangeType typeOfChange);
+        public delegate void LobbyChanged(string lobbyId, LobbyChangeType typeOfChange);
 
         /// <summary>
         /// Event that is run whenever the local user's relationship to a Lobby has been changed.
         /// Indicates the Lobby that the change relates to.
         /// </summary>
-        public event LobbyChangedEventHandler OnLobbyChanged;
+        public event LobbyChanged OnLobbyChanged;
 
         private List<Action> LobbyUpdateCallbacks;
 

--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -29,6 +29,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
     using Epic.OnlineServices.Lobby;
     using Epic.OnlineServices.RTC;
     using Epic.OnlineServices.RTCAudio;
+	
     public enum LobbyChangedEvent { Create, Join, Leave, Kicked }
 
     /// <summary>


### PR DESCRIPTION
This adds a way for subscribers of the lobby changing event to know what kind of event has occurred.

This is a pull request split from: https://github.com/PlayEveryWare/eos_plugin_for_unity/pull/862

There is consideration if we instead of having this enum, want to use four different events. That discussion should happen here.

Original work from @Ermelious 