### PR TITLE
fix: EOS Disable in AuthenticationListener

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/AuthenticationListener.cs
+++ b/com.playeveryware.eos/Runtime/Core/AuthenticationListener.cs
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices;
@@ -165,3 +167,5 @@ namespace PlayEveryWare.EpicOnlineServices
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Fixes the EOS_DISABLE define for AuthenticationListener by excluding it entirely when EOS_DISABLE is defined.

#EOS-2057