### PR TITLE
Add missing `JsonConverter` attributes

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -261,7 +261,11 @@ namespace PlayEveryWare.EpicOnlineServices
             public string clientID;
             public uint tickBudgetInMilliseconds;
             public double taskNetworkTimeoutSeconds;
+
+            [JsonConverter(typeof(ListOfStringsToPlatformFlags))]
             public WrappedPlatformFlags platformOptionsFlags;
+
+            [JsonConverter(typeof(ListOfStringsToAuthScopeFlags))]
             public AuthScopeFlags authScopeOptionsFlags;
             public bool alwaysSendInputToOverlay;
 


### PR DESCRIPTION
This PR fixes an issue where config values are not properly migrated, by adding `JsonConverter` attributes to certain fields within classes internal to `PlatformConfig`.

#EOS-2219