### PR TITLE
Change `FileSystemUtility.GetProjectPath()` to not use `Application.dataPath`

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -413,6 +413,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             }
         }
 
+#if UNITY_EDITOR
         /// <summary>
         /// Returns the root of the Unity project.
         /// </summary>
@@ -433,7 +434,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             throw new DirectoryNotFoundException("Unable to locate the Assets folder from the current directory.");
         }
 
-#if UNITY_EDITOR
+
         #region Line Ending Manipulations
 
         public static void ConvertDosToUnixLineEndings(string filename)

--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -419,7 +419,18 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// <returns>Fully-qualified file path to the root of the Unity project.</returns>
         public static string GetProjectPath()
         {
-            return Path.GetFullPath(Path.Combine(Application.dataPath, "../"));
+            // Assuming the current directory is within the project (e.g., in the Editor or during Play mode)
+            string assetsPath = CombinePaths(Directory.GetCurrentDirectory(), "Assets");
+
+            // Ensure the Assets folder exists at the expected location
+            if (DirectoryExists(assetsPath))
+            {
+                // Move up one directory from Assets to get the root directory of the project
+                return Path.GetFullPath(CombinePaths(assetsPath, ".."));
+            }
+
+            // If running in a different context or the assumption is wrong, handle accordingly
+            throw new DirectoryNotFoundException("Unable to locate the Assets folder from the current directory.");
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
This PR addresses an issue currently existing within the `development` branch that causes all the unit tests that derive from `EOSTestBase` to fail. The cause of this was access of the `Application.dataPath` property from within a thread other than the "main" Unity Thread.

This PR sidesteps that limitation by using a different means by which to infer the location of the project directory.

Thanks to @WispyMouse for documenting this issue and helping us find a solution.

 #EOS-2084