### PR TITLE
fix(lobby): Use LobbyChangeEventArgs for events

### DIFF
--- a/Assets/Scripts/EOSEACLobbyManager.cs
+++ b/Assets/Scripts/EOSEACLobbyManager.cs
@@ -62,7 +62,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             if (AntiCheatManager.IsAntiCheatAvailable())
             {
-                LobbyManager.OnLobbyChanged += OnLobbyChanged;
+                LobbyManager.LobbyChanged += OnLobbyChanged;
                 LobbyManager.AddNotifyLobbyUpdate(OnLobbyUpdated);
                 LobbyManager.AddNotifyMemberUpdateReceived(OnMemberUpdated);
 
@@ -233,7 +233,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
         }
 
-        private void OnLobbyChanged(string lobbyId, LobbyChangeType lobbyChangedEvent)
+        private void OnLobbyChanged(object sender, EOSLobbyManager.LobbyChangeEventArgs args)
         {
             string previousLobbyId = CurrentLobbyId;
             var currentLobby = LobbyManager.GetCurrentLobby();

--- a/Assets/Scripts/EOSLobbyManager.cs
+++ b/Assets/Scripts/EOSLobbyManager.cs
@@ -482,14 +482,27 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private List<OnMemberUpdateCallback> MemberUpdateCallbacks;
 
+        public class LobbyChangeEventArgs
+        {
+            public string LobbyId { get; }
+            public LobbyChangeType LobbyChangeType { get; }
 
-        public delegate void LobbyChanged(string lobbyId, LobbyChangeType typeOfChange);
+            public LobbyChangeEventArgs(string lobbyId, LobbyChangeType changeType)
+            {
+                LobbyId = lobbyId;
+                LobbyChangeType = changeType;
+            }
+        }
 
-        /// <summary>
-        /// Event that is run whenever the local user's relationship to a Lobby has been changed.
-        /// Indicates the Lobby that the change relates to.
-        /// </summary>
-        public event LobbyChanged OnLobbyChanged;
+        public delegate void LobbyChangeEventHandler(object sender, LobbyChangeEventArgs e);
+
+        public event LobbyChangeEventHandler LobbyChanged;
+
+        protected virtual void OnLobbyChanged(LobbyChangeEventArgs args)
+        {
+            LobbyChangeEventHandler handler = LobbyChanged;
+            handler?.Invoke(this, args);
+        }
 
         private List<Action> LobbyUpdateCallbacks;
 
@@ -1365,7 +1378,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 AddLocalUserAttributes();
             }
 
-            OnLobbyChanged?.Invoke(CurrentLobby?.Id, lobbyChangedEvent);
+            OnLobbyChanged(new LobbyChangeEventArgs(CurrentLobby?.Id, lobbyChangedEvent));
         }
 
         private void OnUpdateLobbyCallBack(ref UpdateLobbyCallbackInfo data)


### PR DESCRIPTION
This PR implements a suggested change from @paulhazen in relation to the LobbyChange. Here's the original comment:

> My thought process on this has evolved since my last review. Primarily due to [this](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-type-members#names-of-events) documentation provided by Microsoft that outlines naming conventions surrounding events and delegates in C#.
> 
> My updated understanding of the pattern (as described in the link above, and applied to this circumstance) is that the following should be done:
> 
> ```c#
> public class LobbyChangeEventArgs
> {
>     public string LobbyId { get; }
>     public LobbyChangeType { get; }
>     
>     public LobbyChangeEventArgs(string lobbyId, LobbyChangeType changeType)
>     {
>         LobbyId = lobbyId;
>         LobbyChangeType = changeType;
>     }
> }
> 
> public delegate void LobbyChangeEventHandler(object sender, LobbyChangeEventArgs e);
> 
> public event LobbyChangedEventHandler LobbyChanged;
> 
> // Made virtual in case a deriving class wants to override it.
> // Use this function to trigger the event from inside EOSLobbyManager so that it is threadsafe
> protected virtual void OnLobbyChanged(LobbyChangeEventArgs args)
> {
>     LobbyChangedEventHandler handler = LobbyChanged;
>     handler?.Invoke(this, args);
> }
> ```

This was implemented almost exactly as suggested, including position in the file. It'd make sense if we want to rearrange these, let me know.

My main thought is that now that the event is meant to be fired through OnLobbyChanged, we might want to reintroduce a public function for subscribing/unsubscribing, and make the event not public?