### PR TITLE
fix: Sample Manager Menu Runs "ShowInternal" Only When It Should

### DIFF
--- a/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
+++ b/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
@@ -434,7 +434,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             if (isClient || isHost)
             {
@@ -452,7 +452,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             RemoveJoinListener();
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             Background.enabled = false;
 

--- a/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
+++ b/Assets/Scripts/P2PNetcodeSample/UI/P2PNetcode/UIP2PTransportMenu.cs
@@ -434,10 +434,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
-
             if (isClient || isHost)
             {
                 DisconnectOnClick();
@@ -454,10 +452,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             RemoveJoinListener();
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
-
             Background.enabled = false;
 
             SetSessionUIActive(false);

--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -219,7 +219,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>
         /// Shows the SampleMenu.
         /// If this menu was not hidden, nothing happens.
-        /// If the menu was hidden, this calls <see cref="OnShow"/>.
+        /// If the menu was hidden, this calls <see cref="ShowInternal"/>.
         /// </summary>
         public void Show()
         {
@@ -256,7 +256,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // Flag as showing.
             Hidden = false;
 
-            OnShow();
+            ShowInternal();
 
             Log($"Show() completed");
         }
@@ -264,7 +264,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>
         /// Hides the SampleMenu.
         /// If this menu was already hidden, nothing happens.
-        /// If the menu was not already hidden, this calls <see cref="OnShow"/>.
+        /// If the menu was not already hidden, this calls <see cref="ShowInternal"/>.
         /// </summary>
         public void Hide()
         {
@@ -289,7 +289,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // Flag as hidden.
             Hidden = true;
 
-            OnHide();
+            HideInternal();
 
             Log($"Hide() completed");
         }
@@ -299,7 +299,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// this method is run so that implementing child classes can respond
         /// to becoming available.
         /// </summary>
-        protected virtual void OnShow()
+        protected virtual void ShowInternal()
         {
 
         }
@@ -309,7 +309,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// this method is run so that implementing child classes can respond
         /// to becoming unavailable.
         /// </summary>
-        protected virtual void OnHide()
+        protected virtual void HideInternal()
         {
 
         }

--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -217,10 +217,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         }
 
         /// <summary>
-        /// Shows the SampleMenu. If overriding, make sure to call this base
-        /// implementation first.
+        /// Shows the SampleMenu.
+        /// If this menu was not hidden, nothing happens.
+        /// If the menu was hidden, this calls <see cref="OnShow"/>.
         /// </summary>
-        public virtual void Show()
+        public void Show()
         {
             Log($"Show() started");
 
@@ -255,14 +256,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // Flag as showing.
             Hidden = false;
 
+            OnShow();
+
             Log($"Show() completed");
         }
 
         /// <summary>
-        /// Hides the SampleMenu. If overriding, make sure to call this base
-        /// implementation first.
+        /// Hides the SampleMenu.
+        /// If this menu was already hidden, nothing happens.
+        /// If the menu was not already hidden, this calls <see cref="OnShow"/>.
         /// </summary>
-        public virtual void Hide()
+        public void Hide()
         {
             Log($"Hide() started");
 
@@ -285,7 +289,29 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             // Flag as hidden.
             Hidden = true;
 
+            OnHide();
+
             Log($"Hide() completed");
+        }
+
+        /// <summary>
+        /// If this menu is shown through <see cref="Show"/> successfully, then
+        /// this method is run so that implementing child classes can respond
+        /// to becoming available.
+        /// </summary>
+        protected virtual void OnShow()
+        {
+
+        }
+
+        /// <summary>
+        /// If this menu is hidden through <see cref="Hide"/> successfully, then
+        /// this method is run so that implementing child classes can respond
+        /// to becoming unavailable.
+        /// </summary>
+        protected virtual void OnHide()
+        {
+
         }
 
         /// <summary>

--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -24,6 +24,7 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Samples
 {
+    using Epic.OnlineServices;
     using System.Diagnostics;
     using System.Runtime.CompilerServices;
     using UnityEngine;
@@ -224,6 +225,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public void Show()
         {
             Log($"Show() started");
+
+            if (RequiresAuthentication)
+            {
+                ProductUserId user = EOSManager.Instance.GetProductUserId();
+                if (user == null || !user.IsValid())
+                {
+                    Log($"This SampleMenu requires authentication, and the user " +
+                        "has not set a ProductUserId yet. Will not set this " +
+                        "sample to visible until OnAuthenticationChanged.");
+                    return;
+                }
+            }
 
             // Don't do anything if already showing.
             if (!Hidden) return;

--- a/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/SampleMenu.cs
@@ -314,7 +314,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </summary>
         protected virtual void ShowInternal()
         {
-
+            // The default implementation of this function is blank;
+            // children can override it to run operations that are suitable
+            // for Show
         }
 
         /// <summary>
@@ -324,7 +326,9 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </summary>
         protected virtual void HideInternal()
         {
-
+            // The default implementation of this function is blank;
+            // children can override it to run operations that are suitable
+            // for Hide
         }
 
         /// <summary>

--- a/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
@@ -62,7 +62,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             EOSManager.Instance.RemoveManager<EOSCustomInvitesManager>();
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             if (EOSManager.Instance.GetProductUserId()?.IsValid() == true)
             {
@@ -70,7 +70,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             PayloadInputField.InputField.text = string.Empty;
             CustomInvitesManager.ClearPayload();

--- a/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/CustomInvites/UICustomInvitesMenu.cs
@@ -62,18 +62,16 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             EOSManager.Instance.RemoveManager<EOSCustomInvitesManager>();
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             if (EOSManager.Instance.GetProductUserId()?.IsValid() == true)
             {
                 CustomInvitesManager?.ClearPayload();
             }
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             PayloadInputField.InputField.text = string.Empty;
             CustomInvitesManager.ClearPayload();
             

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -301,12 +301,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             FriendsManager.QueryFriends(null);
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             EOSManager.Instance.GetOrCreateManager<EOSFriendsManager>().OnLoggedIn();
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             FriendsManager?.OnLoggedOut();
         }

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -301,15 +301,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             FriendsManager.QueryFriends(null);
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             EOSManager.Instance.GetOrCreateManager<EOSFriendsManager>().OnLoggedIn();
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             FriendsManager?.OnLoggedOut();
         }
     }

--- a/Assets/Scripts/StandardSamples/UI/Leaderboard/UILeaderboardMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Leaderboard/UILeaderboardMenu.cs
@@ -358,9 +358,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsAfterStatIngestedToRefresh));
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             Invoke(nameof(InitFriends), 0);
         }
 

