### PR TITLE
Fix Documentation Links

### DIFF
--- a/com.playeveryware.eos/Documentation~/Walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/Walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # EOS Plugin for Unity Walkthrough
  
@@ -24,7 +24,7 @@ The Debug log provides a filterable on screen debug output
 ## Scene selection
 The yellow dropdown in the top of the window allows the user to select which demo scene they would like to log into
 
-There is a standard sample pack, and several extra packs in the EOS Unity Plugin. If a scene doesn't load, remember to import the wanted extra pack, and [add them in the build settings](/README.md#importing-samples)
+There is a standard sample pack, and several extra packs in the EOS Unity Plugin. If a scene doesn't load, remember to import the wanted extra pack, and [add them in the build settings](/com.playeveryware.eos/README.md#importing-samples)
 
 
 ## Login Page

--- a/com.playeveryware.eos/Documentation~/add_plugin.md
+++ b/com.playeveryware.eos/Documentation~/add_plugin.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
 
 # Adding via Package Manager
 

--- a/com.playeveryware.eos/Documentation~/android/README_Android.md
+++ b/com.playeveryware.eos/Documentation~/android/README_Android.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
 
 <div align="center"> <img src="/com.playeveryware.eos/Documentation~/images/EOSPluginLogo.png" alt="PlayEveryWare EOS Plugin for Unity" /> </div>
 
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
-* The standard <a href="/README.md#prerequisites">Prerequisites</a> for all platforms.
+* The standard <a href="/com.playeveryware.eos/README.md#prerequisites">Prerequisites</a> for all platforms.
 *  Check out this <a href="environment_setup_android.md#environment-setup-for-android">Environment Setup</a> doc for a quick setup guide.
 *  More detailed instructions can be found in the links below.
     * <a href="https://docs.unity3d.com/2021.3/Documentation/Manual/android-sdksetup.html">Android environment setup</a> for Unity.
@@ -16,13 +16,13 @@
 ## Importing the Plugin
 
 
-You can follow the standard <a href="/README.md#importing-the-plugin">Importing the Plugin</a> process. With a few changes here when <a href="#running-the-samples">running the samples</a> and <a href="#configuring-the-plugin">configuring the plugin</a>.
+You can follow the standard <a href="/com.playeveryware.eos/README.md#importing-the-plugin">Importing the Plugin</a> process. With a few changes here when <a href="#running-the-samples">running the samples</a> and <a href="#configuring-the-plugin">configuring the plugin</a>.
 > [!WARNING]
 > If you choose the tarball method, when downloading the release on mac it may convert the `.tgz` into a `.tar` which is not compatible with unity. Changing the file extension back to a `.tgz` should fix this.
 
 ## Samples
 
-You can follow the standard <a href="/README.md#samples">Samples</a> process.   
+You can follow the standard <a href="/com.playeveryware.eos/README.md#samples">Samples</a> process.   
 Please note the details in the <a href="#running-the-samples">Running the samples</a> section when running the samples from a build for Android.  
 
 > [!WARNING] 
@@ -30,14 +30,14 @@ Please note the details in the <a href="#running-the-samples">Running the sample
 
 ## Running the samples
 
-When following the steps to <a href="/README.md#running-the-samples">run a sample</a> from a build for Android, follow the Unity doc for <a href="https://docs.unity3d.com/2021.3/Documentation/Manual/android-sdksetup.html">Debugging on an Android device</a>, to connect your device to the engine.  
+When following the steps to <a href="/com.playeveryware.eos/README.md#running-the-samples">run a sample</a> from a build for Android, follow the Unity doc for <a href="https://docs.unity3d.com/2021.3/Documentation/Manual/android-sdksetup.html">Debugging on an Android device</a>, to connect your device to the engine.  
 This will allow the smoother ```Build And Run``` option to work instead of just using the ```Build``` button.  
 
 When running on a device you may need to <a href="https://developer.android.com/studio/debug/dev-options#enable">enable developer mode</a> on the device, then <a href="https://developer.android.com/studio/debug/dev-options#Enable-debugging">Enable USB debugging on your device</a>, as well as accepting any popups that appear on the phone during the process.
 
 ## Configuring the Plugin
 
-You can follow the standard <a href="/README.md#configuring-the-plugin">Configuring the Plugin</a> process.  With the additional steps after saving the Main EOS Config.
+You can follow the standard <a href="/com.playeveryware.eos/README.md#configuring-the-plugin">Configuring the Plugin</a> process.  With the additional steps after saving the Main EOS Config.
 
 ## Additional Configuration Steps <a name="configuration-steps" />
 

