### PR TITLE
test: Auth/Connect while already logged in produces expected results

### DIFF
--- a/Assets/Tests/PlayMode/AuthenticationTests.cs
+++ b/Assets/Tests/PlayMode/AuthenticationTests.cs
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PlayEveryWare.EpicOnlineServices.Tests.Auth
+{
+    using Epic.OnlineServices;
+    using Epic.OnlineServices.Achievements;
+    using Epic.OnlineServices.Auth;
+    using Epic.OnlineServices.Stats;
+    using NUnit.Framework;
+    using System.Collections;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public class AuthenticationTests
+    {
+        GameObject eosObject;
+        protected const float LoginTestTimeout = 30f;
+
+        [TearDown]
+        public void ShutdownEOS()
+        {
+            EOSManager.Instance?.OnShutdown();
+            UnityEngine.Object.Destroy(eosObject);
+        }
+
+        /// <summary>
+        /// This test creates a new EOSManager object, and uses it to auth-login.
+        /// Then after a successful login, it tries to auth login again.
+        /// The result should be as expected.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator AuthLogin_WhileAlreadyLoggedIn_ReturnsExpectedResult()
+        {
+            eosObject = new GameObject();
+            var eosManager = eosObject.AddComponent<EOSManager>();
+
+            UnitTestConfig config = EpicOnlineServices.Config.Get<UnitTestConfig>();
+
+            // Initial Auth login
+            LoginCallbackInfo? loginResult = null;
+            EOSManager.Instance.StartLoginWithLoginTypeAndToken(LoginCredentialType.Developer,
+                                                                $"{config.EOSDevAuthToolIP}:{config.EOSDevAuthToolPort}",
+                                                                config.EOSDevAuthToolUserName,
+                                                                data => { loginResult = data; });
+
+            yield return new EOSTestBase.WaitUntilDone(LoginTestTimeout, () => loginResult != null);
+
+            Assert.IsNotNull(loginResult,
+                "Could not log into EOS, loginResult was not set.");
+
+            Assert.AreEqual(Result.Success, loginResult.Value.ResultCode,
+                $"Login result failed: {loginResult.Value.ResultCode}");
+
+            // Subsequent Auth login
+            loginResult = null;
+            EOSManager.Instance.StartLoginWithLoginTypeAndToken(LoginCredentialType.Developer,
+                                                                $"{config.EOSDevAuthToolIP}:{config.EOSDevAuthToolPort}",
+                                                                config.EOSDevAuthToolUserName,
+                                                                data => { loginResult = data; });
+
+            yield return new EOSTestBase.WaitUntilDone(LoginTestTimeout, () => loginResult != null);
+
+            Assert.IsNotNull(loginResult,
+                "Could not log into EOS, loginResult was not set.");
+
+            Assert.AreEqual(Result.Success, loginResult.Value.ResultCode,
+                $"Login result failed: {loginResult.Value.ResultCode}");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/AuthenticationTests.cs.meta
+++ b/Assets/Tests/PlayMode/AuthenticationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20ac7e12f4cad0c478a6c0906a7a55ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/ConnectTests.cs
+++ b/Assets/Tests/PlayMode/ConnectTests.cs
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PlayEveryWare.EpicOnlineServices.Tests.Connect
+{
+    using Epic.OnlineServices;
+    using Epic.OnlineServices.Achievements;
+    using Epic.OnlineServices.Stats;
+    using NUnit.Framework;
+    using System.Collections;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public class ConnectTests
+    {
+        GameObject eosObject;
+        protected const float LoginTestTimeout = 30f;
+
+        [TearDown]
+        public void ShutdownEOS()
+        {
+            EOSManager.Instance?.OnShutdown();
+            UnityEngine.Object.Destroy(eosObject);
+        }
+
+        /// <summary>
+        /// This test creates a new EOSManager object, and uses it to auth-login.
+        /// Then it does a Connect login.
+        /// After a successful Connect login, it tries to perform another Connect login.
+        /// The result should be as expected.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator ConnectLogin_WhileAlreadyLoggedIn_ReturnsExpectedResult()
+        {
+            eosObject = new GameObject();
+            var eosManager = eosObject.AddComponent<EOSManager>();
+
+            UnitTestConfig config = EpicOnlineServices.Config.Get<UnitTestConfig>();
+
+            // Auth login
+            // This isn't what this test is testing, but we must first auth login before connect login
+            Epic.OnlineServices.Auth.LoginCallbackInfo? loginResult = null;
+            EOSManager.Instance.StartLoginWithLoginTypeAndToken(Epic.OnlineServices.Auth.LoginCredentialType.Developer,
+                                                                $"{config.EOSDevAuthToolIP}:{config.EOSDevAuthToolPort}",
+                                                                config.EOSDevAuthToolUserName,
+                                                                data => { loginResult = data; });
+
+            yield return new EOSTestBase.WaitUntilDone(LoginTestTimeout, () => loginResult != null);
+
+            Assert.IsNotNull(loginResult,
+                "Could not log into EOS, loginResult was not set.");
+
+            Assert.AreEqual(Result.Success, loginResult.Value.ResultCode,
+                $"Login result failed: {loginResult.Value.ResultCode}");
+
+            // Now that this is logged in, attempt connect login
+            Epic.OnlineServices.Connect.LoginCallbackInfo? callbackInfo = null;
+            EOSManager.Instance.StartConnectLoginWithEpicAccount(loginResult.Value.LocalUserId, data =>
+            {
+                callbackInfo = data;
+            });
+
+            yield return new EOSTestBase.WaitUntilDone(LoginTestTimeout, () => callbackInfo != null);
+
+            Assert.IsNotNull(callbackInfo,
+                "Could not connect with Epic account, callbackInfo was not set.");
+
+            Assert.AreEqual(Result.Success, callbackInfo.Value.ResultCode,
+                $"Could not connect with Epic account: {callbackInfo.Value.ResultCode}");
+
+            Assert.That(EOSManager.Instance.GetProductUserId().IsValid(),
+                "Current player is invalid.");
+
+            // Subsequent connect login, check for expected results
+            callbackInfo = null;
+            EOSManager.Instance.StartConnectLoginWithEpicAccount(loginResult.Value.LocalUserId, data =>
+            {
+                callbackInfo = data;
+            });
+
+            yield return new EOSTestBase.WaitUntilDone(LoginTestTimeout, () => callbackInfo != null);
+
+            Assert.IsNotNull(callbackInfo,
+                "Could not connect with Epic account, callbackInfo was not set.");
+
+            Assert.AreEqual(Result.Success, callbackInfo.Value.ResultCode,
+                $"Could not connect with Epic account: {callbackInfo.Value.ResultCode}");
+
+            Assert.That(EOSManager.Instance.GetProductUserId().IsValid(),
+                "Current player is invalid.");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ConnectTests.cs.meta
+++ b/Assets/Tests/PlayMode/ConnectTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eeb531ad22b0ae949b9e1d3ce870a980
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/com.playeveryware.eos.tests.playmode.asmdef
+++ b/Assets/Tests/PlayMode/com.playeveryware.eos.tests.playmode.asmdef
@@ -7,7 +7,8 @@
         "GUID:3a63500f0eef43a438c0553491f7c5da",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:f4c43db447a22a645bb9364507e4ba6c"
+        "GUID:f4c43db447a22a645bb9364507e4ba6c",
+        "GUID:cc11d9857b82d9b458fca637d5cb33fb"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Paul had a suspicion that #889 might need to handle a user scenario where the system is already authenticated. To attempt to determine how this works, we made these two very simple tests.

Auth login, then try to Auth login. The result should be success.

Connect login, then try to Connect login. The result should be success.

Added a reference to the -Editor assembly in PlayMode tests so that it can access UnitTestConfig. If this isn't appropriate, we can try to address that.

#EOS-2113