### PR TITLE
documentation: Document Friends Query Requiring Consent

### DIFF
--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -34,6 +34,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
     using Epic.OnlineServices.Friends;
     using Epic.OnlineServices.Presence;
 
+    /// <summary>
+    /// Provides an implementation of requesting friends from the EOS SDK, arranging, and displaying the information.
+    /// [!NOTE]: Only friends that have consented to the currently running application will appear when queried as friends.
+    /// See [Epic's documentation on the Friends Interface](https://dev.epicgames.com/docs/epic-account-services/eos-friends-interface#retrieving-and-caching-the-friends-list)
+    /// for more information.
+    /// </summary>
     public class UIFriendsMenu : SampleMenu
     {
         [Header("Friends UI")]

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_netcode_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_netcode_walkthrough.md
@@ -17,3 +17,5 @@ Upon import, the `com.unity.netcode.gameobjects` package that this scene require
 > [!NOTE]
 > See [Epic's documentation on the P2P interface](https://dev.epicgames.com/docs/game-services/p-2-p) for more information.
 
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_walkthrough.md
@@ -10,3 +10,6 @@ The Peer 2 Peer demo showcases the peer 2 peer interface. This is done through a
 
 > [!NOTE]
 > See [Epic's Peer 2 Peer documentation](https://dev.epicgames.com/docs/game-services/p-2-p) for more information.
+
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/auth&friends_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/auth&friends_walkthrough.md
@@ -10,3 +10,6 @@ This demo showcases an implementation of the friends list into a game UI. The pa
 
 > [!NOTE]
 > See [Epic's documentation on the Auth interface](https://dev.epicgames.com/docs/epic-account-services/auth) as well as [Epic's documentation on the Friends interface](https://dev.epicgames.com/docs/epic-account-services/eos-friends-interface) for more information on each respective topic.
+
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/customInvites_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/customInvites_walkthrough.md
@@ -13,3 +13,6 @@ This demo showcases the custom invite functionality allowing for messaging with 
 
 > [!NOTE] 
 > See [Epic's documentation on the Custom Invites interface](https://dev.epicgames.com/docs/game-services/custom-invites-interface) for more information.
+
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/lobbies_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/lobbies_walkthrough.md
@@ -42,3 +42,6 @@ This demo showcases the lobby and includes a voice chat interface in a combined 
 
 > [!NOTE]
 > See [Epic's documentation on the lobby interface](https://dev.epicgames.com/docs/game-services/lobbies) for more information.
+
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/player_reports_and_sanctions_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/player_reports_and_sanctions_walkthrough.md
@@ -14,3 +14,6 @@ This demo showcases the reports interface and sanctions interface. This is done 
 
 > [!NOTE]
 > See [Epic's documentation on the reports interface](https://dev.epicgames.com/docs/game-services/reports-interface), and [Epic's documentation on the sanctions interface](https://dev.epicgames.com/docs/game-services/sanctions-interface) respectively for more information.
+
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/sessions_and_matchmaking_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/sessions_and_matchmaking_walkthrough.md
@@ -36,3 +36,6 @@ This demo showcases the sessions interface, users can create, manage and join se
 
 > [!NOTE]
 > See [Epic's documentation on the sessions interface](https://dev.epicgames.com/docs/game-services/sessions) for more information.
+
+> [!NOTE]
+> This sample includes the UIFriendsMenu. Please see [the plugin's documentation on UIFriendsMenu](../uifriendsmenu.md) for more information.

--- a/com.playeveryware.eos/Documentation~/uifriendsmenu.md
+++ b/com.playeveryware.eos/Documentation~/uifriendsmenu.md
@@ -1,0 +1,9 @@
+<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+
+# UIFriendsMenu.cs
+
+Some scenes in the provided samples have the `friendsTabUI.prefab` included in them. This tab demonstrates the ability to query friends, send social invitations, and display social statuses.
+
+# QueryFriends Consent Requirement
+
+When friends are queried outside of the Epic Social Overlay, only friends who have consented to the application will appear. This could mean that while testing a game with this plugin included, either none of or a subset of your friends may appear in the UI. See [Epic's documentation on Friends List data privacy](https://dev.epicgames.com/docs/epic-account-services/eos-data-privacy-visibility#friends-list) and [Epic's documentation on Authorization and Consent Management](https://dev.epicgames.com/docs/epic-account-services/consent-management) for more information on this restriction.


### PR DESCRIPTION
When querying friends, the Friends Interface can only return friends that have consented to the application. This PR adds documentation to notify users of this limitation.

- A new documentation page for the UIFriendsMenu, which mentions this requirement.
- Each sample with the UIFriendsMenu included links to the above documentation.
- `UIFriendsMenu.cs` has a class-level documentation that mentions this.

Please let me know if the language can be more clear, or if there's other or additional places that require this documentation. I wasn't sure where to put it for `UIFriendsMenu`, so I put it at the top.

#EOS-1941