### PR TITLE
fix: EOSManager to use print for all logs

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -325,6 +325,18 @@ namespace PlayEveryWare.EpicOnlineServices
                 Debug.Log(toPrint);
             }
 
+            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
+            static void printError(string toPrint)
+            {
+                Debug.LogError(toPrint);
+            }
+
+            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
+            static void printWarning(string toPrint)
+            {
+                Debug.LogWarning(toPrint);
+            }
+
             //-------------------------------------------------------------------------
             public void AddConnectLoginListener(IEOSOnConnectLogin connectLogin)
             {

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -320,21 +320,9 @@ namespace PlayEveryWare.EpicOnlineServices
 
             //-------------------------------------------------------------------------
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void print(string toPrint)
+            internal static void print(string toPrint, LogType type = LogType.Log)
             {
                 Debug.Log(toPrint);
-            }
-
-            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void printError(string toPrint)
-            {
-                Debug.LogError(toPrint);
-            }
-
-            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void printWarning(string toPrint)
-            {
-                Debug.LogWarning(toPrint);
             }
 
             //-------------------------------------------------------------------------
@@ -490,8 +478,9 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else
                 {
-                    printWarning(
-                        "EOS config data does not contain a valid encryption key which is needed for Player Data Storage and Title Storage.");
+                    print(
+                        "EOS config data does not contain a valid encryption key which is needed for Player Data Storage and Title Storage.",
+                        LogType.Warning);
                 }
 
                 platformOptions.options.OverrideCountryCode = null;
@@ -1436,7 +1425,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (createPresenceModificationResult != Result.Success)
                 {
-                    printError("Unable to create presence modfication handle");
+                    print("Unable to create presence modfication handle", LogType.Error);
                 }
 
                 var presenceModificationSetStatUsOptions = new PresenceModificationSetStatusOptions();
@@ -1445,7 +1434,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (setStatusResult != Result.Success)
                 {
-                    printError("unable to set status");
+                    print("unable to set status", LogType.Error);
                 }
 
                 var richTextOptions = new PresenceModificationSetRawRichTextOptions();
@@ -1459,7 +1448,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 {
                     if (callbackInfo.ResultCode != Result.Success)
                     {
-                        printError("Unable to set presence: " + callbackInfo.ResultCode);
+                        print("Unable to set presence: " + callbackInfo.ResultCode, LogType.Error);
                     }
                 });
             }
@@ -1513,8 +1502,9 @@ namespace PlayEveryWare.EpicOnlineServices
                     {
                         if (deletePersistentAuthCallbackInfo.ResultCode != Result.Success)
                         {
-                            printError("Unable to delete persistent token, Result : " +
-                                           deletePersistentAuthCallbackInfo.ResultCode);
+                            print("Unable to delete persistent token, Result : " +
+                                           deletePersistentAuthCallbackInfo.ResultCode, 
+                                           LogType.Error);
                         }
                         else
                         {
@@ -1660,8 +1650,9 @@ namespace PlayEveryWare.EpicOnlineServices
                     Result result = GetEOSPlatformInterface().SetApplicationStatus(newStatus);
                     if (result != Result.Success)
                     {
-                        printError(
-                            $"EOSSingleton.SetEOSApplicationStatus: Error setting EOS application status (Result = {result})");
+                        print(
+                            $"EOSSingleton.SetEOSApplicationStatus: Error setting EOS application status (Result = {result})",
+                            LogType.Error);
                     }
                 }
             }

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -325,6 +325,18 @@ namespace PlayEveryWare.EpicOnlineServices
                 Debug.Log(toPrint);
             }
 
+            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
+            static void printError(string toPrint)
+            {
+                Debug.LogError(toPrint);
+            }
+
+            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
+            static void printWarning(string toPrint)
+            {
+                Debug.LogWarning(toPrint);
+            }
+
             //-------------------------------------------------------------------------
             public void AddConnectLoginListener(IEOSOnConnectLogin connectLogin)
             {
@@ -478,7 +490,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else
                 {
-                    Debug.LogWarning(
+                    printWarning(
                         "EOS config data does not contain a valid encryption key which is needed for Player Data Storage and Title Storage.");
                 }
 
@@ -633,7 +645,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     }
                 }
 
-                Debug.Log($"EOSManager::Init: InitializePlatformInterface: initResult = {initResult}");
+                print($"EOSManager::Init: InitializePlatformInterface: initResult = {initResult}");
 
 
                 s_hasInitializedPlatform = true;
@@ -666,7 +678,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 IPlatformSpecifics platformSpecifics = EOSManagerPlatformSpecificsSingleton.Instance;
                 if (platformSpecifics != null)
                 {
-                    Debug.Log("EOSManager: Registering for platform-specific notifications");
+                    print("EOSManager: Registering for platform-specific notifications");
                     platformSpecifics.RegisterForPlatformNotifications();
                 }
             }
@@ -809,7 +821,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 var dateTime = DateTime.Now;
                 var messageCategory = message.Category.Length == 0 ? new Utf8String() : message.Category;
 
-                Debug.LogFormat(null, "{0:O} {1}({2}): {3}", dateTime, messageCategory, message.Level, message.Message);
+                print(string.Format("{0:O} {1}({2}): {3}", dateTime, messageCategory, message.Level, message.Message));
             }
 
             //-------------------------------------------------------------------------
@@ -1424,7 +1436,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (createPresenceModificationResult != Result.Success)
                 {
-                    Debug.LogError("Unable to create presence modfication handle");
+                    printError("Unable to create presence modfication handle");
                 }
 
                 var presenceModificationSetStatUsOptions = new PresenceModificationSetStatusOptions();