--- a/Assets/Scripts/StandardSamples/UI/Leaderboard/UILeaderboardMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Leaderboard/UILeaderboardMenu.cs
@@ -358,7 +358,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             refreshLeaderboardCoroutine = StartCoroutine(RefreshCurrentLeaderboardAfterWait(SecondsAfterStatIngestedToRefresh));
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             Invoke(nameof(InitFriends), 0);
         }

--- a/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
@@ -764,12 +764,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             EOSManager.Instance.GetOrCreateManager<EOSLobbyManager>().OnLoggedIn();
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             LobbyManager?.OnLoggedOut();
         }

--- a/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Lobbies/UILobbiesMenu.cs
@@ -763,16 +763,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
             }
         }
-     
-        public override void Show()
+
+        protected override void OnShow()
         {
-            base.Show();
             EOSManager.Instance.GetOrCreateManager<EOSLobbyManager>().OnLoggedIn();
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             LobbyManager?.OnLoggedOut();
         }
 

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -369,7 +369,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             GetEOSSessionsManager.DeclineLobbyInvite();
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             GetEOSSessionsManager.OnLoggedIn();
             GetEOSSessionsManager.OnPresenceChange.AddListener(SetDirtyFlagAction);
@@ -378,7 +378,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             EOSManager.Instance.SetLogLevel(Epic.OnlineServices.Logging.LogCategory.Sessions, Epic.OnlineServices.Logging.LogLevel.Verbose);
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             if (GetEOSSessionsManager.IsUserLoggedIn)//check to prevent warnings when done unnecessarily during Sessions & Matchmaking startup
             {

--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -369,9 +369,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             GetEOSSessionsManager.DeclineLobbyInvite();
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             GetEOSSessionsManager.OnLoggedIn();
             GetEOSSessionsManager.OnPresenceChange.AddListener(SetDirtyFlagAction);
 
@@ -379,9 +378,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             EOSManager.Instance.SetLogLevel(Epic.OnlineServices.Logging.LogCategory.Sessions, Epic.OnlineServices.Logging.LogLevel.Verbose);
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             if (GetEOSSessionsManager.IsUserLoggedIn)//check to prevent warnings when done unnecessarily during Sessions & Matchmaking startup
             {
                 GetEOSSessionsManager.OnPresenceChange.RemoveListener(SetDirtyFlagAction);

--- a/Assets/Scripts/StandardSamples/UI/Metrics/UIMetricsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Metrics/UIMetricsMenu.cs
@@ -146,15 +146,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             UpdateButtons();
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             UpdateButtons();
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             var localUserInfo = UserInfoManager.GetLocalUserInfo();
             if (localUserInfo.UserId?.IsValid() == true)
             {

--- a/Assets/Scripts/StandardSamples/UI/Metrics/UIMetricsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Metrics/UIMetricsMenu.cs
@@ -45,8 +45,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private EOSMetricsManager MetricsManager;
         private EOSUserInfoManager UserInfoManager;
 
+        private bool Initialized { get; set; } = false;
+
         private void Start()
         {
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            if (Initialized)
+            {
+                return;
+            }
+
             MetricsManager = EOSManager.Instance.GetOrCreateManager<EOSMetricsManager>();
             UserInfoManager = EOSManager.Instance.GetOrCreateManager<EOSUserInfoManager>();
 
@@ -60,6 +72,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             ErrorMessageTxt.gameObject.SetActive(false);
             UpdateButtons();
+
+            Initialized = true;
         }
 
         protected override void OnDestroy()
@@ -103,6 +117,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void UpdateButtons()
         {
+            // If this update was requested before the menu is set up, exit early
+            if (MetricsManager == null)
+            {
+                return;
+            }
+
             bool sessionActive = MetricsManager.IsSessionActive();
             BeginBtn.interactable = !sessionActive;
             EndBtn.interactable = sessionActive;
@@ -153,6 +173,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         protected override void OnShow()
         {
+            Initialize();
+
             var localUserInfo = UserInfoManager.GetLocalUserInfo();
             if (localUserInfo.UserId?.IsValid() == true)
             {

--- a/Assets/Scripts/StandardSamples/UI/Metrics/UIMetricsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Metrics/UIMetricsMenu.cs
@@ -166,12 +166,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             UpdateButtons();
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             UpdateButtons();
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             Initialize();
 

--- a/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
@@ -230,7 +230,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ChatMessageInput.InputField.text = string.Empty;
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             EOSManager.Instance.GetOrCreateManager<EOSPeer2PeerManager>().OnLoggedIn();
 
@@ -276,7 +276,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             Debug.Log("UIPeer2PeerMenu (SetPacketSize):Updated packet size to " + Peer2PeerManager.packetSizeMB + " Mb.");
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             Peer2PeerManager?.OnLoggedOut();
         }

--- a/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
@@ -230,9 +230,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ChatMessageInput.InputField.text = string.Empty;
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             EOSManager.Instance.GetOrCreateManager<EOSPeer2PeerManager>().OnLoggedIn();
 
             var presenceInterface = EOSManager.Instance.GetEOSPresenceInterface();
@@ -277,9 +276,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             Debug.Log("UIPeer2PeerMenu (SetPacketSize):Updated packet size to " + Peer2PeerManager.packetSizeMB + " Mb.");
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             Peer2PeerManager?.OnLoggedOut();
         }
 

--- a/Assets/Scripts/StandardSamples/UI/Peer2Peer/UIPeer2PeerMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Peer2Peer/UIPeer2PeerMenu.cs
@@ -279,7 +279,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ChatMessageInput.InputField.text = string.Empty;
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             EOSManager.Instance.GetOrCreateManager<EOSPeer2PeerManager>().OnLoggedIn();
 
@@ -312,7 +312,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             Peer2PeerManager?.OnLoggedOut();
 

--- a/Assets/Scripts/StandardSamples/UI/Peer2Peer/UIPeer2PeerMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Peer2Peer/UIPeer2PeerMenu.cs
@@ -279,9 +279,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ChatMessageInput.InputField.text = string.Empty;
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             EOSManager.Instance.GetOrCreateManager<EOSPeer2PeerManager>().OnLoggedIn();
 
             var presenceInterface = EOSManager.Instance.GetEOSPresenceInterface();
@@ -313,10 +312,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
-
             Peer2PeerManager?.OnLoggedOut();
 
             CloseChatOnClick();

--- a/Assets/Scripts/StandardSamples/UI/PlayerReports/UIPlayerReportMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/PlayerReports/UIPlayerReportMenu.cs
@@ -189,12 +189,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ReportButtonOnClick(friendData.UserProductUserId, friendData.Name);
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             ResetPopUp();
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             ResetPopUp();
         }

--- a/Assets/Scripts/StandardSamples/UI/PlayerReports/UIPlayerReportMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/PlayerReports/UIPlayerReportMenu.cs
@@ -189,15 +189,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             ReportButtonOnClick(friendData.UserProductUserId, friendData.Name);
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             ResetPopUp();
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
             ResetPopUp();
         }
     }

--- a/Assets/Scripts/StandardSamples/UI/Storage/Player/UIPlayerDataStorageMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Storage/Player/UIPlayerDataStorageMenu.cs
@@ -294,17 +294,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             LocalViewText.text = JsonUtility.ToJson(currentInventory, true);
         }
 
