### PR TITLE
Expansion of config attribute usage

### DIFF
--- a/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
@@ -221,7 +221,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
                 float labelWidth = GetMaximumLabelWidth(fieldGroup);
 
                 // If there is a label for the field group, then display it.
-                if (_groupLabels?.Length > fieldGroup.Key)
+                if (0 >= fieldGroup.Key && _groupLabels?.Length > fieldGroup.Key)
                 {
                     GUILayout.Label(_groupLabels[fieldGroup.Key], EditorStyles.boldLabel);
                 }

--- a/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
@@ -32,8 +32,6 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
     using UnityEngine.Events;
     using Utility;
     using Task = System.Threading.Tasks.Task;
-    using Config = EpicOnlineServices.Config;
-
 
     /// <summary>
     /// Contains implementations of IConfigEditor that are common to all
@@ -50,6 +48,11 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         /// The string to use for the label for the config editor.
         /// </summary>
         protected string _labelText;
+
+        /// <summary>
+        /// The labels for each group.
+        /// </summary>
+        protected string[] _groupLabels;
 
         /// <summary>
         /// Event that triggers when the config editor is expanded.
@@ -103,6 +106,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
             {
                 _collapsible = attribute.Collapsible;   
                 _labelText = attribute.Label;
+                _groupLabels = attribute.GroupLabels;
             }
 
             _animExpanded = new(_collapsible);
