### PR TITLE
Swap `UnityEngine.JsonUtility` for `Newtonsoft.Json`

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -5,7 +5,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
         "com.unity.editorcoroutines": "1.0.0"
       }
     },
@@ -88,8 +88,8 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.2.0"
+        "com.unity.transport": "1.2.0",
+        "com.unity.nuget.mono-cecil": "1.10.1"
       },
       "url": "https://packages.unity.com"
     },
@@ -102,7 +102,7 @@
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.0.2",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -121,9 +121,9 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.androidjni": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.0.2",
-        "com.unity.modules.androidjni": "1.0.0"
+        "com.unity.modules.unitywebrequest": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -176,9 +176,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -198,8 +198,8 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "1.2.4",
         "com.unity.burst": "1.6.6",
+        "com.unity.collections": "1.2.4",
         "com.unity.mathematics": "1.2.6"
       },
       "url": "https://packages.unity.com"

--- a/com.playeveryware.eos/Runtime/Core/Utility/JsonUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/JsonUtility.cs
@@ -23,68 +23,70 @@
 namespace PlayEveryWare.EpicOnlineServices.Utility
 {
     using UnityEngine;
+    using Newtonsoft.Json;
+    using System;
 
     /// <summary>
-    /// Contains functions to interact with various json data.
+    /// Contains functions to interact with various JSON data.
     /// </summary>
     public static class JsonUtility
     {
         /// <summary>
         /// Tries to parse the given JSON into an object.
         /// </summary>
-        /// <typeparam name="T">The type to deserialize from the given json.
+        /// <typeparam name="T">
+        /// The type to deserialize from the given JSON.
         /// </typeparam>
         /// <param name="json">
         /// The JSON to deserialize from.
         /// </param>
-        /// <param name="obj">The object to contain the deserialized value.
+        /// <param name="obj">
+        /// The object to contain the deserialized value.
         /// </param>
         /// <returns>
-        /// True if the json was successfully deserialized, false otherwise.
+        /// True if the JSON was successfully deserialized, false otherwise.
         /// </returns>
         private static bool TryFromJson<T>(string json, out T obj)
         {
             obj = default;
             try
             {
-                obj = UnityEngine.JsonUtility.FromJson<T>(json);
+                obj = JsonConvert.DeserializeObject<T>(json);
                 return true;
             }
-            catch
+            catch (Exception ex)
             {
                 Debug.LogError($"Unable to parse object of type " +
                                $"\"{typeof(T).FullName}\" from " +
-                               $"JSON: \"{json}\".");
+                               $"JSON: \"{json}\". Exception: {ex.Message}");
 #if UNITY_EDITOR
-                // If running in the context of the Unity editor, then throw the
-                // exception in an effort to "fail loudly" so that the user is
-                // more likely to fix the problem. If not in editor mode, still
-                // log the error, but do not throw an exception.
                 throw;
 #else
-                // The else conditional is here because if an exception is not
-                // thrown, a value still needs to be returned.
                 return false;
 #endif
             }
         }
 
         /// <summary>
-        /// Convert an object into JSON.
+        /// Converts an object into JSON.
         /// </summary>
-        /// <param name="obj">The object to serialize into JSON.</param>
-        /// <param name="pretty">Whether to make the JSON pretty.</param>
+        /// <param name="obj">
+        /// The object to serialize into JSON.
+        /// </param>
+        /// <param name="pretty">
+        /// Whether to make the JSON pretty.
+        /// </param>
         /// <returns>
         /// String representation of the given object serialized.
         /// </returns>
         public static string ToJson(object obj, bool pretty = false)
         {
-            return UnityEngine.JsonUtility.ToJson(obj, pretty);
+            return JsonConvert.SerializeObject(obj, pretty ? Formatting.Indented : Formatting.None);
         }
 
         /// <summary>
-        /// Return an object deserialized from the given json string. If json is
-        /// invalid, errors will be logged, and an object with default values
+        /// Returns an object deserialized from the given JSON string. If JSON 
+        /// is invalid, errors will be logged, and an object with default values
         /// will be returned depending on whether running in editor mode or as a
         /// standalone.
         /// </summary>
@@ -93,17 +95,12 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// <returns>The deserialized object.</returns>
         public static T FromJson<T>(string json)
         {
-            // NOTE: The return value of the TryFromJson method call below is
-            //       not observed, because regardless of if the from json method
-            //       was successful, the value defined by the out variable is
-            //       returned to the caller.
             _ = TryFromJson(json, out T returnObject);
-
             return returnObject;
         }
 
         /// <summary>
-        /// Return an object deserialized from the given json file.
+        /// Returns an object deserialized from the given JSON file.
         /// </summary>
         /// <typeparam name="T">The type of object to deserialize.</typeparam>
         /// <param name="filepath">The path to the JSON file.</param>
@@ -115,39 +112,37 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         }
 
         /// <summary>
-        /// Overwrites the given json object with values deserialized from the
-        /// given json string. If json is invalid, errors will be logged and no
-        /// change will be made to the object.
+        /// Overwrites the given object's properties with values deserialized 
+        /// from the given JSON string. If JSON is invalid, errors will be 
+        /// logged and no change will be made to the object.
         /// </summary>
