### PR TITLE
tests(PlayerDataStorage)

### DIFF
--- a/Assets/Scripts/EOSPlayerDataStorageManager.cs
+++ b/Assets/Scripts/EOSPlayerDataStorageManager.cs
@@ -483,5 +483,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             QueryFileList();
         }
+
+        public override void RemoveCallbacks()
+        {
+            base.RemoveCallbacks();
+            OnFileListUpdated = null;
+        }
     }
 }

--- a/Assets/Scripts/StandardSamples/Services/DataService.cs
+++ b/Assets/Scripts/StandardSamples/Services/DataService.cs
@@ -310,5 +310,10 @@ namespace PlayEveryWare.EpicOnlineServices
 
             return FileTransferResult.ContinueReading;
         }
+
+        public virtual void RemoveCallbacks()
+        {
+            OnFileDownloaded = null;
+        }
     }
 }

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
@@ -306,10 +306,6 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), newFileString, doneWaiting);
             yield return new WaitUntilDone(10f, () => waiting == false);
 
-            waiting = true;
-            playerDataStorageManager.StartFileDataUpload(nameof(UploadingFile_WithSameName_Overrides), doneWaiting);
-            yield return new WaitUntilDone(10f, () => waiting == false);
-
             Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
 
             Assert.NotNull(localCache, "Local cache is null, should be a dictionary.");

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
@@ -70,7 +70,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
 
             // The key is the file name; we need to delete all of these files
-            foreach (string localCacheKey in localCache.Keys)
+            foreach (string localCacheKey in new List<string>(localCache.Keys))
             {
                 // To know when the DeleteFile operation is complete, we also listen to the file list being updated
                 waiting = true;

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
@@ -137,11 +137,6 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
                 playerDataStorageManager.AddFile(randomName, Encoding.UTF8.GetString(fileBytes), doneWaiting);
 
                 yield return new WaitUntilDone(10f, () => waitingForAdd == false);
-
-                waitingForAdd = true;
-                playerDataStorageManager.StartFileDataUpload(randomName, doneWaiting);
-
-                yield return new WaitUntilDone(10f, () => waitingForAdd == false);
             }
 			
             bool waiting = true;
@@ -169,22 +164,18 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
         [UnityTest]
         public IEnumerator UploadedFile_HasSameContents()
         {
-            const int LengthOfUploadedBytes = 100;
+            const int LengthOfUploadedBytes = byte.MaxValue;
 
             bool waiting = true;
             Action doneWaiting = () => waiting = false;
-            byte[] uploadedFileBytes = new byte[LengthOfUploadedBytes];
+            string uploadedFileString = "";
 
             for (int byteIndex = 0; byteIndex < LengthOfUploadedBytes; byteIndex++)
             {
-                uploadedFileBytes[byteIndex] = (byte)UnityEngine.Random.Range(0, byte.MaxValue);
+                uploadedFileString += UnityEngine.Random.Range(0, byte.MaxValue);
             }
 
-            playerDataStorageManager.AddFile(nameof(UploadedFile_HasSameContents), Encoding.UTF8.GetString(uploadedFileBytes), doneWaiting);
-            yield return new WaitUntilDone(10f, () => waiting == false);
-
-            waiting = true;
-            playerDataStorageManager.StartFileDataUpload(nameof(UploadedFile_HasSameContents), doneWaiting);
+            playerDataStorageManager.AddFile(nameof(UploadedFile_HasSameContents), uploadedFileString, doneWaiting);
             yield return new WaitUntilDone(10f, () => waiting == false);
 
             waiting = true;
@@ -200,12 +191,11 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             string downloadedFileString = localCache[nameof(UploadedFile_HasSameContents)];
 
             Assert.IsFalse(string.IsNullOrEmpty(downloadedFileString), "Downloaded file's contents is null or empty, should contain data.");
-            byte[] downloadedFileBytes = Encoding.UTF8.GetBytes(downloadedFileString);
-            Assert.AreEqual(uploadedFileBytes.Length, downloadedFileBytes.Length, "Downloaded file's length is different than the uploaded file.");
+            Assert.AreEqual(uploadedFileString.Length, downloadedFileString.Length, "Downloaded file's length is different than the uploaded file.");
 
-            for (int byteIndex = 0; byteIndex < uploadedFileBytes.Length; byteIndex++)
+            for (int byteIndex = 0; byteIndex < uploadedFileString.Length; byteIndex++)
             {
-                Assert.AreEqual(uploadedFileBytes[byteIndex], downloadedFileBytes[byteIndex], "Downloaded file's contents are different than the uploaded file, should be identical.");
+                Assert.AreEqual(uploadedFileString[byteIndex], downloadedFileString[byteIndex], "Downloaded file's contents are different than the uploaded file, should be identical.");
             }
         }
 