@@ -124,7 +128,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         /// </summary>
         public void Expand()
         {
-            // Don't do anything if already expanded, or if cannot expand
+            // Don't do anything if already expanded, or cannot expand
             if (_expanded || !_collapsible)
             {
                 return;
@@ -162,13 +166,11 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         /// <returns>A collection of config fields.</returns>
         private static IOrderedEnumerable<IGrouping<int, (FieldInfo FieldInfo, ConfigFieldAttribute FieldDetails)>> GetFieldsByGroup()
         {
-            var returnValue = typeof(T).GetFields(BindingFlags.Public | BindingFlags.Instance)
+            return typeof(T).GetFields(BindingFlags.Public | BindingFlags.Instance)
                 .Where(field => field.GetCustomAttribute<ConfigFieldAttribute>() != null)
                 .Select(info => (info, info.GetCustomAttribute<ConfigFieldAttribute>()))
                 .GroupBy(r => r.Item2.Group)
                 .OrderBy(group => group.Key);
-
-            return returnValue;
         }
 
         /// <summary>
@@ -214,10 +216,15 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         /// </exception>
         protected void RenderConfigFields()
         {
-            var fieldGroups = GetFieldsByGroup();
-            foreach (var fieldGroup in fieldGroups)
+            foreach (var fieldGroup in GetFieldsByGroup())
             {
                 float labelWidth = GetMaximumLabelWidth(fieldGroup);
+
+                // If there is a label for the field group, then display it.
+                if (_groupLabels?.Length > fieldGroup.Key)
+                {
+                    GUILayout.Label(_groupLabels[fieldGroup.Key], EditorStyles.boldLabel);
+                }
 
                 foreach (var field in fieldGroup)
                 {
@@ -237,6 +244,9 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
                             break;
                         case ConfigFieldType.Ulong:
                             field.FieldInfo.SetValue(config, GUIEditorUtility.RenderInputField(field.FieldDetails, (ulong)field.FieldInfo.GetValue(config), labelWidth));
+                            break;
+                        case ConfigFieldType.Double:
+                            field.FieldInfo.SetValue(config, GUIEditorUtility.RenderInputField(field.FieldDetails, (double)field.FieldInfo.GetValue(config), labelWidth));
                             break;
                         case ConfigFieldType.TextList:
                             field.FieldInfo.SetValue(config, GUIEditorUtility.RenderInputField(field.FieldDetails, (List<string>)field.FieldInfo.GetValue(config), labelWidth));

--- a/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
@@ -96,94 +96,6 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
             EditorGUIUtility.labelWidth = originalLabelWidth;
         }
 
-        public static void AssigningPath(string label, ref string filePath, string prompt, string directory = "", string extension = "", bool selectFolder = false, bool horizontalLayout = true, float maxButtonWidth = 100, float labelWidth = -1, string tooltip = null)
-        {
-            if (horizontalLayout)
-            {
-                EditorGUILayout.BeginHorizontal();
-            }
-
-            AssigningTextField(label, ref filePath, labelWidth, tooltip);
-
-            bool buttonPressed = maxButtonWidth > 0 ? GUILayout.Button("Select", GUILayout.MaxWidth(maxButtonWidth)) : GUILayout.Button("Select");
-
-            if (buttonPressed)
-            {
-                var newFilePath = selectFolder ? EditorUtility.OpenFolderPanel(prompt, "", "") : EditorUtility.OpenFilePanel(prompt, directory, extension);
-                if (!string.IsNullOrWhiteSpace(newFilePath))
-                {
-                    filePath = newFilePath;
-                }
-            }
-
-            if (horizontalLayout)
-            {
-                EditorGUILayout.EndHorizontal();
-            }
-        }
-
-        private delegate T InputRenderDelegate<T>(string label, T value, float labelWidth, string tooltip);
-
-        public static void AssigningULongField(string label, ref ulong value, float labelWidth = -1, string tooltip = null)
-        {
-            float originalLabelWidth = EditorGUIUtility.labelWidth;
-            if (labelWidth >= 0)
-            {
-                EditorGUIUtility.labelWidth = labelWidth;
-            }
-
-            ulong newValue = value;
-            var newValueAsString = EditorGUILayout.TextField(CreateGUIContent(label, tooltip), value.ToString(), GUILayout.ExpandWidth(true));
-            if (string.IsNullOrWhiteSpace(newValueAsString))
-            {
-                newValueAsString = "0";
-            }
-
-            try
-            {
-                newValue = ulong.Parse(newValueAsString);
-                value = newValue;
-            }
-            catch (FormatException)
-            {
-            }
-            catch (OverflowException)
-            {
-            }
-
-            EditorGUIUtility.labelWidth = originalLabelWidth;
-        }
-
-        public static void AssigningUintField(string label, ref uint value, float labelWidth = -1, string tooltip = null)
-        {
-            float originalLabelWidth = EditorGUIUtility.labelWidth;
-            if (labelWidth >= 0)
-            {
-                EditorGUIUtility.labelWidth = labelWidth;
-            }
-
-            uint newValue = value;
-            var newValueAsString = EditorGUILayout.TextField(CreateGUIContent(label, tooltip), value.ToString(), GUILayout.ExpandWidth(true));
-            if (string.IsNullOrWhiteSpace(newValueAsString))
-            {
-                newValueAsString = "0";
-            }
-
-            try
-            {
-                newValue = uint.Parse(newValueAsString);
-                value = newValue;
-            }
-            catch (FormatException)
-            {
-            }
-            catch (OverflowException)
-            {
-            }
-
-            EditorGUIUtility.labelWidth = originalLabelWidth;
-        }
-
         public static void AssigningULongToStringField(string label, ref string value, float labelWidth = -1, string tooltip = null)
         {
             float originalLabelWidth = EditorGUIUtility.labelWidth;
@@ -288,6 +200,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
 
         #region New methods for rendering input fields
 
+        private delegate T InputRenderDelegate<T>(string label, T value, float labelWidth, string tooltip);
+
         public static List<string> RenderInputField(ConfigFieldAttribute configFieldDetails, List<string> value,
             float labelWidth, string tooltip = null)
         {
@@ -389,6 +303,18 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
             EditorGUILayout.EndHorizontal();
 
             return filePath;
+        }
+
+        public static double RenderInputField(ConfigFieldAttribute configFieldDetails, double value, float labelWidth, string tooltip = null)
+        {
+            return InputRendererWrapper(configFieldDetails.Label, value, labelWidth, tooltip,
+                (label, value1, width, s) =>
+                {
+                    return EditorGUILayout.DoubleField(
+                        CreateGUIContent(configFieldDetails.Label, tooltip),
+                        value,
+                        GUILayout.ExpandWidth(true));
+                });
         }
 
         public static string RenderInputField(ConfigFieldAttribute configFieldDetails, string value, float labelWidth,

--- a/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldAttribute.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldAttribute.cs
@@ -50,12 +50,6 @@ namespace PlayEveryWare.EpicOnlineServices
         public ConfigFieldType FieldType { get; }
 
         public ConfigFieldAttribute(
-            string label,
-            string tooltip = null,
-            int group = -1) : 
-            this(label, ConfigFieldType.Text, tooltip, group) { }
-
-        public ConfigFieldAttribute(
             string label, 
             ConfigFieldType type, 
             string tooltip = null, 

--- a/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldAttribute.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldAttribute.cs
@@ -44,11 +44,6 @@ namespace PlayEveryWare.EpicOnlineServices
         public int Group { get; }
 
         /// <summary>
-        /// The label to use for the group that the config field is a member of.
-        /// </summary>
-        public string GroupLabel { get; }
-
-        /// <summary>
         /// The type of the field - used to inform how to render input controls
         /// and validation.
         /// </summary>
@@ -57,25 +52,19 @@ namespace PlayEveryWare.EpicOnlineServices
         public ConfigFieldAttribute(
             string label,
             string tooltip = null,
-            int group = -1,
-            string groupLabel = "") : 
-            this(label, ConfigFieldType.Text, tooltip, group, groupLabel)
-        {
-
-        }
+            int group = -1) : 
+            this(label, ConfigFieldType.Text, tooltip, group) { }
 
         public ConfigFieldAttribute(
             string label, 
             ConfigFieldType type, 
             string tooltip = null, 
-            int group = -1,
-            string groupLabel = "")
+            int group = -1)
         {
             Label = label;
             ToolTip = tooltip;
             Group = group;
             FieldType = type;
-            GroupLabel = groupLabel;
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldAttribute.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldAttribute.cs
@@ -43,18 +43,39 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         public int Group { get; }
 
+        /// <summary>
+        /// The label to use for the group that the config field is a member of.
+        /// </summary>
+        public string GroupLabel { get; }
+
+        /// <summary>
+        /// The type of the field - used to inform how to render input controls
+        /// and validation.
+        /// </summary>
         public ConfigFieldType FieldType { get; }
-        
+
+        public ConfigFieldAttribute(
+            string label,
+            string tooltip = null,
+            int group = -1,
+            string groupLabel = "") : 
+            this(label, ConfigFieldType.Text, tooltip, group, groupLabel)
+        {
+
+        }
+
         public ConfigFieldAttribute(
             string label, 
             ConfigFieldType type, 
             string tooltip = null, 
-            int group = -1)
+            int group = -1,
+            string groupLabel = "")
         {
             Label = label;
             ToolTip = tooltip;
             Group = group;
             FieldType = type;
+            GroupLabel = groupLabel;
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldType.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigFieldType.cs
@@ -61,6 +61,11 @@ namespace PlayEveryWare.EpicOnlineServices
         Ulong,
 
         /// <summary>
+        /// A plain double.
+        /// </summary>
+        Double,
+
+        /// <summary>
         /// A list of strings.
         /// </summary>
         TextList,

--- a/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigGroupAttribute.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Attributes/ConfigGroupAttribute.cs
@@ -43,10 +43,21 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         public bool Collapsible { get; }
 
+        /// <summary>
+        /// Set the 
+        /// </summary>
+        public string[] GroupLabels { get; }
+
         public ConfigGroupAttribute(string label, bool collapsible = true)
         {
             Label = label;
             Collapsible = collapsible;
+        }
+
+        public ConfigGroupAttribute(string label, string[] groupLabels, bool collapsible = true)
+        : this(label, collapsible)
+        {
+            GroupLabels = groupLabels;
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/Config/Config.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Config.cs
@@ -220,7 +220,8 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <returns>
         /// True if the parsing of flags was successful, false otherwise.
         /// </returns>
-        protected delegate bool TryParseEnumDelegate<TEnum>(IList<string> stringFlags, out TEnum result) where TEnum : struct, Enum;
+        protected delegate bool TryParseEnumDelegate<TEnum>(IList<string> 
+            stringFlags, out TEnum result) where TEnum : struct, Enum;
 
         /// <summary>
         /// Private static wrapper to handle converting a list of strings into
@@ -240,7 +241,9 @@ namespace PlayEveryWare.EpicOnlineServices
         /// operation between the enum values that result from parsing each of
         /// the items in a list into the indicated enum type value.
         /// </returns>
-        protected static TEnum StringsToEnum<TEnum>(IList<string> stringFlags, TryParseEnumDelegate<TEnum> parseEnumFn)
+        protected static TEnum StringsToEnum<TEnum>(
+            IList<string> stringFlags, 
+            TryParseEnumDelegate<TEnum> parseEnumFn)
             where TEnum : struct, Enum
         {
             _ = parseEnumFn(stringFlags, out TEnum result);

--- a/com.playeveryware.eos/Runtime/Core/Config/Config.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Config.cs
@@ -298,10 +298,10 @@ namespace PlayEveryWare.EpicOnlineServices
                 // If the editor is not running, then the config file not
                 // existing should throw an error.
                 throw new FileNotFoundException(
-                $"Config file \"{FilePath}\" does not exist.");
+                    $"Config file \"{FilePath}\" does not exist.");
 #endif
             }
-    }
+        }
 
         // Functions declared below should only ever be utilized in the editor.
         // They are so divided to guarantee separation of concerns.

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -37,7 +37,8 @@ namespace PlayEveryWare.EpicOnlineServices
     using Extensions;
 
     /// <summary>
-    /// Represents the default deployment ID to use when a given sandbox ID is active.
+    /// Represents the default deployment ID to use when a given sandbox ID is
+    /// active.
     /// </summary>
     [Serializable]
     public class SandboxDeploymentOverride
@@ -60,152 +61,265 @@ namespace PlayEveryWare.EpicOnlineServices
 
         protected EOSConfig() : base("EpicOnlineServicesConfig.json") { }
 
+        #region Product Information
+
         /// <summary>
         /// Product Name defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
+        [ConfigField("Product Name",
+            "Product name defined in the Development Portal.", 
+            0, "Product Information")]
         public string productName;
 
         /// <summary>
         /// Version of Product.
         /// </summary>
+        [ConfigField("Product Version",
+            "Version of the product.", 
+            0, "Product Information")]
         public string productVersion;
 
         /// <summary>
         /// Product Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
+        [ConfigField("Product Id",
+            "Product Id defined in the Development Portal.", 
+            0, "Product Information")]
         public string productID;
+
+        #endregion
+
+        #region Deployment
 
         /// <summary>
         /// Sandbox Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
+        [ConfigField("Sandbox Id",
+            "Sandbox Id to use.", 
+            1, "Deployment")]
         public string sandboxID;
 
         /// <summary>
         /// Deployment Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
+        [ConfigField("Deployment Id",
+            "Deployment Id to use.", 
+            1, "Deployment")]
         public string deploymentID;
 
         /// <summary>
         /// SandboxDeploymentOverride pairs used to override Deployment ID when
         /// a given Sandbox ID is used.
         /// </summary>
+        [ConfigField("Sandbox Deployment Overrides", 
+            ConfigFieldType.TextList, 
+            "Deployment Id to use.", 
+            1, "Deployment")]
         public List<SandboxDeploymentOverride> sandboxDeploymentOverrides;
+
+        /// <summary>
+        /// Set to 'true' if the application is a dedicated game server.
+        /// </summary>
+        [ConfigField("Is Server", 
+            ConfigFieldType.Flag, 
+            "Indicates whether the application is a dedicated game " +
+            "server.", 1, "Deployment")]
+        public bool isServer;
+
+        #endregion
+
+        #region Client Authentication
 
         /// <summary>
         /// Client Secret defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
+        [ConfigField("Client Secret", 
+            "Client Secret defined in the Development Portal.", 
+            2, "Client Authentication")]
         public string clientSecret;
 
         /// <summary>
         /// Client Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
+        [ConfigField("Client Id", 
+            "Client Id defined in the Development Portal.", 
+            2, "Client Authentication")]
         public string clientID;
 
         /// <summary>
         /// Encryption Key&lt; used by default to decode files previously
         /// encoded and stored in EOS.
         /// </summary>
+        [ConfigField("Encryption Key", 
+            "Encryption key to use for client authentication.",
+            2, "Client Authentication")]
         public string encryptionKey;
+
+        /// <summary>
+        /// Used to store what should be done when the Generate Key button is
+        /// pressed.
+        /// </summary>
+        [ConfigField("Generate Key", ConfigFieldType.Button,
+            "Click to generate an encryption key.", 
+            2, "Client Authentication")]
+        private Action GenerateKeyButtonAction;
+
+        #endregion
+
+        #region Flags
 
         /// <summary>
         /// Flags; used to initialize the EOS platform.
         /// </summary>
+        [ConfigField("Platform Options", 
+            ConfigFieldType.TextList,
+            "Platform option flags", 
+            3, "Flags")]
         public List<string> platformOptionsFlags;
 
         /// <summary>
         /// Flags; used to set user auth when logging in.
         /// </summary>
+        [ConfigField("Auth Scope Options", 
+            ConfigFieldType.TextList, 
+            "Platform option flags", 
+            3, "Flags")]
         public List<string> authScopeOptionsFlags;
+
+        #endregion
+
+        #region Thread Affinity & Various Time Budgets
 
         /// <summary>
         /// Tick Budget; used to define the maximum amount of execution time the
         /// EOS SDK can use each frame.
         /// </summary>
+        [ConfigField("Tick Budget (ms)", 
+            ConfigFieldType.Uint, 
+            "Used to define the maximum amount of execution time the " +
+            "EOS SDK can use each frame.", 
+            3, "Thread Affinity & Tick Budgets")]
         public uint tickBudgetInMilliseconds;
 
         /// <summary>
-        /// TaskNetworkTimeoutSeconds; used to define the maximum number of seconds
-        /// the EOS SDK will allow network calls to run before failing with EOS_TimedOut.
-        /// This plugin treats any value that is less than or equal to zero as
-        /// using the default value for the EOS SDK, which is 30 seconds.
-        /// This value is only used when the <see cref="NetworkStatus"/> is not <see cref="NetworkStatus.Online"/>.
+        /// TaskNetworkTimeoutSeconds; used to define the maximum number of
+        /// seconds the EOS SDK will allow network calls to run before failing
+        /// with EOS_TimedOut. This plugin treats any value that is less than or
+        /// equal to zero as using the default value for the EOS SDK, which is
+        /// 30 seconds.
+        ///
+        /// This value is only used when the <see cref="NetworkStatus"/> is not
+        /// <see cref="NetworkStatus.Online"/>.
         /// <seealso cref="PlatformInterface.GetNetworkStatus"/>
         /// </summary>
+        [ConfigField("Network Timeout Seconds", 
+            ConfigFieldType.Double, 
+            "Indicates the maximum number of seconds that EOS SDK " +
+            "will allow network calls to run before failing with EOS_TimedOut.",
+            3, "Thread Affinity & Tick Budgets")]
         public double taskNetworkTimeoutSeconds;
 
         /// <summary>
         /// Network Work Affinity; specifies thread affinity for network
         /// management that is not IO.
         /// </summary>
+        [ConfigField("Network Work",
+            "Specifies affinity for threads that manage network tasks " +
+            "that are not IO related.", 
+            3, "Thread Affinity & Tick Budgets")]
         public string ThreadAffinity_networkWork;
-        
+
         /// <summary>
         /// Storage IO Affinity; specifies affinity for threads that will
         /// interact with a storage device.
         /// </summary>
+        [ConfigField("Storage IO", 
+            "Specifies affinity for threads that generate storage IO.", 
+            3, "Thread Affinity & Tick Budgets")]
         public string ThreadAffinity_storageIO;
-        
+
         /// <summary>
         /// Web Socket IO Affinity; specifies affinity for threads that generate
         /// web socket IO.
         /// </summary>
+        [ConfigField("Web Socket IO", 
+            "Specifies affinity for threads that generate web socket " +
+            "IO.", 3, "Thread Affinity & Tick Budgets")]
         public string ThreadAffinity_webSocketIO;
-        
+
         /// <summary>
         /// P2P IO Affinity; specifies affinity for any thread that will
         /// generate IO related to P2P traffic and management.
         /// </summary>
+        [ConfigField("P2P IO",
+            "Specifies affinity for any thread that will generate IO " +
+            "related to P2P traffic and management.", 
+            3, "Thread Affinity & Tick Budgets")]
         public string ThreadAffinity_P2PIO;
-        
+
         /// <summary>
         /// HTTP Request IO Affinity; specifies affinity for any thread that
         /// will generate http request IO.
         /// </summary>
+        [ConfigField("HTTP Request IO",
+            "Specifies the affinity for any thread that will generate " +
+            "HTTP request IO.", 
+            3, "Thread Affinity & Tick Budgets")]
         public string ThreadAffinity_HTTPRequestIO;
 
         /// <summary>
         /// RTC IO Affinity&lt;/c&gt; specifies affinity for any thread that
         /// will generate IO related to RTC traffic and management.
         /// </summary>
+        [ConfigField("RTC IO",
+            "Specifies the affinity for any thread that will generate " +
+            "IO related to RTC traffic and management.", 
+            3, "Thread Affinity & Tick Budgets")]
         public string ThreadAffinity_RTCIO;
+
+        #endregion
+
+        #region Overlay Options
 
         /// <summary>
         /// Always Send Input to Overlay &lt;/c&gt;If true, the plugin will
         /// always send input to the overlay from the C# side to native, and
-        /// handle showing the overlay. This doesn't always mean input makes
-        /// it to the EOS SDK.
+        /// handle showing the overlay. This doesn't always mean input makes it
+        /// to the EOS SDK.
         /// </summary>
+        [ConfigField("Always Send Input to Overlay", 
+            ConfigFieldType.Flag, 
+            "If true, the plugin will always send input to the " +
+            "overlay from the C# side to native, and handle showing the " +
+            "overlay. This doesn't always mean input makes it to the EOS SDK.",
+            4, "Overlay Options")]
         public bool alwaysSendInputToOverlay;
 
         /// <summary>
-        /// Initial Button Delay; Stored as a string so it can be 'empty'
+        /// Initial Button Delay.
         /// </summary>
+        [ConfigField("Initial Button Delay", 
+            "Initial Button Delay (if not set, whatever the default " +
+            "is will be used).",
+            4, "Overlay Options")]
         public string initialButtonDelayForOverlay;
 
         /// <summary>
-        /// Repeat button delay for overlay; Stored as a string so it can be
-        /// 'empty'.
+        /// Repeat button delay for overlay.
         /// </summary>
+        [ConfigField("Repeat Button Delay",
+            "Repeat button delay for the overlay. If not set, " +
+            "whatever the default is will be used.", 
+            4, "Overlay Options")]
         public string repeatButtonDelayForOverlay;
 
-        /// <summary>
-        /// HACK: send force send input without delay&lt;/c&gt;If true, the
-        /// native plugin will always send input received directly to the SDK.
-        /// If set to false, the plugin will attempt to delay the input to
-        /// mitigate CPU spikes caused by spamming the SDK.
-        /// </summary>
-        public bool hackForceSendInputDirectlyToSDK;
-
-        /// <summary>
-        /// Set to 'true' if the application is a dedicated game server.
-        /// </summary>
-        public bool isServer;
+        #endregion
 
         public static Regex InvalidEncryptionKeyRegex;
         
@@ -293,7 +407,9 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <returns>A PlatformFlags enum value.</returns>
         public PlatformFlags GetPlatformFlags()
         {
-            return StringsToEnum<PlatformFlags>(platformOptionsFlags, PlatformFlagsExtensions.TryParse);
+            return StringsToEnum<PlatformFlags>(
+                platformOptionsFlags, 
+                PlatformFlagsExtensions.TryParse);
         }
 
         /// <summary>
@@ -304,7 +420,9 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <returns>An AuthScopeFlags enum value.</returns>
         public AuthScopeFlags GetAuthScopeFlags()
         {
-            return StringsToEnum<AuthScopeFlags>(authScopeOptionsFlags, AuthScopeFlagsExtensions.TryParse);
+            return StringsToEnum<AuthScopeFlags>(
+                authScopeOptionsFlags, 
+                AuthScopeFlagsExtensions.TryParse);
         }
 
         /// <summary>

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -77,14 +77,14 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Product Name defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Product Name",
+        [ConfigField("Product Name", ConfigFieldType.Text,
             "Product name defined in the Development Portal.", 0)]
         public string productName;
 
         /// <summary>
         /// Version of Product.
         /// </summary>
-        [ConfigField("Product Version",
+        [ConfigField("Product Version", ConfigFieldType.Text,
             "Version of the product.", 0)]
         public string productVersion;
 
@@ -92,7 +92,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Product Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Product Id",
+        [ConfigField("Product Id", ConfigFieldType.Text,
             "Product Id defined in the Development Portal.", 0)]
         public string productID;
 
@@ -104,14 +104,15 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Sandbox Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Sandbox Id", "Sandbox Id to use.", 1)]
+        [ConfigField("Sandbox Id", ConfigFieldType.Text, 
+            "Sandbox Id to use.", 1)]
         public string sandboxID;
 
         /// <summary>
         /// Deployment Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Deployment Id", 
+        [ConfigField("Deployment Id", ConfigFieldType.Text,
             "Deployment Id to use.", 1)]
         public string deploymentID;
 
@@ -142,7 +143,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Client Secret defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Client Secret", 
+        [ConfigField("Client Secret", ConfigFieldType.Text,
             "Client Secret defined in the Development Portal.", 
             2)]
         public string clientSecret;
@@ -151,7 +152,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Client Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Client Id", 
+        [ConfigField("Client Id", ConfigFieldType.Text,
             "Client Id defined in the Development Portal.", 
             2)]
         public string clientID;
@@ -160,7 +161,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Encryption Key&lt; used by default to decode files previously
         /// encoded and stored in EOS.
         /// </summary>
-        [ConfigField("Encryption Key", 
+        [ConfigField("Encryption Key", ConfigFieldType.Text,
             "Encryption key to use for client authentication.",
             2)]
         public string encryptionKey;
@@ -233,7 +234,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Network Work Affinity; specifies thread affinity for network
         /// management that is not IO.
         /// </summary>
-        [ConfigField("Network Work",
+        [ConfigField("Network Work", ConfigFieldType.Text,
             "Specifies affinity for threads that manage network tasks " +
             "that are not IO related.", 
             3)]
@@ -243,7 +244,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Storage IO Affinity; specifies affinity for threads that will
         /// interact with a storage device.
         /// </summary>
-        [ConfigField("Storage IO", 
+        [ConfigField("Storage IO", ConfigFieldType.Text,
             "Specifies affinity for threads that generate storage IO.", 
             3)]
         public string ThreadAffinity_storageIO;
@@ -252,7 +253,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Web Socket IO Affinity; specifies affinity for threads that generate
         /// web socket IO.
         /// </summary>
-        [ConfigField("Web Socket IO", 
+        [ConfigField("Web Socket IO", ConfigFieldType.Text,
             "Specifies affinity for threads that generate web socket " +
             "IO.", 3)]
         public string ThreadAffinity_webSocketIO;
@@ -261,7 +262,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// P2P IO Affinity; specifies affinity for any thread that will
         /// generate IO related to P2P traffic and management.
         /// </summary>
-        [ConfigField("P2P IO",
+        [ConfigField("P2P IO", ConfigFieldType.Text,
             "Specifies affinity for any thread that will generate IO " +
             "related to P2P traffic and management.", 
             3)]
@@ -271,7 +272,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// HTTP Request IO Affinity; specifies affinity for any thread that
         /// will generate http request IO.
         /// </summary>
-        [ConfigField("HTTP Request IO",
+        [ConfigField("HTTP Request IO", ConfigFieldType.Text,
             "Specifies the affinity for any thread that will generate " +
             "HTTP request IO.", 
             3)]
@@ -281,7 +282,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// RTC IO Affinity&lt;/c&gt; specifies affinity for any thread that
         /// will generate IO related to RTC traffic and management.
         /// </summary>
-        [ConfigField("RTC IO",
+        [ConfigField("RTC IO", ConfigFieldType.Text,
             "Specifies the affinity for any thread that will generate " +
             "IO related to RTC traffic and management.", 
             3)]
@@ -308,7 +309,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <summary>
         /// Initial Button Delay.
         /// </summary>
-        [ConfigField("Initial Button Delay", 
+        [ConfigField("Initial Button Delay", ConfigFieldType.Text,
             "Initial Button Delay (if not set, whatever the default " +
             "is will be used).", 4)]
         public string initialButtonDelayForOverlay;
@@ -316,7 +317,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <summary>
         /// Repeat button delay for overlay.
         /// </summary>
-        [ConfigField("Repeat Button Delay",
+        [ConfigField("Repeat Button Delay", ConfigFieldType.Text,
             "Repeat button delay for the overlay. If not set, " +
             "whatever the default is will be used.", 4)]
         public string repeatButtonDelayForOverlay;

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -310,8 +310,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Initial Button Delay", 
             "Initial Button Delay (if not set, whatever the default " +
-            "is will be used).",
-            4)]
+            "is will be used).", 4)]
         public string initialButtonDelayForOverlay;
 
         /// <summary>
@@ -319,9 +318,21 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Repeat Button Delay",
             "Repeat button delay for the overlay. If not set, " +
-            "whatever the default is will be used.", 
-            4)]
+            "whatever the default is will be used.", 4)]
         public string repeatButtonDelayForOverlay;
+
+        /// <summary>
+        /// HACK: send force send input without delay&lt;/c&gt;If true, the
+        /// native plugin will always send input received directly to the SDK.
+        /// If set to false, the plugin will attempt to delay the input to
+        /// mitigate CPU spikes caused by spamming the SDK.
+        /// </summary>
+        [ConfigField("Send input without delay", 
+            ConfigFieldType.Flag, 
+            "Workaround to force send input without any delay. If " +
+            "true, the native plugin will always send input receive directly " +
+            "to the SDK.", 4)]
+        public bool hackForceSendInputDirectlyToSDK;
 
         #endregion
 

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -51,6 +51,15 @@ namespace PlayEveryWare.EpicOnlineServices
     /// Represents the EOS Configuration used for initializing EOS SDK.
     /// </summary>
     [Serializable]
+    [ConfigGroup("EOS Config", new []
+    {
+        "Product Information",
+        "Deployment",
+        "Client Authentication",
+        "Flags",
+        "Thread Affinity & Tick Budgets",
+        "Overlay Options"
+    }, false)]
     public class EOSConfig : Config
     {
         static EOSConfig()
@@ -59,7 +68,8 @@ namespace PlayEveryWare.EpicOnlineServices
             RegisterFactory(() => new EOSConfig());
         }
 
-        protected EOSConfig() : base("EpicOnlineServicesConfig.json") { }
+        protected EOSConfig() : base("EpicOnlineServicesConfig.json") 
+        { }
 
         #region Product Information
 
@@ -68,16 +78,14 @@ namespace PlayEveryWare.EpicOnlineServices
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
         [ConfigField("Product Name",
-            "Product name defined in the Development Portal.", 
-            0, "Product Information")]
+            "Product name defined in the Development Portal.", 0)]
         public string productName;
 
         /// <summary>
         /// Version of Product.
         /// </summary>
         [ConfigField("Product Version",
-            "Version of the product.", 
-            0, "Product Information")]
+            "Version of the product.", 0)]
         public string productVersion;
 
         /// <summary>
@@ -85,8 +93,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
         [ConfigField("Product Id",
-            "Product Id defined in the Development Portal.", 
-            0, "Product Information")]
+            "Product Id defined in the Development Portal.", 0)]
         public string productID;
 
         #endregion
@@ -97,18 +104,15 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Sandbox Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Sandbox Id",
-            "Sandbox Id to use.", 
-            1, "Deployment")]
+        [ConfigField("Sandbox Id", "Sandbox Id to use.", 1)]
         public string sandboxID;
 
         /// <summary>
         /// Deployment Id defined in the
         /// [Development Portal](https://dev.epicgames.com/portal/)
         /// </summary>
-        [ConfigField("Deployment Id",
-            "Deployment Id to use.", 
-            1, "Deployment")]
+        [ConfigField("Deployment Id", 
+            "Deployment Id to use.", 1)]
         public string deploymentID;
 
         /// <summary>
@@ -117,8 +121,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Sandbox Deployment Overrides", 
             ConfigFieldType.TextList, 
-            "Deployment Id to use.", 
-            1, "Deployment")]
+            "Deployment Id to use.", 1)]
         public List<SandboxDeploymentOverride> sandboxDeploymentOverrides;
 
         /// <summary>
@@ -127,7 +130,8 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("Is Server", 
             ConfigFieldType.Flag, 
             "Indicates whether the application is a dedicated game " +
-            "server.", 1, "Deployment")]
+            "server.", 
+            1)]
         public bool isServer;
 
         #endregion
@@ -140,7 +144,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Client Secret", 
             "Client Secret defined in the Development Portal.", 
-            2, "Client Authentication")]
+            2)]
         public string clientSecret;
 
         /// <summary>