+        /// <typeparam name="T">
+        /// The type of the object to populate.
+        /// </typeparam>
         /// <param name="json">
-        /// The string of json to deserialize values from.
+        /// The JSON string to deserialize values from.
         /// </param>
         /// <param name="obj">
         /// The object to change the values of.
         /// </param>
         public static void FromJsonOverwrite<T>(string json, T obj)
         {
-            // NOTES:
-            //
-            // If the type 'T' indicated is abstract, then it is not possible to
-            // use UnityEngine.JsonUtility to verify the validity of the
-            // incoming JSON. This is because the validation is accomplished by
-            // performing the deserialization step and catching any thrown
-            // exceptions. Therefore, if the type indicated is abstract, don't
-            // bother trying to validate, go straight to using the
-            // 'FromJsonOverwrite' function in UnityEngine.JsonUtility.
-            //
-            // If the type indicated is _not_ abstract, then it is possible to
-            // utilize the validation approach, therefore in that scenario
-            // perform validation before performing the intended operation.
-            //
-            // That this code can only validate JSON representing a non-abstract
-            // class is a limitation of the UnityEngine.JsonUtility. Most other
-            // available libraries will support this and remove the need for
-            // this check.
-            if (typeof(T).IsAbstract || TryFromJson(json, out T _))
+            if (obj == null)
             {
-                UnityEngine.JsonUtility.FromJsonOverwrite(json, obj);
+                throw new ArgumentNullException(nameof(obj));
+            }
+            try
+            {
+                JsonConvert.PopulateObject(json, obj);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Unable to populate object of type " +
+                               $"\"{typeof(T).FullName}\" from " +
+                               $"JSON: \"{json}\". Exception: {ex.Message}");
+#if UNITY_EDITOR
+                throw;
+#endif
             }
         }
     }

--- a/com.playeveryware.eos/Runtime/Core/Utility/JsonUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/JsonUtility.cs
@@ -58,7 +58,8 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             {
                 Debug.LogError($"Unable to parse object of type " +
                                $"\"{typeof(T).FullName}\" from " +
-                               $"JSON: \"{json}\". Exception: {ex.Message}");
+                               $"JSON: \"{json}\". " +
+                               $"Exception: \"{ex.Message}\"");
 #if UNITY_EDITOR
                 // If running in the context of the Unity editor, then throw the
                 // exception in an effort to "fail loudly" so that the user is
@@ -149,7 +150,8 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             {
                 Debug.LogError($"Unable to populate object of type " +
                                $"\"{typeof(T).FullName}\" from " +
-                               $"JSON: \"{json}\". Exception: {ex.Message}");
+                               $"JSON: \"{json}\". " +
+                               $"Exception: \"{ex.Message}\"");
 #if UNITY_EDITOR
                 throw;
 #endif

--- a/com.playeveryware.eos/Runtime/Core/Utility/JsonUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/JsonUtility.cs
@@ -60,8 +60,14 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                                $"\"{typeof(T).FullName}\" from " +
                                $"JSON: \"{json}\". Exception: {ex.Message}");
 #if UNITY_EDITOR
+                // If running in the context of the Unity editor, then throw the
+                // exception in an effort to "fail loudly" so that the user is
+                // more likely to fix the problem. If not in editor mode, still
+                // log the error, but do not throw an exception.
                 throw;
 #else
+                // The else conditional is here because if an exception is not
+                // thrown, a value still needs to be returned.
                 return false;
 #endif
             }
@@ -95,6 +101,10 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// <returns>The deserialized object.</returns>
         public static T FromJson<T>(string json)
         {
+            // NOTE: The return value of the TryFromJson method call below is
+            //       not observed, because regardless of if the from json method
+            //       was successful, the value defined by the out variable is
+            //       returned to the caller.
             _ = TryFromJson(json, out T returnObject);
             return returnObject;
         }

--- a/com.playeveryware.eos/package.json
+++ b/com.playeveryware.eos/package.json
@@ -12,7 +12,7 @@
     "description": "Friendly Plugin for Epic Online Services\n Unity 2021.3.16f1\n EOS SDK 1.16.3\n\n Dependencies for Extra Packs:\n P2P Netcode Sample : [com.unity.netcode.gameobjects] \n Performance Stress Test Sample : [com.unity.postprocessing]",
     "documentationUrl": "https://eospluginforunity.playeveryware.com",
     "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
         "com.unity.editorcoroutines": "1.0.0"
     },
     "keywords": [


### PR DESCRIPTION
This PR swaps usage of Unity's built in `JsonUtility` with `Newtonsoft.Json`. It has been tested in release as a package (both in editor and as standalone) and functions properly.

> [!NOTE] 
> To affect this change in a manner that declares our dependencies explicitly, the `com.unity.modules.jsonserialize` dependency was replaced in `package.json` (and subsequently `packages-lock.json`) with a dependency on `com.unity.nuget.newtonsoft-json`. 
> 
> Documentation regarding this package and why it is the preferred means to include Newtonsoft.Json (aka JSON.NET) can be found [here](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.0/manual/index.html)

#EOS-1977