@@ -220,10 +210,6 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             Action doneWaiting = () => waiting = false;
             byte[] fileBytes = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5 };
             playerDataStorageManager.AddFile(nameof(UploadedFile_CanBeDeleted), Encoding.UTF8.GetString(fileBytes), doneWaiting);
-            yield return new WaitUntilDone(10f, () => waiting == false);
-
-            waiting = true;
-            playerDataStorageManager.StartFileDataUpload(nameof(UploadedFile_CanBeDeleted), doneWaiting);
             yield return new WaitUntilDone(10f, () => waiting == false);
 
             // We know the delete operation is complete when the file list is next updated
@@ -253,10 +239,6 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             Action doneWaiting = () => waiting = false;
             byte[] fileBytes = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5 };
             playerDataStorageManager.AddFile(nameof(UploadedFile_CanBeCopied), Encoding.UTF8.GetString(fileBytes), doneWaiting);
-            yield return new WaitUntilDone(10f, () => waiting == false);
-
-            waiting = true;
-            playerDataStorageManager.StartFileDataUpload(nameof(UploadedFile_CanBeCopied), doneWaiting);
             yield return new WaitUntilDone(10f, () => waiting == false);
 
             // We know the copy operation is complete when the file list is next updated
@@ -298,19 +280,30 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
         [UnityTest]
         public IEnumerator UploadingFile_WithSameName_Overrides()
         {
+            const int lengthOfOriginalString = 10;
+            const int lengthOfNewString = 20;
+
             bool waiting = true;
             Action doneWaiting = () => waiting = false;
-            byte[] originalFileBytes = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5 };
-            playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), Encoding.UTF8.GetString(originalFileBytes), doneWaiting);
-            yield return new WaitUntilDone(10f, () => waiting == false);
+            string originalFileString = "";
 
-            waiting = true;
-            playerDataStorageManager.StartFileDataUpload(nameof(UploadingFile_WithSameName_Overrides), doneWaiting);
+            for (int byteIndex = 0; byteIndex < lengthOfOriginalString; byteIndex++)
+            {
+                originalFileString += UnityEngine.Random.Range(0, byte.MaxValue);
+            }
+
+            playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), originalFileString, doneWaiting);
             yield return new WaitUntilDone(10f, () => waiting == false);
 
             // Now create an identically named file but with different contents
-            byte[] newFileBytes = new byte[] { 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF };
-            playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), Encoding.UTF8.GetString(newFileBytes), doneWaiting);
+            string newFileString = "";
+
+            for (int byteIndex = 0; byteIndex < lengthOfNewString; byteIndex++)
+            {
+                newFileString += UnityEngine.Random.Range(0, byte.MaxValue);
+            }
+
+            playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), newFileString, doneWaiting);
             yield return new WaitUntilDone(10f, () => waiting == false);
 
             waiting = true;
@@ -326,12 +319,11 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             string downloadedFileString = localCache[nameof(UploadingFile_WithSameName_Overrides)];
 
             Assert.IsFalse(string.IsNullOrEmpty(downloadedFileString), "Downloaded file's contents is null or empty, should contain data.");
-            byte[] downloadedFileBytes = Encoding.UTF8.GetBytes(downloadedFileString);
-            Assert.AreEqual(newFileBytes.Length, downloadedFileBytes.Length, "Downloaded file's length is different than the overriding file.");
+            Assert.AreEqual(newFileString.Length, downloadedFileString.Length, "Downloaded file's length is different than the overriding file.");
 
-            for (int byteIndex = 0; byteIndex < newFileBytes.Length; byteIndex++)
+            for (int byteIndex = 0; byteIndex < newFileString.Length; byteIndex++)
             {
-                Assert.AreEqual(newFileBytes[byteIndex], downloadedFileBytes[byteIndex], "Downloaded file's contents are different than the overriding file, should be identical.");
+                Assert.AreEqual(newFileString[byteIndex], downloadedFileString[byteIndex], "Downloaded file's contents are different than the overriding file, should be identical.");
             }
         }
     }

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
@@ -143,6 +143,13 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
 
                 yield return new WaitUntilDone(10f, () => waitingForAdd == false);
             }
