### PR TITLE
Stop build pre/post-processor scripts from running if EOS_DISABLE is defined.

### DIFF
--- a/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
@@ -64,6 +64,11 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         /// <param name="report">The pre-process build report.</param>
         public void OnPreprocessBuild(BuildReport report)
         {
+            if (ScriptingDefineUtility.IsEOSDisabled(report))
+            {
+                return;
+            }
+
             // Set the current platform that is being built against
             if (PlatformManager.TryGetPlatform(report.summary.platform, out PlatformManager.Platform platform))
             {
@@ -101,6 +106,11 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         /// <param name="report">The report from the post-process build.</param>
         public void OnPostprocessBuild(BuildReport report)
         {
+            if (ScriptingDefineUtility.IsEOSDisabled(report))
+            {
+                return;
+            }
+
             // Run the static builder's postbuild
             s_builder?.PostBuild(report);
         }


### PR DESCRIPTION
Currently, we only use the EOS plugin for Epic Store builds, but the pre/post-processor scripts run for every platform. This has some undesirable effects, e.g. copying Android plugins into the project even though we don't use the plugin on Android.

This PR stops the platform-specific build scripts from running if `EOS_DISABLE` is defined.