### PR TITLE
feat: Authentication Listener knows the difference between a Connect and Auth login

### DIFF
--- a/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
+++ b/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
@@ -107,7 +107,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return buffer;
         }
 
-        protected async override void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType)
+        protected async override void OnLoggedIn(AuthenticationListener.LoginChangeKind changeType)
         {
             await RefreshAsync();
         }

--- a/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
+++ b/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
@@ -107,7 +107,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             return buffer;
         }
 
-        protected async override void OnLoggedIn()
+        protected async override void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType)
         {
             await RefreshAsync();
         }

--- a/Assets/Scripts/StandardSamples/Services/EOSService.cs
+++ b/Assets/Scripts/StandardSamples/Services/EOSService.cs
@@ -159,15 +159,15 @@ namespace PlayEveryWare.EpicOnlineServices
 
         }
 
-        private void OnAuthenticationChanged(bool authenticated)
+        private void OnAuthenticationChanged(bool authenticated, AuthenticationListener.AuthenticationLevelChangeType changeType)
         {
             if (authenticated)
             {
-                OnLoggedIn();
+                OnLoggedIn(changeType);
             }
             else
             {
-                OnLoggedOut();
+                OnLoggedOut(changeType);
             }
         }
 
@@ -175,14 +175,16 @@ namespace PlayEveryWare.EpicOnlineServices
         /// Implement this method to perform tasks when a user authenticates.
         /// By default, there is no action taken.
         /// </summary>
-        protected virtual void OnLoggedIn() { }
+        /// <param name="changeType">The type of authentication change.</param>
+        protected virtual void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType) { }
 
         /// <summary>
         /// If there are tasks that need to be done when logged out, consider
         /// overriding the Reset() function as that is where such things should
         /// be done.
         /// </summary>
-        protected void OnLoggedOut()
+        /// <param name="changeType">The type of authentication change.</param>
+        protected void OnLoggedOut(AuthenticationListener.AuthenticationLevelChangeType changeType)
         {
             Reset();
         }

--- a/Assets/Scripts/StandardSamples/Services/EOSService.cs
+++ b/Assets/Scripts/StandardSamples/Services/EOSService.cs
@@ -159,7 +159,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         }
 
-        private void OnAuthenticationChanged(bool authenticated, AuthenticationListener.AuthenticationLevelChangeType changeType)
+        private void OnAuthenticationChanged(bool authenticated, AuthenticationListener.LoginChangeKind changeType)
         {
             if (authenticated)
             {
@@ -176,7 +176,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// By default, there is no action taken.
         /// </summary>
         /// <param name="changeType">The type of authentication change.</param>
-        protected virtual void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType) { }
+        protected virtual void OnLoggedIn(AuthenticationListener.LoginChangeKind changeType) { }
 
         /// <summary>
         /// If there are tasks that need to be done when logged out, consider
@@ -184,7 +184,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// be done.
         /// </summary>
         /// <param name="changeType">The type of authentication change.</param>
-        protected void OnLoggedOut(AuthenticationListener.AuthenticationLevelChangeType changeType)
+        protected void OnLoggedOut(AuthenticationListener.LoginChangeKind changeType)
         {
             Reset();
         }

--- a/Assets/Scripts/StandardSamples/Services/PlayerDataStorageService.cs
+++ b/Assets/Scripts/StandardSamples/Services/PlayerDataStorageService.cs
@@ -372,9 +372,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <list type="bullet">
         ///     <item><description><c>QueryFileList()</c></description></item>
         /// </list>
-        protected override void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType)
+        protected override void OnLoggedIn(AuthenticationListener.LoginChangeKind changeType)
         {
-            if (changeType == AuthenticationListener.AuthenticationLevelChangeType.Connect)
+            if (changeType == AuthenticationListener.LoginChangeKind.Connect)
             {
                 QueryFileList();
             }

--- a/Assets/Scripts/StandardSamples/Services/PlayerDataStorageService.cs
+++ b/Assets/Scripts/StandardSamples/Services/PlayerDataStorageService.cs
@@ -372,9 +372,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <list type="bullet">
         ///     <item><description><c>QueryFileList()</c></description></item>
         /// </list>
-        protected override void OnLoggedIn()
+        protected override void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType)
         {
-            QueryFileList();
+            if (changeType == AuthenticationListener.AuthenticationLevelChangeType.Connect)
+            {
+                QueryFileList();
+            }
         }
 
         protected override Task InternalRefreshAsync()

