### PR TITLE
fix(playerdatastorage): Explicitly set _instance to null to avoid double release

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/PlayerDataStorageFileTransferRequestWrapper.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/PlayerDataStorageFileTransferRequestWrapper.cs
@@ -53,7 +53,8 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public override void Release()
         {
-            _instance.Release();
+            _instance?.Release();
+            _instance = null;
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/TitleStorageFileTransferRequestWrapper.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/TitleStorageFileTransferRequestWrapper.cs
@@ -53,6 +53,7 @@ namespace PlayEveryWare.EpicOnlineServices
         public override void Release()
         {
             _instance?.Release();
+            _instance = null;
         }
     }
 }


### PR DESCRIPTION
The `Release` method is being called directly in some places for the wrapper. If you try to Release a EOS notification handle that has already been released, it crashes Unity. This safely sets the _instance to null after releasing, to make sure that doesn't happen again.