-        public override void Show()
+        protected override void OnShow()
         {
-            base.Show();
             UpdateFileListUI();
             PlayerDataStorageService.Instance.OnFileListUpdated += UpdateFileListUI;
         }
 
-        public override void Hide()
+        protected override void OnHide()
         {
-            base.Hide();
-
             currentSelectedFile = string.Empty;
             currentInventory = null;
             PlayerDataStorageService.Instance.OnFileListUpdated -= UpdateFileListUI;

--- a/Assets/Scripts/StandardSamples/UI/Storage/Player/UIPlayerDataStorageMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Storage/Player/UIPlayerDataStorageMenu.cs
@@ -294,13 +294,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             LocalViewText.text = JsonUtility.ToJson(currentInventory, true);
         }
 
-        protected override void OnShow()
+        protected override void ShowInternal()
         {
             UpdateFileListUI();
             PlayerDataStorageService.Instance.OnFileListUpdated += UpdateFileListUI;
         }
 
-        protected override void OnHide()
+        protected override void HideInternal()
         {
             currentSelectedFile = string.Empty;
             currentInventory = null;


### PR DESCRIPTION
When logging in to a sample, only run "Show" once when it is appropriate, and "Hide" once when it is appropriate. Before this change, "Show" was an overrideable function that child menus utilized. There was logic in all of them to run on various situations, some of which only should be run a single time. This introduces a function change to Show to make it no longer overrideable, instead instructing child implementers to override "ShowInternal".

The Metrics sample in particular was throwing an exception because Show was attempting to run logic before it had properly set itself up using this new paradigm. Now it has an "Initialize" variable that tracks if this should happen.

This has some risk in that it could be that some sample code was depending on this to run when it has. I've run each sample individually, and didn't find any other issues.

#EOS-2232