### PR TITLE
Break up `IPlatformSpecifics.cs` contents into individual files

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManagerPlatformSpecificsSingleton.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManagerPlatformSpecificsSingleton.cs
@@ -1,0 +1,65 @@
+/*
+* Copyright (c) 2021 PlayEveryWare
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+
+namespace PlayEveryWare.EpicOnlineServices
+{
+    using System;
+    using UnityEngine;
+
+    //-------------------------------------------------------------------------
+    public class EOSManagerPlatformSpecificsSingleton
+    {
+        static IPlatformSpecifics s_platformSpecifics;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void InitOnPlayMode()
+        {
+            s_platformSpecifics = null;
+        }
+
+        //-------------------------------------------------------------------------
+        // Should only be called once
+        static public void SetEOSManagerPlatformSpecificsInterface(IPlatformSpecifics platformSpecifics)
+        {
+            if (s_platformSpecifics != null)
+            {
+                throw new Exception(string.Format(
+                    "Trying to set the EOSManagerPlatformSpecificsSingleton twice: {0} => {1}",
+                    s_platformSpecifics.GetType().Name,
+                    platformSpecifics == null ? "NULL" : platformSpecifics.GetType().Name
+                ));
+            }
+
+            s_platformSpecifics = platformSpecifics;
+        }
+
+        //-------------------------------------------------------------------------
+        static public IPlatformSpecifics Instance
+        {
+            get
+            {
+                return s_platformSpecifics;
+            }
+        }
+    }
+}

--- a/com.playeveryware.eos/Runtime/Core/EOSManagerPlatformSpecificsSingleton.cs.meta
+++ b/com.playeveryware.eos/Runtime/Core/EOSManagerPlatformSpecificsSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59af5061342c5614ca15df078bb9aeae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.playeveryware.eos/Runtime/Core/IEOSCoroutineOwner.cs
+++ b/com.playeveryware.eos/Runtime/Core/IEOSCoroutineOwner.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+namespace PlayEveryWare.EpicOnlineServices
+{
+    using System.Collections;
+    
+    //-------------------------------------------------------------------------
+    public interface IEOSCoroutineOwner
+    {
+        void StartCoroutine(IEnumerator routine);
+    }
+}

--- a/com.playeveryware.eos/Runtime/Core/IEOSCoroutineOwner.cs.meta
+++ b/com.playeveryware.eos/Runtime/Core/IEOSCoroutineOwner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5c3a175a6ed8dc4da94dfd98dd9d3dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.playeveryware.eos/Runtime/Core/IPlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/IPlatformSpecifics.cs
@@ -20,66 +20,16 @@
 * SOFTWARE.
 */
 
-using System;
-using UnityEngine;
-using System.Collections;
-using System.Collections.Generic;
-
-#if !EOS_DISABLE
-using Epic.OnlineServices;
-using Epic.OnlineServices.Platform;
-#endif
-
 namespace PlayEveryWare.EpicOnlineServices
 {
-    //-------------------------------------------------------------------------
-    public class EOSManagerPlatformSpecificsSingleton
-    {
-        static IPlatformSpecifics s_platformSpecifics;
-
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void InitOnPlayMode()
-        {
-            s_platformSpecifics = null;
-        }
-
-        //-------------------------------------------------------------------------
-        // Should only be called once
-        static public void SetEOSManagerPlatformSpecificsInterface(IPlatformSpecifics platformSpecifics)
-        {
-            if (s_platformSpecifics != null)
-            {
-                throw new Exception(string.Format("Trying to set the EOSManagerPlatformSpecificsSingleton twice: {0} => {1}", 
-                    s_platformSpecifics.GetType().Name,
-                    platformSpecifics == null ? "NULL" : platformSpecifics.GetType().Name
-                ));
-            }
-            s_platformSpecifics = platformSpecifics;
-        }
-
-        //-------------------------------------------------------------------------
-        static public IPlatformSpecifics Instance
-        {
-            get
-            {
-                return s_platformSpecifics;
-            }
-        }
-    }
-
-    //-------------------------------------------------------------------------
-    public interface IEOSCoroutineOwner
-    {
-        void StartCoroutine(IEnumerator routine);
-    }
+    using System;
+    using System.Collections.Generic;
 
     //-------------------------------------------------------------------------
     public interface IPlatformSpecifics
     {
 #if !EOS_DISABLE
         string GetTempDir();
-
-       // Int32 IsReadyForNetworkActivity();
 
         void AddPluginSearchPaths(ref List<string> pluginPaths);
 

--- a/com.playeveryware.eos/Runtime/Core/IPlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/IPlatformSpecifics.cs
@@ -68,12 +68,6 @@ namespace PlayEveryWare.EpicOnlineServices
     }
 
     //-------------------------------------------------------------------------
-    public interface IEOSNetworkStatusUpdater
-    {
-        void UpdateNetworkStatus();
-    }
-
-    //-------------------------------------------------------------------------
     public interface IEOSCoroutineOwner
     {
         void StartCoroutine(IEnumerator routine);


### PR DESCRIPTION
In the course of implementing the config overrides, namespace changes were appropriate, but they were complicated by all the definitions being contained within the same file. They are separated here preparatory to making those changes.

#EOS-1982