--- a/com.playeveryware.eos/Documentation~/android/environment_setup_android.md
+++ b/com.playeveryware.eos/Documentation~/android/environment_setup_android.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
 
 # <div align="center">Environment Setup for Android</div>
 ---

--- a/com.playeveryware.eos/Documentation~/android/link_eos_library_settings.md
+++ b/com.playeveryware.eos/Documentation~/android/link_eos_library_settings.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
 
 # <div align="center">Linking EOS Library on Android Settings</div>
 ---

--- a/com.playeveryware.eos/Documentation~/apple_signin.md
+++ b/com.playeveryware.eos/Documentation~/apple_signin.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Connect Login with AppleID using Sign In With Apple Plugin</div>
 ---

--- a/com.playeveryware.eos/Documentation~/class_description.md
+++ b/com.playeveryware.eos/Documentation~/class_description.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Class descriptions</div>
 

--- a/com.playeveryware.eos/Documentation~/configure_plugin.md
+++ b/com.playeveryware.eos/Documentation~/configure_plugin.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
 
 # Configuring the Plugin
 
@@ -40,6 +40,6 @@ To function, the plugin needs some information from your EOS project. Be sure to
     - Attach `EOSManager.cs (Script)` to a Unity object, and it will initialize the plugin with the specified configuration in `OnAwake()` (this is what `Singletons.prefab` does).
 
 > [!NOTE]
