### PR TITLE
docs: Use `NOTE:` instead of `[!NOTE]`

### DIFF
--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -36,7 +36,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
     /// <summary>
     /// Provides an implementation of requesting friends from the EOS SDK, arranging, and displaying the information.
-    /// [!NOTE]: Only friends that have consented to the currently running application will appear when queried as friends.
+    /// NOTE: Only friends that have consented to the currently running application will appear when queried as friends.
     /// See [Epic's documentation on the Friends Interface](https://dev.epicgames.com/docs/epic-account-services/eos-friends-interface#retrieving-and-caching-the-friends-list)
     /// for more information.
     /// </summary>


### PR DESCRIPTION
Per @paulhazen 's suggestion, since [!NOTE] isn't a recognized syntax for comments, so let's just say "NOTE:" instead.