@@ -1433,7 +1445,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (setStatusResult != Result.Success)
                 {
-                    Debug.LogError("unable to set status");
+                    printError("unable to set status");
                 }
 
                 var richTextOptions = new PresenceModificationSetRawRichTextOptions();
@@ -1447,7 +1459,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 {
                     if (callbackInfo.ResultCode != Result.Success)
                     {
-                        Debug.LogError("Unable to set presence: " + callbackInfo.ResultCode);
+                        printError("Unable to set presence: " + callbackInfo.ResultCode);
                     }
                 });
             }
@@ -1501,12 +1513,12 @@ namespace PlayEveryWare.EpicOnlineServices
                     {
                         if (deletePersistentAuthCallbackInfo.ResultCode != Result.Success)
                         {
-                            Debug.LogError("Unable to delete persistent token, Result : " +
+                            printError("Unable to delete persistent token, Result : " +
                                            deletePersistentAuthCallbackInfo.ResultCode);
                         }
                         else
                         {
-                            Debug.Log("Successfully deleted persistent token");
+                            print("Successfully deleted persistent token");
                         }
                     });
             }
@@ -1585,18 +1597,18 @@ namespace PlayEveryWare.EpicOnlineServices
                     // Not doing this in the editor, because it doesn't seem to be an issue there
 #if !UNITY_EDITOR_OSX
 #if !UNITY_EDITOR
-                    Debug.Log("Running garbage collection.");
+                    print("Running garbage collection.");
                     System.GC.Collect();
 
-                    Debug.Log("Waiting for pending finalizers.");
+                    print("Waiting for pending finalizers.");
                     System.GC.WaitForPendingFinalizers();
 #endif
-                    Debug.Log("Releasing the EOS Platform Interface.");
+                    print("Releasing the EOS Platform Interface.");
                     GetEOSPlatformInterface()?.Release();
 
                     if (s_eosUnloadSDKOnShutdown)
                     {
-                        Debug.Log("Shutting down the platform interface.");
+                        print("Shutting down the platform interface.");
                         ShutdownPlatformInterface();
                     }
 
@@ -1607,11 +1619,11 @@ namespace PlayEveryWare.EpicOnlineServices
 #if UNITY_EDITOR
                     if (s_eosUnloadSDKOnShutdown)
                     {
-                        Debug.Log("Unloading all libraries.");
+                        print("Unloading all libraries.");
                         UnloadAllLibraries();
                     }
 #endif
-                    Debug.Log("Finished shutdown.");
+                    print("Finished shutdown.");
                     s_state = EOSState.Shutdown;
                 }
             }
@@ -1648,7 +1660,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     Result result = GetEOSPlatformInterface().SetApplicationStatus(newStatus);
                     if (result != Result.Success)
                     {
-                        Debug.LogError(
+                        printError(
                             $"EOSSingleton.SetEOSApplicationStatus: Error setting EOS application status (Result = {result})");
                     }
                 }

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -325,18 +325,6 @@ namespace PlayEveryWare.EpicOnlineServices
                 Debug.Log(toPrint);
             }
 
-            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void printError(string toPrint)
-            {
-                Debug.LogError(toPrint);
-            }
-
-            [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void printWarning(string toPrint)
-            {
-                Debug.LogWarning(toPrint);
-            }
-
             //-------------------------------------------------------------------------
             public void AddConnectLoginListener(IEOSOnConnectLogin connectLogin)
             {

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -326,13 +326,13 @@ namespace PlayEveryWare.EpicOnlineServices
             }
 
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            static void printError(string toPrint)
+            internal static void printError(string toPrint)
             {
                 Debug.LogError(toPrint);
             }
 
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            static void printWarning(string toPrint)
+            internal static void printWarning(string toPrint)
             {
                 Debug.LogWarning(toPrint);
             }

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -322,7 +322,7 @@ namespace PlayEveryWare.EpicOnlineServices
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
             internal static void print(string toPrint, LogType type = LogType.Log)
             {
-                Debug.Log(toPrint);
+                Debug.LogFormat(type, LogOption.None, null, toPrint);
             }
 
             //-------------------------------------------------------------------------

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -320,19 +320,19 @@ namespace PlayEveryWare.EpicOnlineServices
 
             //-------------------------------------------------------------------------
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            static void print(string toPrint)
+            internal static void print(string toPrint)
             {
                 Debug.Log(toPrint);
             }
 
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            static void printError(string toPrint)
+            internal static void printError(string toPrint)
             {
                 Debug.LogError(toPrint);
             }
 
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            static void printWarning(string toPrint)
+            internal static void printWarning(string toPrint)
             {
                 Debug.LogWarning(toPrint);
             }
@@ -1883,15 +1883,15 @@ namespace PlayEveryWare.EpicOnlineServices
             if (ShouldShutdownOnApplicationQuit)
             {
 #if EOS_CAN_SHUTDOWN
-                print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is true, so the EOS SDK will now be shut down fully.");
+                EOSSingleton.print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is true, so the EOS SDK will now be shut down fully.");
 #else
-                print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is false, so the EOS SDK will not be shut down.");
+                EOSSingleton.print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is false, so the EOS SDK will not be shut down.");
 #endif
                 Instance.OnShutdown();
             }
             else
             {
-                print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
+                EOSSingleton.print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
             }
         }
 #endif


### PR DESCRIPTION
Moves all EOSManager `Debug.Log` calls under the `EOSSingleton.print` functions, which are conditionally excluded from builds. Made a warning/error version, and gave them the internal accessor.

Bonus; Can anyone think of a better name than `print`, etc? It turns out that's already a function name for `MonoBehaviours`, and I had originally accidentally used that instead of the thing I meant to.

#EOS-1785