### PR TITLE
Make test classes `partial` so they can be expanded

### DIFF
--- a/Assets/Tests/Common/EOSTestBase.cs
+++ b/Assets/Tests/Common/EOSTestBase.cs
@@ -33,7 +33,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests
     /// <summary>
     /// Initial setup and shutdown procedure for all tests.
     /// </summary>
-    public class EOSTestBase
+    public partial class EOSTestBase
     {
         /// <summary>
         /// Common constants used in the tests.

--- a/Assets/Tests/PlayMode/AuthenticationTests.cs
+++ b/Assets/Tests/PlayMode/AuthenticationTests.cs
@@ -31,7 +31,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Auth
     using UnityEngine;
     using UnityEngine.TestTools;
 
-    public class AuthenticationTests
+    public partial class AuthenticationTests
     {
         GameObject eosObject;
         protected const float LoginTestTimeout = 30f;

--- a/Assets/Tests/PlayMode/ConnectTests.cs
+++ b/Assets/Tests/PlayMode/ConnectTests.cs
@@ -30,7 +30,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Connect
     using UnityEngine;
     using UnityEngine.TestTools;
 
-    public class ConnectTests
+    public partial class ConnectTests
     {
         GameObject eosObject;
         protected const float LoginTestTimeout = 30f;

--- a/Assets/Tests/PlayMode/Services/AchievementsTests.cs
+++ b/Assets/Tests/PlayMode/Services/AchievementsTests.cs
@@ -33,7 +33,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Achievements
     /// <summary>
     /// Integration tests for achievements.
     /// </summary>
-    public class AchievementsTests : EOSTestBase
+    public partial class AchievementsTests : EOSTestBase
     {
         /// <summary>
         /// Checks to see if we can get a count for the number of achievements for the product user.

--- a/Assets/Tests/PlayMode/Services/ClientLobbyTests.cs
+++ b/Assets/Tests/PlayMode/Services/ClientLobbyTests.cs
@@ -34,7 +34,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Lobby
     /// <summary>
     /// Lobby connection tests that test connecting to an existing lobby.
     /// </summary>
-    public class ClientLobbyTests : EOSTestBase
+    public partial class ClientLobbyTests : EOSTestBase
     {
         private string lobbyId;
         private NotifyEventHandle lobbyInviteNotification;

--- a/Assets/Tests/PlayMode/Services/ClientSessionTests.cs
+++ b/Assets/Tests/PlayMode/Services/ClientSessionTests.cs
@@ -35,7 +35,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Sessions
     /// <summary>
     /// Session connection tests that test connecting to an existing session.
     /// </summary>
-    public class ClientSessionTests : EOSTestBase
+    public partial class ClientSessionTests : EOSTestBase
     {
         private const ulong InvalidNotificationId = 0;
 

--- a/Assets/Tests/PlayMode/Services/EOSSessionsManagerTests.cs
+++ b/Assets/Tests/PlayMode/Services/EOSSessionsManagerTests.cs
@@ -34,7 +34,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Sessions
     using System.Collections.Generic;
     using System.Text.RegularExpressions;
 
-    public class EOSSessionsManagerTests : EOSTestBase
+    public partial class EOSSessionsManagerTests : EOSTestBase
     {
         protected EOSSessionsManager ManagerInstance { get; set; } = null;
 

--- a/Assets/Tests/PlayMode/Services/FriendsTests.cs
+++ b/Assets/Tests/PlayMode/Services/FriendsTests.cs
@@ -39,7 +39,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Friends
     /// <summary>
     /// Integration tests for friend related calls.
     /// </summary>
-    public class FriendsTests : EOSTestBase
+    public partial class FriendsTests : EOSTestBase
     {
         private FriendsInterface _friendsInterface;
         private UserInfoInterface _userInfoInterface;

--- a/Assets/Tests/PlayMode/Services/LeaderboardTests.cs
+++ b/Assets/Tests/PlayMode/Services/LeaderboardTests.cs
@@ -35,7 +35,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Leaderboard
     /// <summary>
     /// Integration tests for leaderboard related calls.
     /// </summary>
-    public class LeaderboardTests : EOSTestBase
+    public partial class LeaderboardTests : EOSTestBase
     {
         private LeaderboardsInterface _leaderboardsInterface;
         private StatsInterface statsInterface;

--- a/Assets/Tests/PlayMode/Services/LobbyTests.cs
+++ b/Assets/Tests/PlayMode/Services/LobbyTests.cs
@@ -34,7 +34,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Lobby
     /// <summary>
     /// Lobby related tests.
     /// </summary>
-    public class LobbyTests : EOSTestBase
+    public partial class LobbyTests : EOSTestBase
     {
         private CreateLobbyCallbackInfo? createLobbyResult = null;
         private LobbySearchFindCallbackInfo? searchLobbyResult = null;

--- a/Assets/Tests/PlayMode/Services/PlayerDataStorageServiceTests.cs
+++ b/Assets/Tests/PlayMode/Services/PlayerDataStorageServiceTests.cs
@@ -30,7 +30,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.IntegrationTests
     using System.Text;
     using System.Collections.Generic;
 
-    public class PlayerDataStorageServiceTests
+    public partial class PlayerDataStorageServiceTests
         : EOSTestBase
     {
         [UnitySetUp]

--- a/Assets/Tests/PlayMode/Services/PlayerStorageTests.cs
+++ b/Assets/Tests/PlayMode/Services/PlayerStorageTests.cs
@@ -36,7 +36,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.PlayerStorage
     /// <summary>
     /// Tests for the player storage functionality of EOS.
     /// </summary>
-    public class PlayerStorageTests : EOSTestBase
+    public partial class PlayerStorageTests : EOSTestBase
     {
         private const uint MAX_CHUNK_SIZE = 4096;
         private static readonly System.Random random = new();

--- a/Assets/Tests/PlayMode/Services/SessionTests.cs
+++ b/Assets/Tests/PlayMode/Services/SessionTests.cs
@@ -33,7 +33,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.Sessions
     /// <summary>
     /// Integration tests for sessions and matchmaking.
     /// </summary>
-    public class SessionTests : EOSTestBase
+    public partial class SessionTests : EOSTestBase
     {
         private const string SessionName = "IntegrationTestSession";
         private const string LevelName = "CASTLE";

--- a/Assets/Tests/PlayMode/Services/TitleStorageTests.cs
+++ b/Assets/Tests/PlayMode/Services/TitleStorageTests.cs
@@ -33,7 +33,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Services.TitleStorage
     /// <summary>
     /// Tests for the title storage functionality of EOS.
     /// </summary>
-    public class TitleStorageTests : EOSTestBase
+    public partial class TitleStorageTests : EOSTestBase
     {
         private TitleStorageInterface _titleStorageHandle;
 


### PR DESCRIPTION
In an effort to make unit tests more expandable while maintaining structure, this PR makes all the unit test classes `partial` classes, so that other tests can seamlessly be added to them without needing to change the structure of the test organization.

#EOS-2115