### PR TITLE
Deselect Field on Tab Change

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -48,7 +48,16 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
         private static readonly string ConfigDirectory = Path.Combine("Assets", "StreamingAssets", "EOS");
 
-        int toolbarInt;
+        /// <summary>
+        /// Stores the current selected configuration tab.
+        /// "Main" is hard wired to be 0. By default "Main" is the selected tab.
+        /// Everything else is based on its position inside the
+        /// <see cref="platformSpecificConfigEditors"/> list, offset by -1.
+        /// For example if Android is at index 0 of the list, then when 
+        /// toolbarInt is set to 1, the Android configuration should render.
+        /// </summary>
+        int toolbarInt { get; set; }
+
         string[] toolbarTitleStrings;
 
         EOSConfig mainEOSConfigFile;
@@ -376,7 +385,22 @@ _WIN32 || _WIN64
         protected override void RenderWindow()
         {
             int xCount = (int)(EditorGUIUtility.currentViewWidth / 200);
-            toolbarInt = GUILayout.SelectionGrid(toolbarInt, toolbarTitleStrings, xCount);
+
+            // Determine the new toolbarInt state, so that it can be compared
+            // against the current value, determining if this changed
+            int newToolbarInt = GUILayout.SelectionGrid(toolbarInt, toolbarTitleStrings, xCount);
+
+            // If the selection is now different, deselect all selected textboxes
+            // This is to address #EOS-2085: Fix Editor Phantom Fields,
+            // wherein selecting a text box, then navigating to another config
+            // tab, would result in a "phantom" value appearing
+            if (newToolbarInt != toolbarInt && EditorGUIUtility.keyboardControl > 0)
+            {
+                GUI.FocusControl(null);
+            }
+
+            toolbarInt = newToolbarInt;
+
             switch (toolbarInt)
             {
                 case 0:

--- a/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
@@ -122,6 +122,10 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
             if (GUILayout.Button("Clear", GUILayout.MaxWidth(50)))
             {
                 value = null;
+
+                // Remove focus from the control so it doesn't display "phantom"
+                // values
+                GUI.FocusControl(null);
             }
             else
             {
@@ -176,6 +180,10 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
             if (GUILayout.Button("Clear", GUILayout.MaxWidth(50)))
             {
                 value = null;
+
+                // Remove focus from the control so it doesn't display "phantom"
+                // values
+                GUI.FocusControl(null);
             }
             else
             {


### PR DESCRIPTION
Addresses problem with "phantom input" in editor config windows.

- When selecting a different tab in the Editor Config window, clear the selected hot control.
- When pressing "Clear" deselect the control.

Demonstration of problem (before fix):
https://github.com/user-attachments/assets/b79744fb-b3b3-4cdd-9d81-a6ee3b4a8915

Demonstration of fix:
https://github.com/user-attachments/assets/4b4481ef-3678-474a-be30-80b3bf3993a6

#EOS-2085