+			
+            bool waiting = true;
+            Action setWaiting = () => waiting = false;
+            playerDataStorageManager.OnFileListUpdated += setWaiting;
+            playerDataStorageManager.QueryFileList();
+
+            yield return new WaitUntilDone(10f, () => waiting == false);
 
             Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
 

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
+{
+    using Epic.OnlineServices;
+    using Epic.OnlineServices.Sessions;
+    using NUnit.Framework;
+    using EpicOnlineServices;
+    using System.Collections;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using PlayEveryWare.EpicOnlineServices.Samples;
+    using System;
+    using UnityEngine.Events;
+    using System.Text;
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+
+    public class PlayerDataStorageManagerTests : EOSTestBase
+    {
+        EOSPlayerDataStorageManager playerDataStorageManager;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            playerDataStorageManager = new EOSPlayerDataStorageManager();
+
+            yield return DestroyAllFiles();
+        }
+
+        [UnitySetUp]
+        public IEnumerator UnityTearDown()
+        {
+            yield return DestroyAllFiles();
+        }
+
+        private IEnumerator DestroyAllFiles()
+        {
+            // To know when the Query operation is done, subscribe to the file list being updated
+            bool waiting = true;
+            Action setWaiting = () => waiting = false;
+            playerDataStorageManager.OnFileListUpdated += setWaiting;
+            playerDataStorageManager.QueryFileList();
+
+            yield return new WaitUntilDone(10f, () => waiting == false );
+
+            Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
+
+            // The key is the file name; we need to delete all of these files
+            foreach (string localCacheKey in localCache.Keys)
+            {
+                // To know when the DeleteFile operation is complete, we also listen to the file list being updated
+                waiting = true;
+                playerDataStorageManager.DeleteFile(localCacheKey);
+                yield return new WaitUntilDone(10f, () => waiting == false);
+            }
+
+            // Unsubscribe from file list updates before exiting
+            playerDataStorageManager.OnFileListUpdated -= setWaiting;
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs
@@ -49,7 +49,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             yield return DestroyAllFiles();
         }
 
-        [UnitySetUp]
+        [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
             yield return DestroyAllFiles();
@@ -144,13 +144,6 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
                 yield return new WaitUntilDone(10f, () => waitingForAdd == false);
             }
 
-            bool waiting = true;
-            Action setWaiting = () => waiting = false;
-            playerDataStorageManager.OnFileListUpdated += setWaiting;
-            playerDataStorageManager.QueryFileList();
-
-            yield return new WaitUntilDone(10f, () => waiting == false);
-
             Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
 
             Assert.NotNull(localCache, "Local cache is null, should be a dictionary with data.");
@@ -206,6 +199,132 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
             for (int byteIndex = 0; byteIndex < uploadedFileBytes.Length; byteIndex++)
             {
                 Assert.AreEqual(uploadedFileBytes[byteIndex], downloadedFileBytes[byteIndex], "Downloaded file's contents are different than the uploaded file, should be identical.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a file, uploads it, then deletes it.
+        /// Requeries all files. The file should not be present in the cache.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator UploadedFile_CanBeDeleted()
+        {
+            bool waiting = true;
+            Action doneWaiting = () => waiting = false;
+            byte[] fileBytes = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5 };
+            playerDataStorageManager.AddFile(nameof(UploadedFile_CanBeDeleted), Encoding.UTF8.GetString(fileBytes), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            waiting = true;
+            playerDataStorageManager.StartFileDataUpload(nameof(UploadedFile_CanBeDeleted), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            // We know the delete operation is complete when the file list is next updated
+            waiting = true;
+            playerDataStorageManager.OnFileListUpdated += doneWaiting;
+            playerDataStorageManager.DeleteFile(nameof(UploadedFile_CanBeDeleted));
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
+
+            Assert.NotNull(localCache, "Local cache is null, should be an empty non-null dictionary.");
+            Assert.AreEqual(0, localCache.Keys.Count, "Local cache contains items. It should be empty.");
+        }
+
+        /// <summary>
+        /// Creates a file, and uploads it.
+        /// Then after it is uploaded, copioes that file.
+        /// When queried, the copied file should be identical to the uploaded file.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator UploadedFile_CanBeCopied()
+        {
+            const string DestinationFileName = nameof(UploadedFile_CanBeCopied) + "copyfile";
+
+            bool waiting = true;
+            Action doneWaiting = () => waiting = false;
+            byte[] fileBytes = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5 };
+            playerDataStorageManager.AddFile(nameof(UploadedFile_CanBeCopied), Encoding.UTF8.GetString(fileBytes), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            waiting = true;
+            playerDataStorageManager.StartFileDataUpload(nameof(UploadedFile_CanBeCopied), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            // We know the copy operation is complete when the file list is next updated
+            waiting = true;
+            playerDataStorageManager.OnFileListUpdated += doneWaiting;
+            playerDataStorageManager.CopyFile(nameof(UploadedFile_CanBeCopied), DestinationFileName);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            // Now download the file
+            waiting = true;
+            playerDataStorageManager.DownloadFile(DestinationFileName, doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
+
+            Assert.NotNull(localCache, "Local cache is null, should be a dictionary.");
+            Assert.AreEqual(2, localCache.Keys.Count, "Local cache doesn't contain the expected amount of items. Should contain exactly the original file and its copy.");
+            Assert.IsTrue(localCache.ContainsKey(nameof(UploadedFile_CanBeCopied)), "Local cache does not contain the original file.");
+            Assert.IsTrue(localCache.ContainsKey(DestinationFileName), "Local cache does not contain the copy file.");
+
+            string downloadedFileString = localCache[DestinationFileName];
+
+            Assert.IsFalse(string.IsNullOrEmpty(downloadedFileString), "Downloaded copy file's contents is null or empty, should contain data.");
+            byte[] downloadedFileBytes = Encoding.UTF8.GetBytes(downloadedFileString);
+            Assert.AreEqual(fileBytes.Length, downloadedFileBytes.Length, "Downloaded copy file's length is different than the uploaded file.");
+
+            for (int byteIndex = 0; byteIndex < fileBytes.Length; byteIndex++)
+            {
+                Assert.AreEqual(fileBytes[byteIndex], downloadedFileBytes[byteIndex], "Downloaded copy file's contents are different than the original uploaded file, should be identical.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a file, uploads it, then creates another file, and uploads it with the same name.
+        /// The resulting file is downloaded. It should have the contents of the overriding file.
+        /// Implicitly checks for any errors resulting from trying to upload a file with the same name.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator UploadingFile_WithSameName_Overrides()
+        {
+            bool waiting = true;
+            Action doneWaiting = () => waiting = false;
+            byte[] originalFileBytes = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5 };
+            playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), Encoding.UTF8.GetString(originalFileBytes), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            waiting = true;
+            playerDataStorageManager.StartFileDataUpload(nameof(UploadingFile_WithSameName_Overrides), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            // Now create an identically named file but with different contents
+            byte[] newFileBytes = new byte[] { 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF };
+            playerDataStorageManager.AddFile(nameof(UploadingFile_WithSameName_Overrides), Encoding.UTF8.GetString(newFileBytes), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            waiting = true;
+            playerDataStorageManager.StartFileDataUpload(nameof(UploadingFile_WithSameName_Overrides), doneWaiting);
+            yield return new WaitUntilDone(10f, () => waiting == false);
+
+            Dictionary<string, string> localCache = playerDataStorageManager.GetLocallyCachedData();
+
+            Assert.NotNull(localCache, "Local cache is null, should be a dictionary.");
+            Assert.AreEqual(1, localCache.Keys.Count, "Local cache doesn't contain the expected amount of items. Should contain exactly the overriding file.");
+            Assert.IsTrue(localCache.ContainsKey(nameof(UploadingFile_WithSameName_Overrides)), "Local cache does not contain the overriding file.");
+
+            string downloadedFileString = localCache[nameof(UploadingFile_WithSameName_Overrides)];
+
+            Assert.IsFalse(string.IsNullOrEmpty(downloadedFileString), "Downloaded file's contents is null or empty, should contain data.");
+            byte[] downloadedFileBytes = Encoding.UTF8.GetBytes(downloadedFileString);
+            Assert.AreEqual(newFileBytes.Length, downloadedFileBytes.Length, "Downloaded file's length is different than the overriding file.");
+
+            for (int byteIndex = 0; byteIndex < newFileBytes.Length; byteIndex++)
+            {
+                Assert.AreEqual(newFileBytes[byteIndex], downloadedFileBytes[byteIndex], "Downloaded file's contents are different than the overriding file, should be identical.");
             }
         }
     }

--- a/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs.meta
+++ b/Assets/Tests/PlayMode/PlayerDataStorageManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92fb795c2019d5545ad83b6dfe8f85f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/PlayerDataStorageFileTransferRequestWrapper.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/PlayerDataStorageFileTransferRequestWrapper.cs
@@ -53,7 +53,8 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public override void Release()
         {
-            _instance.Release();
+            _instance?.Release();
+            _instance = null;
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/TitleStorageFileTransferRequestWrapper.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/TitleStorageFileTransferRequestWrapper.cs
@@ -53,6 +53,7 @@ namespace PlayEveryWare.EpicOnlineServices
         public override void Release()
         {
             _instance?.Release();
+            _instance = null;
         }
     }
 }


### PR DESCRIPTION
This absorbs all of the tests made in #836 , brought over to the retooled Manager service thing.

This merges into `fix/application-datapath-threadsafe` because it is dependent on a change within to unblock tests.