--- a/Assets/Scripts/StandardSamples/Services/StatsService.cs
+++ b/Assets/Scripts/StandardSamples/Services/StatsService.cs
@@ -94,7 +94,7 @@ namespace PlayEveryWare.EpicOnlineServices
             UnityEngine.Debug.Log(toPrint);
         }
 
-        protected async override void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType)
+        protected async override void OnLoggedIn(AuthenticationListener.LoginChangeKind changeType)
         {
             if (TryGetProductUserId(out ProductUserId userId))
             {

--- a/Assets/Scripts/StandardSamples/Services/StatsService.cs
+++ b/Assets/Scripts/StandardSamples/Services/StatsService.cs
@@ -94,7 +94,7 @@ namespace PlayEveryWare.EpicOnlineServices
             UnityEngine.Debug.Log(toPrint);
         }
 
-        protected async override void OnLoggedIn()
+        protected async override void OnLoggedIn(AuthenticationListener.AuthenticationLevelChangeType changeType)
         {
             if (TryGetProductUserId(out ProductUserId userId))
             {

--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -162,7 +162,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <param name="authenticated">
         /// True if the state has changed to authenticated, false otherwise.
         /// </param>
-        private void OnAuthenticationChanged(bool authenticated)
+        /// <param name="authenticationChangeType">
+        /// What kind of authentication change this is.</param>
+        private void OnAuthenticationChanged(bool authenticated, AuthenticationListener.AuthenticationLevelChangeType authenticationChangeType)
         {
             if (authenticated || !RequiresAuthentication)
             {

--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -164,7 +164,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </param>
         /// <param name="authenticationChangeType">
         /// What kind of authentication change this is.</param>
-        private void OnAuthenticationChanged(bool authenticated, AuthenticationListener.AuthenticationLevelChangeType authenticationChangeType)
+        private void OnAuthenticationChanged(bool authenticated, AuthenticationListener.LoginChangeKind authenticationChangeType)
         {
             if (authenticated || !RequiresAuthentication)
             {

--- a/com.playeveryware.eos/Runtime/Core/AuthenticationListener.cs
+++ b/com.playeveryware.eos/Runtime/Core/AuthenticationListener.cs
@@ -35,6 +35,15 @@ namespace PlayEveryWare.EpicOnlineServices
     public class AuthenticationListener: IAuthInterfaceEventListener, IConnectInterfaceEventListener, IDisposable
     {
         /// <summary>
+        /// Identifies the kind of authentication change.
+        /// </summary>
+        public enum AuthenticationLevelChangeType
+        {
+            Auth,
+            Connect
+        }
+
+        /// <summary>
         /// Used to describe functions that handle change in authentication
         /// state.
         /// </summary>
@@ -42,7 +51,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// True if the authentication state has changed to authenticated, False
         /// otherwise.
         /// </param>
-        public delegate void AuthenticationChangedEventHandler(bool authenticated);
+        public delegate void AuthenticationChangedEventHandler(bool authenticated, AuthenticationLevelChangeType changeType);
 
         /// <summary>
         /// Event that triggers when the state of authentication has changed.
@@ -104,7 +113,8 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </summary>
         /// <param name="attemptedState"></param>
         /// <param name="attemptResult"></param>
-        private void TriggerAuthenticationChangedEvent(bool attemptedState, Result attemptResult)
+        /// <param name="changeType">The type of authentication change.</param>
+        private void TriggerAuthenticationChangedEvent(bool attemptedState, Result attemptResult, AuthenticationLevelChangeType changeType)
         {
             // If the attempt to change the state of authentication did not 
             // succeed, then log a warning and stop.
@@ -119,7 +129,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
             // Trigger the event indicating that the state of authentication for 
             // the user has changed.
-            AuthenticationChanged?.Invoke(attemptedState);
+            AuthenticationChanged?.Invoke(attemptedState, changeType);
         }
 
         /// <summary>
@@ -130,7 +140,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void OnAuthLogin(LoginCallbackInfo loginCallbackInfo)
         {
-            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode);
+            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode, AuthenticationLevelChangeType.Auth);
         }
 
         /// <summary>
@@ -141,7 +151,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void OnAuthLogout(LogoutCallbackInfo logoutCallbackInfo)
         {
-            TriggerAuthenticationChangedEvent(false, logoutCallbackInfo.ResultCode);
+            TriggerAuthenticationChangedEvent(false, logoutCallbackInfo.ResultCode, AuthenticationLevelChangeType.Auth);
         }
 
         /// <summary>
@@ -152,7 +162,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void OnConnectLogin(Epic.OnlineServices.Connect.LoginCallbackInfo loginCallbackInfo)
         {
-            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode);
+            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode, AuthenticationLevelChangeType.Connect);
         }
 
         /// <summary>

--- a/com.playeveryware.eos/Runtime/Core/AuthenticationListener.cs
+++ b/com.playeveryware.eos/Runtime/Core/AuthenticationListener.cs
@@ -37,9 +37,22 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <summary>
         /// Identifies the kind of authentication change.
         /// </summary>
-        public enum AuthenticationLevelChangeType
+        public enum LoginChangeKind
         {
+            /// <summary>
+            /// Represents a login change relating to the Auth-login type with EOS.
+            /// A user logged in with the Auth Interface has access to Epic
+            /// Account Services (EAS) operations.
+            /// </summary>
             Auth,
+
+            /// <summary>
+            /// Represents a login change relating to the Connect-login type with EOS.
+            /// A user logged in with the Connect Interface has access to all
+            /// EOS Game Services.
+            /// Typically a user will be logged in to Auth and then afterwards
+            /// logged in to Connect.
+            /// </summary>
             Connect
         }
 
@@ -51,7 +64,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// True if the authentication state has changed to authenticated, False
         /// otherwise.
         /// </param>
-        public delegate void AuthenticationChangedEventHandler(bool authenticated, AuthenticationLevelChangeType changeType);
+        public delegate void AuthenticationChangedEventHandler(bool authenticated, LoginChangeKind changeType);
 
         /// <summary>
         /// Event that triggers when the state of authentication has changed.
@@ -114,7 +127,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <param name="attemptedState"></param>
         /// <param name="attemptResult"></param>
         /// <param name="changeType">The type of authentication change.</param>
-        private void TriggerAuthenticationChangedEvent(bool attemptedState, Result attemptResult, AuthenticationLevelChangeType changeType)
+        private void TriggerAuthenticationChangedEvent(bool attemptedState, Result attemptResult, LoginChangeKind changeType)
         {
             // If the attempt to change the state of authentication did not 
             // succeed, then log a warning and stop.
@@ -140,7 +153,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void OnAuthLogin(LoginCallbackInfo loginCallbackInfo)
         {
-            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode, AuthenticationLevelChangeType.Auth);
+            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode, LoginChangeKind.Auth);
         }
 
         /// <summary>
@@ -151,7 +164,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void OnAuthLogout(LogoutCallbackInfo logoutCallbackInfo)
         {
-            TriggerAuthenticationChangedEvent(false, logoutCallbackInfo.ResultCode, AuthenticationLevelChangeType.Auth);
+            TriggerAuthenticationChangedEvent(false, logoutCallbackInfo.ResultCode, LoginChangeKind.Auth);
         }
 
         /// <summary>
@@ -162,7 +175,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// </param>
         public void OnConnectLogin(Epic.OnlineServices.Connect.LoginCallbackInfo loginCallbackInfo)
         {
-            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode, AuthenticationLevelChangeType.Connect);
+            TriggerAuthenticationChangedEvent(true, loginCallbackInfo.ResultCode, LoginChangeKind.Connect);
         }
 
         /// <summary>


### PR DESCRIPTION
Previously the Authentication Listeners were receiving a singular message for authentication change. This changeset introduces an enum that identifies a login as either an Auth or Connect login. This will allow for subscribers to run things that require Connect authentication meaningfully separately.

Bundling with this is the relevant area of concern, the Player Data Storage Service, now only querying files on a Connect login.

#EOS-2165