### PR TITLE
fix: Use `PlatformConfig` and `ProductConfig` in place of `EOSConfig`

### DIFF
--- a/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildRunner.cs
@@ -22,7 +22,7 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 {
-    using Config;
+    using PlayEveryWare.EpicOnlineServices;
     using Utility;
     using UnityEditor.Build;
     using UnityEditor.Build.Reporting;
@@ -69,19 +69,13 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
                 return;
             }
 
-            // Set the current platform that is being built against
-            if (PlatformManager.TryGetPlatform(report.summary.platform, out PlatformManager.Platform platform))
-            {
-                PlatformManager.CurrentPlatform = platform;
-            }
-
             // Run the static builder's prebuild.
             s_builder?.PreBuild(report);
 
 #if !DISABLESTEAMWORKS
             // If we're using Steamworks, then look at the user's Steam configuration file
             // If the "steamApiInterfaceVersionsArray" is empty, try to set it for the user
-            SteamConfig config = SteamConfig.Get<SteamConfig>();
+            SteamConfig config = Config.Get<SteamConfig>();
             if (config != null && (config.steamApiInterfaceVersionsArray == null || config.steamApiInterfaceVersionsArray.Count == 0))
             {
                 config.steamApiInterfaceVersionsArray = SteamworksUtility.GetSteamInterfaceVersions();

--- a/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
@@ -243,35 +243,16 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         private static async void AutoSetProductVersion()
         {
             PrebuildConfig prebuildConfig = await Config.GetAsync<PrebuildConfig>();
-
-            // If the product version is set by config, then stop here.
-            if (!prebuildConfig.useAppVersionAsProductVersion)
-            {
-                return;
-            }
-
-            if (!Version.TryParse(Application.version, out Version newVersion))
-            {
-                Debug.LogWarning(
-                    "Option to use Application version as EOS " +
-                    "SDK version has been set to true, but the " +
-                    "Application version string specified in Edit -> " +
-                    "Project Settings -> Player -> Version is not " +
-                    "properly formatted as a semver. Reverting to " +
-                    "default version.");
-                return;
-            }
-
             ProductConfig productConfig = Config.Get<ProductConfig>();
 
-            // If the versions are equal anyways, then we can stop here
-            if (VersionUtility.AreVersionsEqual(productConfig.ProductVersion, newVersion))
+            // If the product version is set by config, or if it already equals the product config, stop here.
+            if (!prebuildConfig.useAppVersionAsProductVersion || productConfig.ProductVersion == Application.version)
             {
                 return;
             }
 
             // Otherwise, set the new product version and write the config.
-            productConfig.ProductVersion = newVersion;
+            productConfig.ProductVersion = Application.version;
             await productConfig.WriteAsync();
         }
 

--- a/Assets/Plugins/Source/Editor/Platforms/Android/AndroidBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Platforms/Android/AndroidBuilder.cs
@@ -346,7 +346,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 
         private static void ConfigureEOSDependentLibrary()
         {
-            string clientIDAsLower = Config.Get<EOSConfig>().clientID.ToLower();
+            string clientIDAsLower = Config.Get<PlatformConfig>().clientCredentials.ClientId.ToLower();
 
             var pathToEOSValuesConfig = GetAndroidEOSValuesConfigPath();
             var currentEOSValuesConfigAsXML = new System.Xml.XmlDocument();

--- a/Assets/Plugins/Source/Editor/Platforms/Android/AndroidBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Platforms/Android/AndroidBuilder.cs
@@ -346,7 +346,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 
         private static void ConfigureEOSDependentLibrary()
         {
-            string clientIDAsLower = Config.Get<PlatformConfig>().clientCredentials.ClientId.ToLower();
+            string clientIDAsLower = PlatformManager.GetPlatformConfig().clientCredentials.ClientId.ToLower();
 
             var pathToEOSValuesConfig = GetAndroidEOSValuesConfigPath();
             var currentEOSValuesConfigAsXML = new System.Xml.XmlDocument();

--- a/Assets/Plugins/Source/Editor/Platforms/Windows/WindowsBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Platforms/Windows/WindowsBuilder.cs
@@ -91,7 +91,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 #else
             // Determine if 'DisableOverlay' is set in Platform Flags. If it is, then the EOSBootstrapper.exe is not included in the build,
             // because without needing the overlay, the EOSBootstrapper.exe is not useful to users of the plugin
-            EOSConfig configuration = await Config.GetAsync<EOSConfig>();
+            PlatformConfig configuration = await Config.GetAsync<PlatformConfig>();
             PlatformFlags configuredFlags = configuration.platformOptionsFlags.Unwrap();
             if (configuredFlags.HasFlag(PlatformFlags.DisableOverlay))
             {

--- a/Assets/Plugins/Source/Editor/Platforms/Windows/WindowsBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Platforms/Windows/WindowsBuilder.cs
@@ -91,7 +91,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 #else
             // Determine if 'DisableOverlay' is set in Platform Flags. If it is, then the EOSBootstrapper.exe is not included in the build,
             // because without needing the overlay, the EOSBootstrapper.exe is not useful to users of the plugin
-            PlatformConfig configuration = await Config.GetAsync<PlatformConfig>();
+            PlatformConfig configuration = PlatformManager.GetPlatformConfig();
             PlatformFlags configuredFlags = configuration.platformOptionsFlags.Unwrap();
             if (configuredFlags.HasFlag(PlatformFlags.DisableOverlay))
             {

--- a/Assets/Plugins/Source/Editor/Utility/EACUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/EACUtility.cs
@@ -22,6 +22,7 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 {
+    using Common.Extensions;
     using UnityEditor.Build.Reporting;
     using UnityEditor;
     using UnityEngine;
@@ -365,17 +366,18 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
             string fileContents = reader.ReadToEnd();
             reader.Close();
 
-            EOSConfig eosConfig = Config.Get<EOSConfig>();
+            ProductConfig productConfig = Config.Get<ProductConfig>();
+            PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
 
             var sb = new System.Text.StringBuilder(fileContents);
 
             sb.Replace("<UnityProductName>", Application.productName);
             sb.Replace("<ExeName>", buildExeName);
             sb.Replace("<ExeNameNoExt>", Path.GetFileNameWithoutExtension(buildExeName));
-            sb.Replace("<ProductName>", eosConfig.productName);
-            sb.Replace("<ProductID>", eosConfig.productID);
-            sb.Replace("<SandboxID>", eosConfig.sandboxID);
-            sb.Replace("<DeploymentID>", eosConfig.deploymentID);
+            sb.Replace("<ProductName>", productConfig.ProductName);
+            sb.Replace("<ProductID>", productConfig.ProductId.ToStrippedString());
+            sb.Replace("<SandboxID>", platformConfig.deployment.SandboxId.ToString());
+            sb.Replace("<DeploymentID>", platformConfig.deployment.DeploymentId.ToStrippedString());
 
             fileContents = sb.ToString();
 
@@ -420,7 +422,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
 
                 if (!string.IsNullOrWhiteSpace(toolPath))
                 {
-                    var productId = (Config.Get<EOSConfig>()).productID;
+                    var productId = Config.Get<ProductConfig>().ProductId.ToStrippedString();
                     GenerateIntegrityCert(report, toolPath, productId,
                         toolsConfig.pathToEACPrivateKey, toolsConfig.pathToEACCertificate, cfgPath);
                 }

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -63,6 +63,8 @@ namespace PlayEveryWare.EpicOnlineServices
 
         private static GCHandle SteamOptionsGCHandle;
 
+        public WindowsPlatformSpecifics() : base(PlatformManager.Platform.Windows) { }
+
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -63,8 +63,6 @@ namespace PlayEveryWare.EpicOnlineServices
 
         private static GCHandle SteamOptionsGCHandle;
 
-        public WindowsPlatformSpecifics() : base(PlatformManager.Platform.Windows, ".dll") { }
-
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()

--- a/Assets/Scripts/StandardSamples/UI/Login/UILoginMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Login/UILoginMenu.cs
@@ -1078,7 +1078,7 @@ using UnityEngine.InputSystem;
             {
                 EOSManager.Instance.StartLoginWithLoginTypeAndToken(loginType,
                                                                        null,
-                                                                       EOSManager.Instance.GetCommandLineArgsFromEpicLauncher().authPassword,
+                                                                       EOSManager.EOSSingleton.GetCommandLineArgsFromEpicLauncher().authPassword,
                                                                        StartLoginWithLoginTypeAndTokenCallback);
             }
             else

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -65,15 +65,6 @@ namespace PlayEveryWare.EpicOnlineServices
         "Thread Affinity & Tick Budgets",
         "Overlay Options"
     }, false)]
-    [Obsolete(
-        "This class has been deprecated in favor of targetted " +
-        "platform specific configuration files. It remains here to provide " +
-        "backwards compatibility but will be removed in an upcoming release." +
-        "Instead, you should utilize the PlatformConfig returned by " +
-        "PlatformManager.TryGetPlatformConfig for values that are unique to " +
-        "a given platform, and you should access ProductConfig via " +
-        "Config.Get<ProductConfig>() for all other values that are common " +
-        "to all platforms.")]
     public class EOSConfig : Config
     {
         static EOSConfig()

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -65,6 +65,15 @@ namespace PlayEveryWare.EpicOnlineServices
         "Thread Affinity & Tick Budgets",
         "Overlay Options"
     }, false)]
+    [Obsolete(
+        "This class has been deprecated in favor of targetted " +
+        "platform specific configuration files. It remains here to provide " +
+        "backwards compatibility but will be removed in an upcoming release." +
+        "Instead, you should utilize the PlatformConfig returned by " +
+        "PlatformManager.TryGetPlatformConfig for values that are unique to " +
+        "a given platform, and you should access ProductConfig via " +
+        "Config.Get<ProductConfig>() for all other values that are common " +
+        "to all platforms.")]
     public class EOSConfig : Config
     {
         static EOSConfig()

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -262,7 +262,13 @@ namespace PlayEveryWare.EpicOnlineServices
 
         // This warning is suppressed in the migration code because it is
         // necessary to make use of the obsolete type in-order to accomplish the
-        // migration.
+        // migration. 
+        // It is added because it is expected that EOSConfig is going to become
+        // obsolete in an upcoming release, and temporarily marking it as such
+        // helps identify areas of the code where it's usage should be replaced.
+        // Due to the nature of the migration code needing to have access, this
+        // warning suppression was added so that instances within the migration
+        // code are not flagged for referencing a potentially obsolete type.
 #pragma warning disable CS0618 // Type or member is obsolete
 
 #if !EOS_DISABLE

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -260,6 +260,11 @@ namespace PlayEveryWare.EpicOnlineServices
 
         #region Logic for Migrating Override Values from Previous Structure
 
+        // This warning is suppressed in the migration code because it is
+        // necessary to make use of the obsolete type in-order to accomplish the
+        // migration.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 #if !EOS_DISABLE
 
         protected sealed class NonOverrideableConfigValues : Config
@@ -328,7 +333,9 @@ namespace PlayEveryWare.EpicOnlineServices
             return !overrideValuesFromFieldMember.Equals(default) ? overrideValuesFromFieldMember : mainConfigValue;
         }
 
+
         private void MigrateButtonDelays(EOSConfig overrideValuesFromFieldMember, OverrideableConfigValues mainOverrideableConfig)
+
         {
             // Import the values for initial button delay and repeat button
             // delay
@@ -510,8 +517,11 @@ namespace PlayEveryWare.EpicOnlineServices
             Write();
 #endif
         }
+
 #endif
 
-#endregion
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        #endregion
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -66,11 +66,10 @@ namespace PlayEveryWare.EpicOnlineServices
     using Epic.OnlineServices.Logging;
     using Epic.OnlineServices.Connect;
     using Epic.OnlineServices.UI;
-#endif
 
-#if !EOS_DISABLE
     using Epic.OnlineServices.Presence;
-
+    
+    using Extensions;
     using System.Diagnostics;
     using System.Globalization;
     using UnityEngine.Assertions;
@@ -84,7 +83,6 @@ namespace PlayEveryWare.EpicOnlineServices
     using LoginStatusChangedCallbackInfo = Epic.OnlineServices.Auth.LoginStatusChangedCallbackInfo;
 
     using Utility;
-    using JsonUtility = PlayEveryWare.EpicOnlineServices.Utility.JsonUtility;
     using LogoutCallbackInfo = Epic.OnlineServices.Auth.LogoutCallbackInfo;
     using LogoutOptions = Epic.OnlineServices.Auth.LogoutOptions;
     using OnLogoutCallback = Epic.OnlineServices.Auth.OnLogoutCallback;

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -52,6 +52,7 @@
 namespace PlayEveryWare.EpicOnlineServices
 {
     //using Extensions;
+    using Common.Extensions;
     using UnityEngine;
     using System;
     using System.Collections.Generic;
@@ -271,7 +272,7 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetProductId()
             {
-                return Config.Get<EOSConfig>().productID;
+                return Config.Get<ProductConfig>().ProductId.ToStrippedString();
             }
 
             //-------------------------------------------------------------------------
@@ -281,7 +282,7 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetSandboxId()
             {
-                return Config.Get<EOSConfig>().sandboxID;
+                return PlatformManager.GetPlatformConfig().deployment.SandboxId.ToString();
             }
 
             //-------------------------------------------------------------------------
@@ -291,7 +292,7 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetDeploymentID()
             {
-                return Config.Get<EOSConfig>().deploymentID;
+                return PlatformManager.GetPlatformConfig().deployment.DeploymentId.ToStrippedString();
             }
 
             //-------------------------------------------------------------------------
@@ -301,7 +302,7 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public bool IsEncryptionKeyValid()
             {
-                return EOSClientCredentials.IsEncryptionKeyValid(Config.Get<EOSConfig>().encryptionKey);
+                return PlatformManager.GetPlatformConfig().clientCredentials.IsEncryptionKeyValid();
             }
 
             //-------------------------------------------------------------------------
@@ -324,7 +325,7 @@ namespace PlayEveryWare.EpicOnlineServices
             public bool ShouldOverlayReceiveInput()
             {
                 return (s_isOverlayVisible && s_DoesOverlayHaveExcusiveInput)
-                       || Config.Get<EOSConfig>().alwaysSendInputToOverlay
+                       || PlatformManager.GetPlatformConfig().alwaysSendInputToOverlay
                     ;
             }
 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -52,6 +52,7 @@
 namespace PlayEveryWare.EpicOnlineServices
 {
     //using Extensions;
+    using Common;
     using Common.Extensions;
     using UnityEngine;
     using System;
@@ -604,9 +605,17 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (!string.IsNullOrWhiteSpace(epicArgs.epicSandboxID))
                 {
-                    // TODO: Move this to set the deployment on the platform config
-                    //       unless that is done, this will no longer function.
-                    Config.Get<EOSConfig>().SetDeployment(epicArgs.epicSandboxID);
+                    var definedProductionEnvironments = Config.Get<ProductConfig>().Environments;
+                    foreach (Named<SandboxId> sandbox in definedProductionEnvironments.Sandboxes)
+                    {
+                        if (sandbox.Value.ToString() != epicArgs.epicSandboxID.ToLower())
+                        {
+                            continue;
+                        }
+
+                        PlatformManager.GetPlatformConfig().deployment.SandboxId = sandbox.Value;
+                        break;
+                    }
                 }
 
                 Result initResult = InitializePlatformInterface();

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -606,6 +606,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 if (!string.IsNullOrWhiteSpace(epicArgs.epicSandboxID))
                 {
                     var definedProductionEnvironments = Config.Get<ProductConfig>().Environments;
+                    bool sandboxOverridden = false;
                     foreach (Named<SandboxId> sandbox in definedProductionEnvironments.Sandboxes)
                     {
                         if (sandbox.Value.ToString() != epicArgs.epicSandboxID.ToLower())
@@ -614,7 +615,20 @@ namespace PlayEveryWare.EpicOnlineServices
                         }
 
                         PlatformManager.GetPlatformConfig().deployment.SandboxId = sandbox.Value;
+                        sandboxOverridden = true;
+                        Debug.Log($"SandboxID was overridden to be \"{sandbox.Value}\" by a command line parameter.");
                         break;
+                    }
+
+                    if (!sandboxOverridden)
+                    {
+                        Debug.LogWarning(
+                            $"The SandboxID " +
+                            $"\"{epicArgs.epicSandboxID}\" specified by " +
+                            $"command line argument is not a valid id. " +
+                            $"Defaulting to SandboxID " +
+                            $"\"{PlatformManager.GetPlatformConfig().deployment.SandboxId}\" " +
+                            $"defined in the configuration.");
                     }
                 }
 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -866,22 +866,6 @@ namespace PlayEveryWare.EpicOnlineServices
                     Id = id,
                     Token = token
                 };
-
-                /*
-
-                TODO: For discussion - this is explicitly setting the auth 
-                      scope flags to something other than the default, this is
-                      misleading and should not be done.
-
-                AuthScopeFlags scopeFlags = (AuthScopeFlags.BasicProfile |
-                                             AuthScopeFlags.FriendsList |
-                                             AuthScopeFlags.Presence);
-                
-                if (Config.Get<EOSConfig>().authScopeOptionsFlags != AuthScopeFlags.NoFlags)
-                {
-                    scopeFlags = Config.Get<EOSConfig>().authScopeOptionsFlags;
-                }
-                */
                 
                 return new LoginOptions
                 {

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -482,11 +482,20 @@ namespace PlayEveryWare.EpicOnlineServices
                 platformOptions.options.IsServer = platformConfig.isServer;
                 platformOptions.options.Flags =
 #if UNITY_EDITOR
-                    PlatformFlags.LoadingInEditor;
+                PlatformFlags.LoadingInEditor;
 #else
-                    configData.platformOptionsFlags.Unwrap();
+                platformConfig.platformOptionsFlags.Unwrap();
 #endif
-                
+
+                if (!platformConfig.clientCredentials.IsEncryptionKeyValid())
+                {
+                    Debug.LogError("The encryption key used for the selected client credentials is invalid. Please see your platform configuration.");
+                }
+                else
+                {
+                    platformOptions.options.EncryptionKey = platformConfig.clientCredentials.EncryptionKey;
+                }
+
                 platformOptions.options.OverrideCountryCode = null;
                 platformOptions.options.OverrideLocaleCode = null;
                 platformOptions.options.ProductId = productConfig.ProductId.ToStrippedString();

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -35,7 +35,7 @@ namespace PlayEveryWare.EpicOnlineServices
 #endif
     using Utility;
 
-    public static class PlatformManager
+    public static partial class PlatformManager
     {
         /// <summary>
         /// Enum that stores the possible platforms

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -92,17 +92,19 @@ namespace PlayEveryWare.EpicOnlineServices
         private static readonly IDictionary<Platform, PlatformInfo> PlatformInformation =
             new Dictionary<Platform, PlatformInfo>()
             {
+#if !EXTERNAL_TO_UNITY
                 { Platform.Android, PlatformInfo.Create<AndroidConfig>("Android", "eos_android_config.json", null,     "Android")},
                 { Platform.iOS,     PlatformInfo.Create<IOSConfig>    ("iOS",     "eos_ios_config.json",     null,     "iPhone") },
                 { Platform.Linux,   PlatformInfo.Create<LinuxConfig>  ("Linux",   "eos_linux_config.json",   ".so",    "Standalone") },
                 { Platform.macOS,   PlatformInfo.Create<MacOSConfig>  ("macOS",   "eos_macos_config.json",   ".dylib", "Standalone") },
+#endif
                 { Platform.Windows, PlatformInfo.Create<WindowsConfig>("Windows", "eos_windows_config.json", ".dll",   "Standalone") },
             };
 #endif
 
-        /// <summary>
-        /// Backing value for the CurrentPlatform property.
-        /// </summary>
+                /// <summary>
+                /// Backing value for the CurrentPlatform property.
+                /// </summary>
         private static Platform s_CurrentPlatform;
 
         /// <summary>
@@ -180,6 +182,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return s_platformConfig;
         }
 
+#if !EXTERNAL_TO_UNITY
         /// <summary>
         /// Maps Unity RuntimePlatform to Platform
         /// </summary>
@@ -217,6 +220,7 @@ namespace PlayEveryWare.EpicOnlineServices
         {
             return RuntimeToPlatformsMap.TryGetValue(runtimePlatform, out platform);
         }
+#endif
 
 #if UNITY_EDITOR
         /// <summary>

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -181,25 +181,6 @@ namespace PlayEveryWare.EpicOnlineServices
             return s_platformConfig;
         }
 
-#if UNITY_EDITOR
-        /// <summary>
-        /// Maps Unity BuildTarget to Platform
-        /// </summary>
-        private static readonly IDictionary<BuildTarget, Platform> TargetToPlatformsMap =
-            new Dictionary<BuildTarget, Platform>()
-            {
-                { BuildTarget.Android,             Platform.Android     },
-                { BuildTarget.GameCoreXboxOne,     Platform.XboxOne     },
-                { BuildTarget.GameCoreXboxSeries,  Platform.XboxSeriesX },
-                { BuildTarget.iOS,                 Platform.iOS         },
-                { BuildTarget.StandaloneLinux64,   Platform.Linux       },
-                { BuildTarget.PS4,                 Platform.PS4         },
-                { BuildTarget.PS5,                 Platform.PS5         },
-                { BuildTarget.Switch,              Platform.Switch      },
-                { BuildTarget.StandaloneWindows,   Platform.Windows     },
-                { BuildTarget.StandaloneWindows64, Platform.Windows     },
-            };
-
         /// <summary>
         /// Maps Unity RuntimePlatform to Platform
         /// </summary>
@@ -225,6 +206,36 @@ namespace PlayEveryWare.EpicOnlineServices
                 { RuntimePlatform.OSXEditor,          Platform.macOS},
                 { RuntimePlatform.OSXPlayer,          Platform.macOS},
                 { RuntimePlatform.OSXServer,          Platform.macOS},
+            };
+
+        /// <summary>
+        /// Get the platform that matches the given runtime platform.
+        /// </summary>
+        /// <param name="runtimePlatform">The active RuntimePlatform</param>
+        /// <param name="platform">The platform for that RuntimePlatform.</param>
+        /// <returns>True if platform was determined, false otherwise.</returns>
+        public static bool TryGetPlatform(RuntimePlatform runtimePlatform, out Platform platform)
+        {
+            return RuntimeToPlatformsMap.TryGetValue(runtimePlatform, out platform);
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Maps Unity BuildTarget to Platform
+        /// </summary>
+        private static readonly IDictionary<BuildTarget, Platform> TargetToPlatformsMap =
+            new Dictionary<BuildTarget, Platform>()
+            {
+                { BuildTarget.Android,             Platform.Android     },
+                { BuildTarget.GameCoreXboxOne,     Platform.XboxOne     },
+                { BuildTarget.GameCoreXboxSeries,  Platform.XboxSeriesX },
+                { BuildTarget.iOS,                 Platform.iOS         },
+                { BuildTarget.StandaloneLinux64,   Platform.Linux       },
+                { BuildTarget.PS4,                 Platform.PS4         },
+                { BuildTarget.PS5,                 Platform.PS5         },
+                { BuildTarget.Switch,              Platform.Switch      },
+                { BuildTarget.StandaloneWindows,   Platform.Windows     },
+                { BuildTarget.StandaloneWindows64, Platform.Windows     },
             };
 
         /// <summary>
@@ -260,17 +271,6 @@ namespace PlayEveryWare.EpicOnlineServices
         public static bool TryGetPlatform(BuildTarget target, out Platform platform)
         {
             return TargetToPlatformsMap.TryGetValue(target, out platform);
-        }
-
-        /// <summary>
-        /// Get the platform that matches the given runtime platform.
-        /// </summary>
-        /// <param name="runtimePlatform">The active RuntimePlatform</param>
-        /// <param name="platform">The platform for that RuntimePlatform.</param>
-        /// <returns>True if platform was determined, false otherwise.</returns>
-        public static bool TryGetPlatform(RuntimePlatform runtimePlatform, out Platform platform)
-        {
-            return RuntimeToPlatformsMap.TryGetValue(runtimePlatform, out platform);
         }
 
         public static bool TryGetConfigType(Platform platform, out Type configType)

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -22,7 +22,6 @@
 
 namespace PlayEveryWare.EpicOnlineServices
 {
-    using JetBrains.Annotations;
     using System.Collections.Generic;
     using System;
 
@@ -63,9 +62,9 @@ namespace PlayEveryWare.EpicOnlineServices
         {
             public string FullName { get;  }
             public string ConfigFileName { get; }
-            [CanBeNull] public string DynamicLibraryExtension { get; }
+            public string DynamicLibraryExtension { get; }
             public string PlatformIconLabel { get; }
-            [CanBeNull] public Func<PlatformConfig> GetConfigFunction { get; }
+            public Func<PlatformConfig> GetConfigFunction { get; }
             public Type ConfigType { get; }
 
             private PlatformInfo(Func<PlatformConfig> getConfigFunction, Type configType, string fullName, string configFileName, string dynamicLibraryExtension,

--- a/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
@@ -38,6 +38,11 @@ namespace PlayEveryWare.EpicOnlineServices
 
         #region Methods for which the functionality is shared (consider these "sealed")
 
+        protected PlatformSpecifics(PlatformManager.Platform platform)
+        {
+            Platform = platform;
+        }
+
         public string GetDynamicLibraryExtension()
         {
             return PlatformManager.GetDynamicLibraryExtension(Platform);

--- a/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
@@ -38,12 +38,6 @@ namespace PlayEveryWare.EpicOnlineServices
 
         #region Methods for which the functionality is shared (consider these "sealed")
 
-        protected PlatformSpecifics(PlatformManager.Platform platform, string dynamicLibraryExtension)
-        {
-            this.Platform = platform;
-            PlatformManager.SetPlatformDetails(platform, typeof(T), dynamicLibraryExtension);
-        }
-
         public string GetDynamicLibraryExtension()
         {
             return PlatformManager.GetDynamicLibraryExtension(Platform);

--- a/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
@@ -109,9 +109,8 @@ namespace PlayEveryWare.EpicOnlineServices
                 var overrideThreadAffinity = initializeOptions.options.OverrideThreadAffinity.Value;
 
                 PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
-                Config.Get<EOSConfig>().ConfigureOverrideThreadAffinity(ref overrideThreadAffinity);
-
-                initializeOptions.options.OverrideThreadAffinity = overrideThreadAffinity;
+                
+                initializeOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity.Unwrap();
             }
         }
 

--- a/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
@@ -105,11 +105,10 @@ namespace PlayEveryWare.EpicOnlineServices
             if (initializeOptions.options.OverrideThreadAffinity.HasValue)
             {
                 Debug.Log($"Assigning thread affinity override values for platform \"{Platform}\".");
-                var overrideThreadAffinity = initializeOptions.options.OverrideThreadAffinity.Value;
 
                 PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
                 
-                initializeOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity.Unwrap();
+                initializeOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity?.Unwrap();
             }
         }
 

--- a/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
@@ -108,6 +108,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 Debug.Log($"Assigning thread affinity override values for platform \"{Platform}\".");
                 var overrideThreadAffinity = initializeOptions.options.OverrideThreadAffinity.Value;
 
+                PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
                 Config.Get<EOSConfig>().ConfigureOverrideThreadAffinity(ref overrideThreadAffinity);
 
                 initializeOptions.options.OverrideThreadAffinity = overrideThreadAffinity;

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/EOSPluginConfig/EOSPluginConfig.csproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/EOSPluginConfig/EOSPluginConfig.csproj
@@ -79,8 +79,20 @@
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Extensions\FileInfoExtensions.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Common\Extensions\FileInfoExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Extensions\GuidExtensions.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Common\Extensions\GuidExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Extensions\ListExtensions.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Common\Extensions\ListExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Utility\EnumUtility.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Utility\EnumUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Utility\HashUtility.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Utility\HashUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Utility\SafeTranslatorUtility.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Utility\SafeTranslatorUtility.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Extensions\StringExtensions.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Common\Extensions\StringExtensions.cs</Link>
@@ -90,6 +102,9 @@
     </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\SetOfNamed.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Common\SetOfNamed.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Common\Wrapped.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Common\Wrapped.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\ButtonFieldAttribute.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\ButtonFieldAttribute.cs</Link>
@@ -199,12 +214,6 @@
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\PlatformManager.cs">
       <Link>com.playeveryware.eos\Runtime\Core\PlatformManager.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Utility\EnumUtility.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Utility\EnumUtility.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Utility\HashUtility.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Utility\HashUtility.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Utility\FileSystemUtility.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Utility\FileSystemUtility.cs</Link>
     </Compile>
@@ -214,9 +223,6 @@
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Utility\LogLevelUtility.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Utility\LogLevelUtility.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Utility\SafeTranslatorUtility.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Utility\SafeTranslatorUtility.cs</Link>
-    </Compile>
     <Compile Include="com.playeveryware.eos\Runtime\Core\Application.cs" />
     <Compile Include="com.playeveryware.eos\Runtime\Core\Debug.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -225,7 +231,7 @@
     </Compile>
     <Compile Include="ResourceUtility.cs" />
     <EmbeddedResource Include="config.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup />
@@ -235,7 +241,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="ModifyJsonFile" BeforeTargets="BeforeBuild">
     <!-- Example: Modify the JSON file using a PowerShell script or inline MSBuild task -->
-    <WriteLinesToFile File="config.json" Overwrite="true"
-        Lines="{ streamingAssetsPath: &quot;$(UnityStreamingAssetsDirectory)&quot; }" />
-</Target>
+    <WriteLinesToFile File="config.json" Overwrite="true" Lines="{ streamingAssetsPath: &quot;$(UnityStreamingAssetsDirectory)&quot; }" />
+  </Target>
 </Project>


### PR DESCRIPTION
In preparation of the upcoming release, and to facilitate the replacement of `EOSConfig` with the more specific `PlatformConfig` and `ProductConfig` classes, this PR alters most of the places where `EOSConfig` is referenced. With the migration code in place, the same values should be applied in all instances.

#EOS-2235