@@ -149,7 +153,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Client Id", 
             "Client Id defined in the Development Portal.", 
-            2, "Client Authentication")]
+            2)]
         public string clientID;
 
         /// <summary>
@@ -158,7 +162,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Encryption Key", 
             "Encryption key to use for client authentication.",
-            2, "Client Authentication")]
+            2)]
         public string encryptionKey;
 
         /// <summary>
@@ -167,7 +171,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Generate Key", ConfigFieldType.Button,
             "Click to generate an encryption key.", 
-            2, "Client Authentication")]
+            2)]
         private Action GenerateKeyButtonAction;
 
         #endregion
@@ -180,7 +184,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("Platform Options", 
             ConfigFieldType.TextList,
             "Platform option flags", 
-            3, "Flags")]
+            3)]
         public List<string> platformOptionsFlags;
 
         /// <summary>
@@ -189,7 +193,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("Auth Scope Options", 
             ConfigFieldType.TextList, 
             "Platform option flags", 
-            3, "Flags")]
+            3)]
         public List<string> authScopeOptionsFlags;
 
         #endregion
@@ -204,7 +208,7 @@ namespace PlayEveryWare.EpicOnlineServices
             ConfigFieldType.Uint, 
             "Used to define the maximum amount of execution time the " +
             "EOS SDK can use each frame.", 
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public uint tickBudgetInMilliseconds;
 
         /// <summary>
