### PR TITLE
(fix): Remove async file read logs

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -507,10 +507,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             // appropriate.
             try
             {
-                Debug.Log("Starting async file read");
-                var result = await File.ReadAllTextAsync(path);
-                Debug.Log("Finished async file read");
-                return result;
+                return await File.ReadAllTextAsync(path);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This minor PR is to remove a log statement that was errantly left in from the work done to repair the async calls to file reading. It currently clogs up the log window pretty badly.

#EOS-2060