### PR TITLE
fix: Remove mentions of the hackForceSendInputDirectlyToSDK

### DIFF
--- a/Assets/StreamingAssets/EOS/EpicOnlineServicesConfig.json
+++ b/Assets/StreamingAssets/EOS/EpicOnlineServicesConfig.json
@@ -13,6 +13,5 @@
     "tickBudgetInMilliseconds": 0,
     "alwaysSendInputToOverlay": true,
     "initialButtonDelayForOverlay": "",
-    "repeatButtonDelayForOverlay": "",
-    "hackForceSendInputDirectlyToSDK": false
+    "repeatButtonDelayForOverlay": ""
 }

--- a/Assets/StreamingAssets/EOS/eos_android_config.json
+++ b/Assets/StreamingAssets/EOS/eos_android_config.json
@@ -15,7 +15,6 @@
         "tickBudgetInMilliseconds": 0,
         "alwaysSendInputToOverlay": false,
         "initialButtonDelayForOverlay": "",
-        "repeatButtonDelayForOverlay": "",
-        "hackForceSendInputDirectlyToSDK": false
+        "repeatButtonDelayForOverlay": ""
     }
 }

--- a/Assets/StreamingAssets/EOS/eos_ios_config.json
+++ b/Assets/StreamingAssets/EOS/eos_ios_config.json
@@ -15,7 +15,6 @@
         "tickBudgetInMilliseconds": 0,
         "alwaysSendInputToOverlay": false,
         "initialButtonDelayForOverlay": "",
-        "repeatButtonDelayForOverlay": "",
-        "hackForceSendInputDirectlyToSDK": false
+        "repeatButtonDelayForOverlay": ""
     }
 }

--- a/Assets/StreamingAssets/EOS/eos_linux_config.json
+++ b/Assets/StreamingAssets/EOS/eos_linux_config.json
@@ -21,7 +21,6 @@
         "ThreadAffinity_RTCIO": "",
         "alwaysSendInputToOverlay": false,
         "initialButtonDelayForOverlay": "",
-        "repeatButtonDelayForOverlay": "",
-        "hackForceSendInputDirectlyToSDK": false
+        "repeatButtonDelayForOverlay": ""
     }
 }

--- a/Assets/StreamingAssets/EOS/eos_macos_config.json
+++ b/Assets/StreamingAssets/EOS/eos_macos_config.json
@@ -15,7 +15,6 @@
         "tickBudgetInMilliseconds": 0,
         "alwaysSendInputToOverlay": false,
         "initialButtonDelayForOverlay": "",
-        "repeatButtonDelayForOverlay": "",
-        "hackForceSendInputDirectlyToSDK": false
+        "repeatButtonDelayForOverlay": ""
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -326,19 +326,6 @@ namespace PlayEveryWare.EpicOnlineServices
         public string repeatButtonDelayForOverlay;
 
         /// <summary>
-        /// HACK: send force send input without delay&lt;/c&gt;If true, the
-        /// native plugin will always send input received directly to the SDK.
-        /// If set to false, the plugin will attempt to delay the input to
-        /// mitigate CPU spikes caused by spamming the SDK.
-        /// </summary>
-        [ConfigField("Send input without delay", 
-            ConfigFieldType.Flag, 
-            "Workaround to force send input without any delay. If " +
-            "true, the native plugin will always send input receive directly " +
-            "to the SDK.", 4)]
-        public bool hackForceSendInputDirectlyToSDK;
-
-        /// <summary>
         /// When this combination of buttons is pressed on a controller, the
         /// social overlay will toggle on.
         /// Default to <see cref="InputStateButtonFlags.SpecialLeft"/>, and will


### PR DESCRIPTION
Removes all mention of hackForceSendInputDirectlyToSDK. Nothing in this repo utilized it, so this is mostly cleaning up the EOSConfig and removing the JSON.

This should be included as part of the release process, and not made publicly available until that is ready.

#EOS-2146