### PR TITLE
String Extensions

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSConfig.cs
@@ -316,37 +316,14 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void ConfigureOverrideThreadAffinity(ref InitializeThreadAffinity affinity)
         {
-            affinity.NetworkWork = GetULongFromString(ThreadAffinity_networkWork);
-            affinity.StorageIo = GetULongFromString(ThreadAffinity_storageIO);
-            affinity.WebSocketIo = GetULongFromString(ThreadAffinity_webSocketIO);
-            affinity.P2PIo = GetULongFromString(ThreadAffinity_P2PIO);
-            affinity.HttpRequestIo = GetULongFromString(ThreadAffinity_HTTPRequestIO);
-            affinity.RTCIo = GetULongFromString(ThreadAffinity_RTCIO);
+            affinity.NetworkWork = ThreadAffinity_networkWork.ToUInt64();
+            affinity.StorageIo = ThreadAffinity_storageIO.ToUInt64();
+            affinity.WebSocketIo = ThreadAffinity_webSocketIO.ToUInt64();
+            affinity.P2PIo = ThreadAffinity_P2PIO.ToUInt64();
+            affinity.HttpRequestIo = ThreadAffinity_HTTPRequestIO.ToUInt64();
+            affinity.RTCIo = ThreadAffinity_RTCIO.ToUInt64();
         }
 #endif
-
-        /// <summary>
-        /// Wrapper function for ulong.Parse. Returns the value from ulong.Parse
-        /// if it succeeds, otherwise sets the value to the indicated default
-        /// value.
-        /// </summary>
-        /// <param name="str">The string to parse into a ulong.</param>
-        /// <param name="defaultValue">
-        /// The value to return in the event parsing fails.
-        /// </param>
-        /// <returns>
-        /// The result of parsing the string to a ulong, or defaultValue if
-        /// parsing fails.
-        /// </returns>
-        private static ulong GetULongFromString(string str, ulong defaultValue = 0)
-        {
-            if (!ulong.TryParse(str, out ulong value))
-            {
-                value = defaultValue;
-            }
-
-            return value;
-        }
 
         /// <summary>
         /// Determines whether the encryption key for the config is valid.

--- a/com.playeveryware.eos/Runtime/Core/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSConfig.cs
@@ -316,12 +316,12 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void ConfigureOverrideThreadAffinity(ref InitializeThreadAffinity affinity)
         {
-            affinity.NetworkWork = ThreadAffinity_networkWork.ToUInt64();
-            affinity.StorageIo = ThreadAffinity_storageIO.ToUInt64();
-            affinity.WebSocketIo = ThreadAffinity_webSocketIO.ToUInt64();
-            affinity.P2PIo = ThreadAffinity_P2PIO.ToUInt64();
-            affinity.HttpRequestIo = ThreadAffinity_HTTPRequestIO.ToUInt64();
-            affinity.RTCIo = ThreadAffinity_RTCIO.ToUInt64();
+            affinity.NetworkWork = ThreadAffinity_networkWork.ToUlong();
+            affinity.StorageIo = ThreadAffinity_storageIO.ToUlong();
+            affinity.WebSocketIo = ThreadAffinity_webSocketIO.ToUlong();
+            affinity.P2PIo = ThreadAffinity_P2PIO.ToUlong();
+            affinity.HttpRequestIo = ThreadAffinity_HTTPRequestIO.ToUlong();
+            affinity.RTCIo = ThreadAffinity_RTCIO.ToUlong();
         }
 #endif
 

--- a/com.playeveryware.eos/Runtime/Core/Extensions/StringExtensions.cs
+++ b/com.playeveryware.eos/Runtime/Core/Extensions/StringExtensions.cs
@@ -24,7 +24,7 @@ namespace PlayEveryWare.EpicOnlineServices.Extensions
 {
     public static class StringExtensions
     {
-        public static ulong ToUInt64(this string value, ulong defaultValue = 0L)
+        public static ulong ToUlong(this string value, ulong defaultValue = 0L)
         {
             ulong returnValue = defaultValue;
 

--- a/com.playeveryware.eos/Runtime/Core/Extensions/StringExtensions.cs
+++ b/com.playeveryware.eos/Runtime/Core/Extensions/StringExtensions.cs
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PlayEveryWare.EpicOnlineServices.Extensions
+{
+    public static class StringExtensions
+    {
+        public static ulong ToUInt64(this string value, ulong defaultValue = 0L)
+        {
+            ulong returnValue = defaultValue;
+
+            if (ulong.TryParse(value, out ulong result))
+            {
+                returnValue = result;
+            }
+
+            return returnValue;
+        }
+    }
+}

--- a/com.playeveryware.eos/Runtime/Core/Extensions/StringExtensions.cs.meta
+++ b/com.playeveryware.eos/Runtime/Core/Extensions/StringExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 857d0850d78eadf47b46bf034483b8ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
In the process of implementing config overrides, it made sense to relegate the conversion of strings to `ulong` with a default value to a `StringExtensions` class. This change is put into a separate PR so that the PR containing the changes for the attached task can be evaluated in isolation.

#EOS-1982