-The included [samples](http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#samples) already have configuration values set for you to experiment with!
+The included [samples](http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/com.playeveryware.eos/README.md#samples) already have configuration values set for you to experiment with!
 
 If you would like to see specific examples of various EOS features in action, import the sample Unity scenes that are described below.

--- a/com.playeveryware.eos/Documentation~/contributions.md
+++ b/com.playeveryware.eos/Documentation~/contributions.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
 
 # Contributor Notes
 

--- a/com.playeveryware.eos/Documentation~/creating_the_upm_package.md
+++ b/com.playeveryware.eos/Documentation~/creating_the_upm_package.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Creating a UPM package</div>
 ---

--- a/com.playeveryware.eos/Documentation~/dev_env/HyperV_Linux_Guest_VM.md
+++ b/com.playeveryware.eos/Documentation~/dev_env/HyperV_Linux_Guest_VM.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Setting up a Hyper-V Linux Guest VM</div>
 ---

--- a/com.playeveryware.eos/Documentation~/dev_env/Ubuntu_Development_Environment.md
+++ b/com.playeveryware.eos/Documentation~/dev_env/Ubuntu_Development_Environment.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Configuring Ubuntu 18.04 for development</div>
 ---

--- a/com.playeveryware.eos/Documentation~/disable_plugin_per_platform.md
+++ b/com.playeveryware.eos/Documentation~/disable_plugin_per_platform.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Disabling the EOS plugin on specific platforms</div>
 ---

--- a/com.playeveryware.eos/Documentation~/docs_on_docs/doc_style_guide.md
+++ b/com.playeveryware.eos/Documentation~/docs_on_docs/doc_style_guide.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Documentation Style Guide</div>
 ---
@@ -35,18 +35,18 @@ Fundamentally (and very broadly speaking) every document should contain two or o
 
 ## Logo:
 
-Each document should start (before the document title) with the PlayEveryWare, Inc. logo. The image should be surrounded by a link (`<a> </a>`) tag with the `href` set to the main [README.md document](/README.md), and with the width of the image set to 10%.
+Each document should start (before the document title) with the PlayEveryWare, Inc. logo. The image should be surrounded by a link (`<a> </a>`) tag with the `href` set to the main [README.md document](/com.playeveryware.eos/README.md), and with the width of the image set to 10%.
 
 Markdown:
 ```markdown
-<a href="/README.md">
+<a href="/com.playeveryware.eos/README.md">
     <img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="PlayEveryWare, Inc. Logo" width="10%"/>
 </a>
 ```
 
 What it looks like:
 
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="PlayEveryWare, Inc. Logo" width="10%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="PlayEveryWare, Inc. Logo" width="10%"/></a>
 
 ## Title:
 
@@ -152,7 +152,7 @@ Web links can be written by surrounding the text you want as the link text in br
 
 When linking to a header within the same document, the link can consist of just the pound sign followed by the header name. 
 
-When linking to another document, the base folder can be the start of the link, so `'/docs/android/README_Android.md'` would be an acceptable link. Additionally you can link to a specific area in another document by adding the pound sign and name at the end of the link, `'/README.md#prerequisites'`. when ending a sentence with a link, make sure the period is not accidentally included in the url portion of the link.
+When linking to another document, the base folder can be the start of the link, so `'/docs/android/README_Android.md'` would be an acceptable link. Additionally you can link to a specific area in another document by adding the pound sign and name at the end of the link, `'/com.playeveryware.eos/README.md#prerequisites'`. when ending a sentence with a link, make sure the period is not accidentally included in the url portion of the link.
 
 Example markdown linking to a specific section within a document:
 

--- a/com.playeveryware.eos/Documentation~/dotnet_quirks.md
+++ b/com.playeveryware.eos/Documentation~/dotnet_quirks.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center"> .NET quirks </div>
 ---

--- a/com.playeveryware.eos/Documentation~/easy_anticheat_configuration.md
+++ b/com.playeveryware.eos/Documentation~/easy_anticheat_configuration.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">How to configure Easy Anti-Cheat</div>
 ---

--- a/com.playeveryware.eos/Documentation~/ecom.md
+++ b/com.playeveryware.eos/Documentation~/ecom.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Ecom API</div>
 ---

--- a/com.playeveryware.eos/Documentation~/enabling_voice.md
+++ b/com.playeveryware.eos/Documentation~/enabling_voice.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Enabling Voice chat</div>
 ---

--- a/com.playeveryware.eos/Documentation~/eos_config_security.md
+++ b/com.playeveryware.eos/Documentation~/eos_config_security.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Security of Config File</div>
 ---

--- a/com.playeveryware.eos/Documentation~/eos_features.md
+++ b/com.playeveryware.eos/Documentation~/eos_features.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
 
 # Supported EOS SDK Features
 

--- a/com.playeveryware.eos/Documentation~/epic_game_store.md
+++ b/com.playeveryware.eos/Documentation~/epic_game_store.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="10%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="10%"/></a>
 
 # <div align="center">Epic Games Store</div> <a name="epic-games-store">
 ---

--- a/com.playeveryware.eos/Documentation~/frequently_asked_questions.md
+++ b/com.playeveryware.eos/Documentation~/frequently_asked_questions.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center"> Frequently Asked Questions (FAQ)</div>
 ---
@@ -90,7 +90,7 @@ all of Unity has been bootstrapped so that the Plugin can hook all the appropria
 ## Why does the Demo Scene fail to load?
 
 There is a standard sample pack, and several extra packs in the EOS Unity Plugin. If a scene doesn't load, remember to import the wanted extra pack.
-Additionally, make sure all wanted sample scenes are included in the build settings as shown in steps 4.-6. of <a href="/README.md#importing-samples">Importing the samples</a>.
+Additionally, make sure all wanted sample scenes are included in the build settings as shown in steps 4.-6. of <a href="/com.playeveryware.eos/README.md#importing-samples">Importing the samples</a>.
 
 ## What is the correct way to log into the Epic Games Store?
 The correct way to connect to the Epic Games Store through your application would be to use the exchange code login method:

--- a/com.playeveryware.eos/Documentation~/generating_docfx_static_site.md
+++ b/com.playeveryware.eos/Documentation~/generating_docfx_static_site.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">How to update the DocFX static site</div>
 ---

--- a/com.playeveryware.eos/Documentation~/iOS/README_iOS.md
+++ b/com.playeveryware.eos/Documentation~/iOS/README_iOS.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
 
 <div align="center"> <img src="/com.playeveryware.eos/Documentation~/images/EOSPluginLogo.png" alt="PlayEveryWare EOS Plugin for Unity" /> </div>
 
@@ -8,35 +8,35 @@
 
 ## Prerequisites
 
-* The standard <a href="/README.md#prerequisites">Prerequisites</a> for all platforms.
+* The standard <a href="/com.playeveryware.eos/README.md#prerequisites">Prerequisites</a> for all platforms.
 * <a href="https://docs.unity3d.com/2021.3/Documentation/Manual/ios-environment-setup.html">iOS environment setup</a> for Unity.
 * The iOS Unity <a href="https://docs.unity3d.com/hub/manual/AddModules.html">module</a>.
 * Xcode 10.2.x.
 
 ## Importing the Plugin
 
-You can follow the standard <a href="/README.md#importing-the-plugin">Importing the Plugin</a> process. With a few changes here when <a href="#running-the-samples">running the samples</a> and <a href="#configuring-the-plugin">configuring the plugin</a>.
+You can follow the standard <a href="/com.playeveryware.eos/README.md#importing-the-plugin">Importing the Plugin</a> process. With a few changes here when <a href="#running-the-samples">running the samples</a> and <a href="#configuring-the-plugin">configuring the plugin</a>.
 
 > [!WARNING]
 > If you choose the tarball method, when downloading the release on mac it may convert the `.tgz` into a `.tar` which is not compatible with unity. Changing the file extension back to a `.tgz` should fix this.
 
 ## Samples
 
-You can follow the standard <a href="/README.md#samples">Samples</a> process. Please note the details in the <a href="#running-the-samples">Running the samples</a> section when running the samples from a build for iOS.
+You can follow the standard <a href="/com.playeveryware.eos/README.md#samples">Samples</a> process. Please note the details in the <a href="#running-the-samples">Running the samples</a> section when running the samples from a build for iOS.
 
 > [!WARNING]
 > The EOS Overlay is not yet implemented for iOS.
 
 ## Running the samples
 
-When following the steps to <a href="/README.md#running-the-samples">run a sample</a> from a build for iOS, in Xcode, open the `.xcodeproj` from the resulting build folder. Follow the [Apple Developer instructions](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device) to build and run the app. If running on a device you may need to <a href="https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device">enable developer mode</a> on the device. This may require you to set up <a href="https://help.apple.com/xcode/mac/current/#/dev80cc24546">automatic signing</a> as well.
+When following the steps to <a href="/com.playeveryware.eos/README.md#running-the-samples">run a sample</a> from a build for iOS, in Xcode, open the `.xcodeproj` from the resulting build folder. Follow the [Apple Developer instructions](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device) to build and run the app. If running on a device you may need to <a href="https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device">enable developer mode</a> on the device. This may require you to set up <a href="https://help.apple.com/xcode/mac/current/#/dev80cc24546">automatic signing</a> as well.
 
 > [!NOTE]
 > Find the build steps in the Unity docs <a href="https://docs.unity3d.com/2021.3/Documentation/Manual/iphone-BuildProcess.html">here</a>.
 
 ## Configuring the Plugin
 
-You can follow the standard <a href="/README.md#configuring-the-plugin">Configuring the Plugin</a> process. With the additional steps after saving the Main EOS Config.
+You can follow the standard <a href="/com.playeveryware.eos/README.md#configuring-the-plugin">Configuring the Plugin</a> process. With the additional steps after saving the Main EOS Config.
 
 ## Additional Configuration Steps
 

--- a/com.playeveryware.eos/Documentation~/login_type_by_platform.md
+++ b/com.playeveryware.eos/Documentation~/login_type_by_platform.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # Login Type by Platform
 

--- a/com.playeveryware.eos/Documentation~/macOS/README_macOS.md
+++ b/com.playeveryware.eos/Documentation~/macOS/README_macOS.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 <div align="center"> <img src="/com.playeveryware.eos/Documentation~/images/EOSPluginLogo.png" alt="PlayEveryWare EOS Plugin for Unity" /> </div>
 
@@ -15,7 +15,7 @@
 
 If you want to do that work manually, please refer to the following:
 
-* The standard <a href="/README.md#prerequisites">Prerequisites</a> for all platforms.
+* The standard <a href="/com.playeveryware.eos/README.md#prerequisites">Prerequisites</a> for all platforms.
 * macOS Device
 * Unity macOS build module
 * XCode

--- a/com.playeveryware.eos/Documentation~/overlay.md
+++ b/com.playeveryware.eos/Documentation~/overlay.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Epic Online Services Overlay debugging</div>
 ---

--- a/com.playeveryware.eos/Documentation~/player_authentication.md
+++ b/com.playeveryware.eos/Documentation~/player_authentication.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # Authenticating Players
 

--- a/com.playeveryware.eos/Documentation~/plugin_advantages.md
+++ b/com.playeveryware.eos/Documentation~/plugin_advantages.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Advantages of using this Plugin</div>
 ---

--- a/com.playeveryware.eos/Documentation~/samples.md
+++ b/com.playeveryware.eos/Documentation~/samples.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
 
 # Samples
 
@@ -34,7 +34,7 @@ The included samples show examples of fully functional [feature implementations]
 ## Running the samples
 
 > [!IMPORTANT]
-> The plugin must be <a href="/com.playeveryware.eos/Documentation~/configure_plugin.md">configured</a> for samples to be functional. Some Samples may not be accessible if the extra packs were not <a href="http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#importing-samples">imported</a>.
+> The plugin must be <a href="/com.playeveryware.eos/Documentation~/configure_plugin.md">configured</a> for samples to be functional. Some Samples may not be accessible if the extra packs were not <a href="http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/com.playeveryware.eos/README.md#importing-samples">imported</a>.
 
 Checkout our [Sample Walkthroughs](/com.playeveryware.eos/Documentation~/Walkthrough.md) for a scene-by-scene walkthrough of each sample.
 
@@ -65,7 +65,7 @@ Checkout our [Sample Walkthroughs](/com.playeveryware.eos/Documentation~/Walkthr
 <br />
 
   > [!NOTE] 
-  > Check the [Prerequisites](http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/README.md#prerequisites) as there may be specific requirements for a player's computer.
+  > Check the [Prerequisites](http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#prerequisites) as there may be specific requirements for a player's computer.
   > For instance, Windows requires the players to have `The latest Microsoft Visual C++ Redistributable` installed on their computer in order to play any distributed builds.
 
   1. In the Unity editor menu bar, open `File -> Build Settings`.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_netcode_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_netcode_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **P2P Netcode Demo**
 This demo showcases the Peer 2 Peer interface working with Unity's netcode. This is done through a simple game where players can move a square around the screen.
@@ -11,7 +11,7 @@ This demo showcases the Peer 2 Peer interface working with Unity's netcode. This
 
 The P2P Netcode Sample Scene is included in the `Extra Pack 1` sample pack.  
 
-Upon import, the `com.unity.netcode.gameobjects` package that this scene requires will be automatically installed. You will still need to <a href="/README.md#importing-samples">add it in the build settings</a>.   
+Upon import, the `com.unity.netcode.gameobjects` package that this scene requires will be automatically installed. You will still need to <a href="/com.playeveryware.eos/README.md#importing-samples">add it in the build settings</a>.   
 *Default version `1.0.2`.  Verified Working Versions `1.5.1` , `1.5.2`*  
 
 > [!NOTE]

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/P2P_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Peer 2 Peer Demo**
 The Peer 2 Peer demo showcases the peer 2 peer interface. This is done through a basic messaging application where users can chat with other users on their friend list.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/achievements_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/achievements_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Achievements Demo**
 This demo showcases the Achievements function. This is done through 2 test achievements, one tracking logins and the other logging an arbitrary stat. Each Achievement has a unlocked and locked display name and description, as well as the ability to hide it and the relevant tracked data for it.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/auth&friends_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/auth&friends_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Auth & Friends Demo**
 This demo showcases an implementation of the friends list into a game UI. The panel on the right shows the user's friend list and status of each friend. This panel can be accessed in other scenes that require access to the friends list.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/customInvites_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/customInvites_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Custom Invites Demo**
 This demo showcases the custom invite functionality allowing for messaging with arbitrary payloads. This is meant for cases where an already existing invitation system exists. This demo allows users to send invites with a text payload to anyone on their friends list.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/leaderboards_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/leaderboards_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Leaderboards Demo**
 This demo showcases the leaderboard functionality to track scores across the player base with multiple filter methods such as global scores or only friend scores.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/lobbies_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/lobbies_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Lobbies Demo**
 This demo showcases the lobby and includes a voice chat interface in a combined demo. The demo functions as a waiting room style lobby where users can create a new lobby or join existing ones, once in a lobby users can communicate through the lobby voice chat.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/metrics_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/metrics_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Metrics Demo**
 The Metrics demo showcases the player metrics interface, allowing for game use and analytical data to be collected. This data can then be accessed through the developer portal for the product.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/performance_stress_test_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/performance_stress_test_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Performance Stress Test**
 This scene was created to test the performance of the overlay under different system conditions, it does not use any EOS systems outside of the overlay. It has the ability to change cpu usage, gpu usage, and memory usage.
@@ -17,4 +17,4 @@ This scene was created to test the performance of the overlay under different sy
 
 The Perfomance Stress Test Sample Scene is included in the `Extra Pack 2` sample pack.  
 
-Upon import, the `com.unity.postprocessing` package that this scene requires will be automatically installed.  You will still need to <a href="/README.md#importing-samples">add it in the build settings</a>.
+Upon import, the `com.unity.postprocessing` package that this scene requires will be automatically installed.  You will still need to <a href="/com.playeveryware.eos/README.md#importing-samples">add it in the build settings</a>.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/player_data_storage_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/player_data_storage_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Player Data Storage Demo**
 This demo showcases the Player Data Storage interface. This allows games to store player specific data in cloud servers. The demo uses a faux inventory to showcase this.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/player_reports_and_sanctions_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/player_reports_and_sanctions_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Player Reports and Sanctions Demo**
 This demo showcases the reports interface and sanctions interface. This is done through a report menu, and a display of any current sanctions on the user's account.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/sessions_and_matchmaking_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/sessions_and_matchmaking_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Sessions and Matchmaking**
 This demo showcases the sessions interface, users can create, manage and join sessions.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/store_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/store_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Store Demo**
 This demo showcases the store interface through a faux store.

--- a/com.playeveryware.eos/Documentation~/scene_walkthrough/title_storage_walkthrough.md
+++ b/com.playeveryware.eos/Documentation~/scene_walkthrough/title_storage_walkthrough.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 ## **Title Storage Demo**
 This demo showcases the title storage interface. This functions similar to the player data storage interface, although the data accessed is game/platform specific instead of player specific. This demo allows users to search files by tag and name and then view their contents. The demo is broken up into three parts, Tags search, File Search and the File viewer:

--- a/com.playeveryware.eos/Documentation~/standards.md
+++ b/com.playeveryware.eos/Documentation~/standards.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Coding Standards</div>
 ---

--- a/com.playeveryware.eos/Documentation~/steam.md
+++ b/com.playeveryware.eos/Documentation~/steam.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
 
 # Steam Integration
 

--- a/com.playeveryware.eos/Documentation~/supported_platforms.md
+++ b/com.playeveryware.eos/Documentation~/supported_platforms.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Readme" width="5%"/></a>
 
 # Supported Platforms
 

--- a/com.playeveryware.eos/Documentation~/supported_versions_of_unity.md
+++ b/com.playeveryware.eos/Documentation~/supported_versions_of_unity.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Supported Versions of Unity</div>
 ---

--- a/com.playeveryware.eos/Documentation~/uifriendsmenu.md
+++ b/com.playeveryware.eos/Documentation~/uifriendsmenu.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # UIFriendsMenu.cs
 

--- a/com.playeveryware.eos/Documentation~/unity_specific.md
+++ b/com.playeveryware.eos/Documentation~/unity_specific.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Unity-specific plugin functionality</div>
 ---

--- a/com.playeveryware.eos/Documentation~/upgrading_to_new_versions_of_eos.md
+++ b/com.playeveryware.eos/Documentation~/upgrading_to_new_versions_of_eos.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="README.md" width="5%"/></a>
 
 # <div align="center">Installing New versions of EOS</div>
 ---
@@ -63,5 +63,5 @@ It requires a JSON description file to direct it where to put the files in the z
 and a zip file that contains the SDK. The latest version of the SDK can be downloaded from
 the EOS Developer Portal.
 
-After being installed via the Tool, update the repo [readme](/README.md) to ensure it lists the correct version
+After being installed via the Tool, update the repo [readme](/com.playeveryware.eos/README.md) to ensure it lists the correct version
 and that any links on the readme are up to date.

--- a/com.playeveryware.eos/README.md
+++ b/com.playeveryware.eos/README.md
@@ -1,4 +1,4 @@
-<a href="/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
+<a href="/com.playeveryware.eos/README.md"><img src="/com.playeveryware.eos/Documentation~/images/PlayEveryWareLogo.gif" alt="Lobby Screenshot" width="5%"/></a>
 
 <div align="center"> <img src="/com.playeveryware.eos/Documentation~/images/EOSPluginLogo.png" alt="PlayEveryWare EOS Plugin for Unity" /> </div>
 


### PR DESCRIPTION
This PR fixes a collection of broken links that exist within the documentation. 

In a separate branch ([`feat/documentation-link-checker`](https://github.com/PlayEveryWare/eos_plugin_for_unity/tree/feat/documentation-link-checker)) I wrote a python script that identifies all broken links. 

In the future, I will open a PR that brings this into our release process as a workflow that must pass before the release can be merged. This will hopefully mean that broken links will be discovered right away, and no broken links will be permitted to be merged into a release branch in the future.

That script, and the workflow that makes it work, falls outside the scope of the release task, but the _product_ of the work done in that branch is the correction of these links (be they image or link, internal, or external).

#EOS-2115

> [!IMPORTANT]
> This is another PR from the same branch, because there were some additional broken links that were introduced by a PR because that PR did not use the documentation link checker.