### PR TITLE
fix: `EOS_DISABLE`

### DIFF
--- a/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
@@ -20,6 +20,8 @@
 * SOFTWARE.
 */
 
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices.Editor
 {
     using System;
@@ -251,3 +253,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/Source/Editor/ConfigEditors/PlatformConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/PlatformConfigEditor.cs
@@ -19,10 +19,12 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
+
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices.Editor
 {
     using System.Linq;
-    using UnityEditor;
     using UnityEngine;
     using Utility;
 
@@ -58,3 +60,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
@@ -20,20 +20,18 @@
 * SOFTWARE.
 */
 
-using System;
-using System.IO;
-using UnityEditor;
-using UnityEngine;
-using System.Collections.Generic;
+#if !EOS_DISABLE
 
 namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 {
+    using System;
+    using System.IO;
+    using UnityEditor;
+    using UnityEngine;
+    using System.Collections.Generic;
     using Config;
     using System.Linq;
     using System.Threading.Tasks;
-    using UnityEditor.AnimatedValues;
-    using Utility;
-    using Config = EpicOnlineServices.Config;
 
     /// <summary>
     /// Creates the view for showing the eos plugin editor config values.
@@ -165,3 +163,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSUnitTestSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSUnitTestSettingsWindow.cs
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices.Tests.Editor
 {
     using EpicOnlineServices.Editor;
@@ -60,3 +62,4 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Editor
         }
     }
 }
+#endif

--- a/Assets/Plugins/Source/Editor/Platforms/Android/AndroidBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Platforms/Android/AndroidBuilder.cs
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 {
     using Config;
@@ -399,3 +401,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         }
     }
 }
+
+#endif

--- a/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/WrappedInitializeThreadAffinity.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOS_SDK_Additions/WrappedInitializeThreadAffinity.cs
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices.Platform;
@@ -157,3 +159,5 @@ namespace PlayEveryWare.EpicOnlineServices
         }
     }
 }
+
+#endif


### PR DESCRIPTION
This PR expands upon and properly implements the usage of `EOS_DISABLE` such that no compiler errors are generated.

This PR is in service of an upcoming release in an effort to stabalize the `development` branch.

#EOS-2227