@@ -222,7 +226,7 @@ namespace PlayEveryWare.EpicOnlineServices
             ConfigFieldType.Double, 
             "Indicates the maximum number of seconds that EOS SDK " +
             "will allow network calls to run before failing with EOS_TimedOut.",
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public double taskNetworkTimeoutSeconds;
 
         /// <summary>
@@ -232,7 +236,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("Network Work",
             "Specifies affinity for threads that manage network tasks " +
             "that are not IO related.", 
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public string ThreadAffinity_networkWork;
 
         /// <summary>
@@ -241,7 +245,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Storage IO", 
             "Specifies affinity for threads that generate storage IO.", 
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public string ThreadAffinity_storageIO;
 
         /// <summary>
@@ -250,7 +254,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         [ConfigField("Web Socket IO", 
             "Specifies affinity for threads that generate web socket " +
-            "IO.", 3, "Thread Affinity & Tick Budgets")]
+            "IO.", 3)]
         public string ThreadAffinity_webSocketIO;
 
         /// <summary>
@@ -260,7 +264,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("P2P IO",
             "Specifies affinity for any thread that will generate IO " +
             "related to P2P traffic and management.", 
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public string ThreadAffinity_P2PIO;
 
         /// <summary>
@@ -270,7 +274,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("HTTP Request IO",
             "Specifies the affinity for any thread that will generate " +
             "HTTP request IO.", 
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public string ThreadAffinity_HTTPRequestIO;
 
         /// <summary>
@@ -280,7 +284,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("RTC IO",
             "Specifies the affinity for any thread that will generate " +
             "IO related to RTC traffic and management.", 
-            3, "Thread Affinity & Tick Budgets")]
+            3)]
         public string ThreadAffinity_RTCIO;
 
         #endregion
