### PR TITLE
fix(login): Fix RefreshToken Login

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -1079,24 +1079,13 @@ namespace PlayEveryWare.EpicOnlineServices
                 {
                     print("Attempting to use refresh token to login with connect");
 
-                    // need to refresh the epicaccount id
-                    // LoginCredentialType.RefreshToken
-                    Instance.StartLoginWithLoginTypeAndToken(LoginCredentialType.RefreshToken, null,
-                        authToken.Value.RefreshToken, callbackInfo =>
-                        {
-                            var EOSAuthInterface = GetEOSPlatformInterface().GetAuthInterface();
-                            var copyUserTokenOptions = new CopyUserAuthTokenOptions();
-                            var result = EOSAuthInterface.CopyUserAuthToken(ref copyUserTokenOptions,
-                                callbackInfo.LocalUserId, out Token? userAuthToken);
+                    connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
+                    {
+                        Token = authToken.Value.RefreshToken,
+                        Type = ExternalCredentialType.Epic
+                    };
 
-                            connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
-                            {
-                                Token = userAuthToken.Value.AccessToken,
-                                Type = ExternalCredentialType.Epic
-                            };
-
-                            StartConnectLoginWithOptions(connectLoginOptions, onConnectLoginCallback);
-                        });
+                    StartConnectLoginWithOptions(connectLoginOptions, onConnectLoginCallback);
                 }
                 else if (authToken.Value.AccessToken != null)
                 {


### PR DESCRIPTION
This PR attempts to address a perceived problem with the refresh token login scenario.

The intention of this code is to recognize that the auth login token has a Refresh Token, and then attempts to use that Refresh Token to do a Connect login.

The previous code seemed to fail on this intent. Instead, it recognized there was a Refresh Token, but then made another Auth Login, then uses that login's Auth Token to do a Connect login.

This change makes it just use the provided RefreshToken directly as a Connect Login argument.

The risk involved is that it turns out there's some esoteric reason it needs to work the way it currently does. It's not clear to me from the code or from the context that this is necessary, though, and I think it was just an implementation error.

#EOS-2164