### PR TITLE
Use Func instead of Custom Delegate for GetUserLoginInfo

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -107,8 +107,6 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public delegate void OnConnectLoginCallback(Epic.OnlineServices.Connect.LoginCallbackInfo loginCallbackInfo);
 
-        public delegate Task<UserLoginInfo> GetUserLoginInfoDelegate();
-
         private static event OnAuthLoginCallback OnAuthLogin;
         private static event OnAuthLogoutCallback OnAuthLogout;
         private static event OnConnectLoginCallback OnConnectLogin;
@@ -119,7 +117,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// UserLoginInfo during <see cref="StartConnectLoginWithEpicAccount"/>.
         /// If this is not provided, no UserLoginInfo will be set.
         /// </summary>
-        public static GetUserLoginInfoDelegate GetUserLoginInfo = null;
+        public static Func<Task<UserLoginInfo>> GetUserLoginInfo = null;
 
         public delegate void OnCreateConnectUserCallback(CreateUserCallbackInfo createUserCallbackInfo);
 


### PR DESCRIPTION
Small addition to previous PR. Use a `Func<>` instead of custom defined delegate for `GetUserLoginInfo`.

Relates to #EOS-2234.