@@ -298,7 +302,7 @@ namespace PlayEveryWare.EpicOnlineServices
             "If true, the plugin will always send input to the " +
             "overlay from the C# side to native, and handle showing the " +
             "overlay. This doesn't always mean input makes it to the EOS SDK.",
-            4, "Overlay Options")]
+            4)]
         public bool alwaysSendInputToOverlay;
 
         /// <summary>
@@ -307,7 +311,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("Initial Button Delay", 
             "Initial Button Delay (if not set, whatever the default " +
             "is will be used).",
-            4, "Overlay Options")]
+            4)]
         public string initialButtonDelayForOverlay;
 
         /// <summary>
@@ -316,7 +320,7 @@ namespace PlayEveryWare.EpicOnlineServices
         [ConfigField("Repeat Button Delay",
             "Repeat button delay for the overlay. If not set, " +
             "whatever the default is will be used.", 
-            4, "Overlay Options")]
+            4)]
         public string repeatButtonDelayForOverlay;
 
         #endregion

--- a/com.playeveryware.eos/Runtime/Core/Config/RuntimeConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/RuntimeConfig.cs
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#define EOS_RUNTIME_NEW_CONFIG_SYSTEM
+//#define EOS_RUNTIME_NEW_CONFIG_SYSTEM
 
 namespace PlayEveryWare.EpicOnlineServices
 {

--- a/com.playeveryware.eos/Runtime/Core/Config/RuntimeConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/RuntimeConfig.cs
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-//#define EOS_RUNTIME_NEW_CONFIG_SYSTEM
+#define EOS_RUNTIME_NEW_CONFIG_SYSTEM
 
 namespace PlayEveryWare.EpicOnlineServices
 {
@@ -47,7 +47,7 @@ namespace PlayEveryWare.EpicOnlineServices
     /// Most of the values for these field members come from the
     /// [Development Portal](https://dev.epicgames.com/portal/)
     /// </summary>
-    public readonly struct RuntimeConfig
+    public struct RuntimeConfig
     {
     #region EOS SDK Configuration Values
 


### PR DESCRIPTION
Preparatory to introducing the ability to validate configuration values and override them in a clear manner through the use of overrides on a per-platform basis, this PR adds (as-of-yet unreferenced) `ConfigFieldAttribute`s to each of the fields within `EOSConfig`.

Adjacent to these changes, several unreferenced editor-centric and unused functions were removed from the utility `GUIEditorUtility`, while a new one for `double` was added:

- `AssigningUintField`
- `AssigningULongField`
- `AssigningPath`

#EOS-1982