### PR TITLE
feat: `ConfigurationUtility`

### DIFF
--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -25,12 +25,15 @@
 //#define ENABLE_CONFIGURE_STEAM_FROM_MANAGED
 
 // If standalone windows and not editor, or the windows editor.
-#if (UNITY_STANDALONE_WIN && !UNITY_EDITOR) || UNITY_EDITOR_WIN
+#if (UNITY_STANDALONE_WIN && !UNITY_EDITOR) || UNITY_EDITOR_WIN || EXTERNAL_TO_UNITY
 
 namespace PlayEveryWare.EpicOnlineServices
 {
     using System.Collections.Generic;
+
+#if !EXTERNAL_TO_UNITY
     using UnityEngine;
+#endif
 
     using Epic.OnlineServices.Platform;
     using System.Runtime.InteropServices;
@@ -65,18 +68,20 @@ namespace PlayEveryWare.EpicOnlineServices
 
         public WindowsPlatformSpecifics() : base(PlatformManager.Platform.Windows) { }
 
+#if !EXTERNAL_TO_UNITY
         //-------------------------------------------------------------------------
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static public void Register()
         {
             EOSManagerPlatformSpecificsSingleton.SetEOSManagerPlatformSpecificsInterface(new WindowsPlatformSpecifics());
         }
+#endif
 
         //-------------------------------------------------------------------------
         public override void LoadDelegatesWithEOSBindingAPI()
         {
             // In the editor, EOS needs to be dynamically bound.
-#if EOS_DYNAMIC_BINDINGS || UNITY_EDITOR 
+#if EOS_DYNAMIC_BINDINGS || UNITY_EDITOR
             const string EOSBinaryName = Epic.OnlineServices.Config.LibraryName;
             var eosLibraryHandle = EOSManager.EOSSingleton.LoadDynamicLibrary(EOSBinaryName);
             Epic.OnlineServices.WindowsBindings.Hook<DLLHandle>(eosLibraryHandle, (DLLHandle handle, string functionName) => {
@@ -85,6 +90,7 @@ namespace PlayEveryWare.EpicOnlineServices
 #endif
         }
 
+#if !EXTERNAL_TO_UNITY
         //-------------------------------------------------------------------------
         /// <summary>
         /// Nothing to be done on windows for the moment
@@ -189,6 +195,8 @@ namespace PlayEveryWare.EpicOnlineServices
 #endif
             }
         }
+
+#endif
     }
 }
 #endif

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -68,7 +68,7 @@ namespace PlayEveryWare.EpicOnlineServices
     using Epic.OnlineServices.UI;
 
     using Epic.OnlineServices.Presence;
-    
+
     using Extensions;
     using System.Diagnostics;
     using System.Globalization;
@@ -189,7 +189,7 @@ namespace PlayEveryWare.EpicOnlineServices
             static private NotifyEventHandle s_notifyLoginStatusChangedCallbackHandle;
             static private NotifyEventHandle s_notifyConnectLoginStatusChangedCallbackHandle;
             static private NotifyEventHandle s_notifyConnectAuthExpirationCallbackHandle;
-            
+
             // Setting it twice will cause an exception
             static bool hasSetLoggingCallback;
 
@@ -437,26 +437,7 @@ namespace PlayEveryWare.EpicOnlineServices
             //-------------------------------------------------------------------------
             private Result InitializePlatformInterface()
             {
-                ProductConfig productConfig = Config.Get<ProductConfig>();
-                IPlatformSpecifics platformSpecifics = EOSManagerPlatformSpecificsSingleton.Instance;
-
-                print("InitializePlatformInterface: platformSpecifics.GetType() = " + platformSpecifics.GetType());
-
-                EOSInitializeOptions initOptions = new();
-
-                print("InitializePlatformInterface: initOptions.GetType() = " + initOptions.GetType());
-
-                initOptions.options.ProductName = productConfig.ProductName;
-                initOptions.options.ProductVersion = productConfig.ProductVersion.ToString();
-                initOptions.options.OverrideThreadAffinity = new InitializeThreadAffinity();
-
-                initOptions.options.AllocateMemoryFunction = IntPtr.Zero;
-                initOptions.options.ReallocateMemoryFunction = IntPtr.Zero;
-                initOptions.options.ReleaseMemoryFunction = IntPtr.Zero;
-
-                initOptions.options.OverrideThreadAffinity = PlatformManager.GetPlatformConfig().threadAffinity.Unwrap();
-
-                platformSpecifics.ConfigureSystemInitOptions(ref initOptions);
+                EOSInitializeOptions initOptions = ConfigurationUtility.GetEOSInitializeOptions();
 
 #if UNITY_PS4 && !UNITY_EDITOR
                 // On PS4, RegisterForPlatformNotifications is called at a later time by EOSPSNManager
@@ -464,73 +445,18 @@ namespace PlayEveryWare.EpicOnlineServices
                 RegisterForPlatformNotifications();
 #endif
 
-                return PlatformInterface.Initialize(ref (initOptions as EOSInitializeOptions).options);
+                return PlatformInterface.Initialize(ref initOptions.options);
             }
 
             //-------------------------------------------------------------------------
             private PlatformInterface CreatePlatformInterface()
             {
-                PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
-                ProductConfig productConfig = Config.Get<ProductConfig>();
+                EOSCreateOptions platformOptions = ConfigurationUtility.GetEOSCreateOptions();
 
-                IPlatformSpecifics platformSpecifics = EOSManagerPlatformSpecificsSingleton.Instance;
-
-                EOSCreateOptions platformOptions = new();
-
-                platformOptions.options.CacheDirectory = platformSpecifics.GetTempDir();
-                platformOptions.options.IsServer = platformConfig.isServer;
-                platformOptions.options.Flags =
-#if UNITY_EDITOR
-                PlatformFlags.LoadingInEditor;
-#else
-                platformConfig.platformOptionsFlags.Unwrap();
-#endif
-
-                if (!platformConfig.clientCredentials.IsEncryptionKeyValid())
-                {
-                    Debug.LogError("The encryption key used for the selected client credentials is invalid. Please see your platform configuration.");
-                }
-                else
-                {
-                    platformOptions.options.EncryptionKey = platformConfig.clientCredentials.EncryptionKey;
-                }
-
-                platformOptions.options.OverrideCountryCode = null;
-                platformOptions.options.OverrideLocaleCode = null;
-                platformOptions.options.ProductId = productConfig.ProductId.ToString("N").ToLowerInvariant();
-                platformOptions.options.SandboxId = platformConfig.deployment.SandboxId.ToString();
-                platformOptions.options.DeploymentId = platformConfig.deployment.DeploymentId.ToString("N").ToLowerInvariant();
-
-                platformOptions.options.TickBudgetInMilliseconds = platformConfig.tickBudgetInMilliseconds;
-
-                // configData has to serialize to JSON, so it doesn't represent null
-                // If the value is <= 0, then set it to null, which the EOS SDK will handle by using default of 30 seconds.
-                platformOptions.options.TaskNetworkTimeoutSeconds = platformConfig.taskNetworkTimeoutSeconds > 0 ? platformConfig.taskNetworkTimeoutSeconds : null;
-
-                platformOptions.options.ClientCredentials = new ClientCredentials
-                {
-                    ClientId = platformConfig.clientCredentials.ClientId,
-                    ClientSecret = platformConfig.clientCredentials.ClientSecret,
-                };
-
+                PlatformInterface platformInterface = PlatformInterface.Create(ref platformOptions.options);
 
 #if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)
-                var createIntegratedPlatformOptionsContainerOptions = new Epic.OnlineServices.IntegratedPlatform.CreateIntegratedPlatformOptionsContainerOptions();
-                var integratedPlatformOptionsContainer = new Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformOptionsContainer();
-                var integratedPlatformOptionsContainerResult = Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformInterface.CreateIntegratedPlatformOptionsContainer(ref createIntegratedPlatformOptionsContainerOptions, out integratedPlatformOptionsContainer);
-                
-                if (integratedPlatformOptionsContainerResult != Result.Success)
-                {
-                    print($"Error creating integrated platform container: {integratedPlatformOptionsContainerResult}");
-                }
-                platformOptions.options.IntegratedPlatformOptionsContainerHandle = integratedPlatformOptionsContainer;
-#endif
-                platformSpecifics.ConfigureSystemPlatformCreateOptions(ref platformOptions);
-
-                PlatformInterface platformInterface = PlatformInterface.Create(ref (platformOptions as EOSCreateOptions).options);
-
-#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)
-                integratedPlatformOptionsContainer.Release();
+                platformOptions.options.IntegratedPlatformOptionsContainerHandle.Release();
 #endif
                 return platformInterface;
 
@@ -872,7 +798,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     Id = id,
                     Token = token
                 };
-                
+
                 return new LoginOptions
                 {
                     Credentials = loginCredentials,
@@ -1558,7 +1484,7 @@ namespace PlayEveryWare.EpicOnlineServices
                         if (deletePersistentAuthCallbackInfo.ResultCode != Result.Success)
                         {
                             print("Unable to delete persistent token, Result : " +
-                                           deletePersistentAuthCallbackInfo.ResultCode, 
+                                           deletePersistentAuthCallbackInfo.ResultCode,
                                            LogType.Error);
                         }
                         else
@@ -1830,8 +1756,8 @@ namespace PlayEveryWare.EpicOnlineServices
         }
 #endif
 
-                /// <value>Private static instance of <c>EOSSingleton</c></value>
-                static EOSSingleton s_instance;
+        /// <value>Private static instance of <c>EOSSingleton</c></value>
+        static EOSSingleton s_instance;
 
         /// <value>Public static instance of <c>EOSSingleton</c></value>
         //-------------------------------------------------------------------------

--- a/com.playeveryware.eos/Runtime/Core/IPlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/IPlatformSpecifics.cs
@@ -35,7 +35,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         string GetDynamicLibraryExtension();
 
-//#if EOS_DYNAMIC_BINDINGS
+        //#if EOS_DYNAMIC_BINDINGS
         // Only called if EOS_DYNAMIC_BINDINGS is defined
         void LoadDelegatesWithEOSBindingAPI();
         //#endif
@@ -45,10 +45,10 @@ namespace PlayEveryWare.EpicOnlineServices
 #if !EXTERNAL_TO_UNITY
         void ConfigureSystemInitOptions(ref EOSInitializeOptions initializeOptions);
 
-        void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions);
-
         void InitializeOverlay(IEOSCoroutineOwner owner);
 #endif
+
+        void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions);
 
         void RegisterForPlatformNotifications();
 

--- a/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformSpecifics.cs
@@ -55,7 +55,7 @@ namespace PlayEveryWare.EpicOnlineServices
         }
 
         #endregion
-        
+
         #region Virtual methods that have a default behavior, but may need to be overwritten by deriving classes.
 
         public virtual string GetTempDir()
@@ -99,34 +99,19 @@ namespace PlayEveryWare.EpicOnlineServices
             return false;
         }
 
-        // The EXTERNAL_TO_UNITY block is here to enable the compilation of this
-        // code file outside of the context of Unity altogether.
-#if !EXTERNAL_TO_UNITY
         public virtual void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions)
         {
             ((EOSCreateOptions)createOptions).options.RTCOptions = new();
         }
-#endif
 
+        // The EXTERNAL_TO_UNITY block is here to enable the compilation of this
+        // code file outside of the context of Unity altogether.
+#if !EXTERNAL_TO_UNITY
         public virtual void ConfigureSystemInitOptions(ref EOSInitializeOptions initializeOptionsRef)
         {
-            Debug.Log("ConfigureSystemInitOptions");
-
-            if (initializeOptionsRef is not EOSInitializeOptions initializeOptions)
-            {
-                throw new Exception("ConfigureSystemInitOptions: initializeOptions is null!");
-            }
-
-            if (initializeOptions.options.OverrideThreadAffinity.HasValue)
-            {
-                Debug.Log($"Assigning thread affinity override values for platform \"{Platform}\".");
-
-                PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
-                
-                initializeOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity?.Unwrap();
-            }
+            // Default implementation is to do nothing
         }
-
+#endif
         /// <summary>
         /// Indicates whether the platform is ready for network activity.
         /// TODO: Determine where this is used, and why it isn't a boolean.

--- a/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
@@ -102,7 +102,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 ClientSecret = platformConfig.clientCredentials.ClientSecret,
             };
 
-            // TODO: Make sure that it is acceptable not to inspect this external to unity
 #if !EXTERNAL_TO_UNITY
 
 #if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)

--- a/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
@@ -1,0 +1,164 @@
+﻿/*
+ * Copyright (c) 2024 PlayEveryWare
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PlayEveryWare.EpicOnlineServices.Utility
+{
+    using Epic.OnlineServices;
+    using Epic.OnlineServices.Platform;
+    using Extensions;
+    using System;
+    using Config = EpicOnlineServices.Config;
+
+#if !EXTERNAL_TO_UNITY
+    using UnityEngine;
+#endif
+
+    /// <summary>
+    /// This class is used to segregate the code responsible for taking
+    /// configuration values (as stored in JSON and editable by the user from
+    /// within the Unity editor) and converting those values into the data
+    /// structures that the EOS SDK requires to be created and initialized.
+    ///
+    /// The primary purpose of doing this - aside from separating the concerns,
+    /// is to allow efficient testing of the verisimilitude between the native
+    /// and managed implementations of this process.
+    /// </summary>
+    public static class ConfigurationUtility
+    {
+        /// <summary>
+        /// Get the create options used to make the EOS platform.
+        /// </summary>
+        /// <returns>
+        /// An object that encapsulates the CreateOptions used for creating the
+        /// EOS SDK platform.
+        /// </returns>
+        public static EOSCreateOptions GetEOSCreateOptions()
+        {
+            PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
+            ProductConfig productConfig = Config.Get<ProductConfig>();
+
+            IPlatformSpecifics platformSpecifics =
+#if EXTERNAL_TO_UNITY
+                new WindowsPlatformSpecifics()
+#else
+                EOSManagerPlatformSpecificsSingleton.Instance
+#endif
+            ;
+
+            EOSCreateOptions platformOptions = new();
+
+            platformOptions.options.CacheDirectory = platformSpecifics.GetTempDir();
+            platformOptions.options.IsServer = platformConfig.isServer;
+            platformOptions.options.Flags =
+#if UNITY_EDITOR
+                PlatformFlags.LoadingInEditor;
+#else
+            platformConfig.platformOptionsFlags.Unwrap();
+#endif
+
+            if (!platformConfig.clientCredentials.IsEncryptionKeyValid())
+            {
+                Debug.LogError("The encryption key used for the selected client credentials is invalid. Please see your platform configuration.");
+            }
+            else
+            {
+                platformOptions.options.EncryptionKey = platformConfig.clientCredentials.EncryptionKey;
+            }
+
+            platformOptions.options.OverrideCountryCode = null;
+            platformOptions.options.OverrideLocaleCode = null;
+            platformOptions.options.ProductId = productConfig.ProductId.ToString("N").ToLowerInvariant();
+            platformOptions.options.SandboxId = platformConfig.deployment.SandboxId.ToString();
+            platformOptions.options.DeploymentId = platformConfig.deployment.DeploymentId.ToString("N").ToLowerInvariant();
+
+            platformOptions.options.TickBudgetInMilliseconds = platformConfig.tickBudgetInMilliseconds;
+
+            // configData has to serialize to JSON, so it doesn't represent null
+            // If the value is <= 0, then set it to null, which the EOS SDK will handle by using default of 30 seconds.
+            platformOptions.options.TaskNetworkTimeoutSeconds = platformConfig.taskNetworkTimeoutSeconds > 0 ? platformConfig.taskNetworkTimeoutSeconds : null;
+
+            platformOptions.options.ClientCredentials = new ClientCredentials
+            {
+                ClientId = platformConfig.clientCredentials.ClientId,
+                ClientSecret = platformConfig.clientCredentials.ClientSecret,
+            };
+
+            // TODO: Make sure that it is acceptable not to inspect this external to unity
+#if !EXTERNAL_TO_UNITY
+
+#if !(UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX)
+            var createIntegratedPlatformOptionsContainerOptions = new Epic.OnlineServices.IntegratedPlatform.CreateIntegratedPlatformOptionsContainerOptions();
+                var integratedPlatformOptionsContainer = new Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformOptionsContainer();
+                var integratedPlatformOptionsContainerResult = Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformInterface.CreateIntegratedPlatformOptionsContainer(ref createIntegratedPlatformOptionsContainerOptions, out integratedPlatformOptionsContainer);
+                
+                if (integratedPlatformOptionsContainerResult != Result.Success)
+                {
+                    Debug.LogError($"Error creating integrated platform container: {integratedPlatformOptionsContainerResult}");
+                }
+                platformOptions.options.IntegratedPlatformOptionsContainerHandle = integratedPlatformOptionsContainer;
+#endif
+#endif
+
+            // Note that this function only sets rtcoptions - which is not
+            // exposed or affected by configuration, so it is not considered
+            // when being called external to unity.
+#if !EXTERNAL_TO_UNITY
+            platformSpecifics.ConfigureSystemPlatformCreateOptions(ref platformOptions);
+#endif
+            return platformOptions;
+        }
+
+        /// <summary>
+        /// Get the initialize options used to initialize the EOS SDK after it
+        /// has been created.
+        /// </summary>
+        /// <returns>
+        /// An object that encapsulates the initialization options utilized to
+        /// initialize the EOS SDK after it has been created.
+        /// </returns>
+        public static EOSInitializeOptions GetEOSInitializeOptions()
+        {
+            EOSInitializeOptions initOptions = new() { options = new() };
+
+            // Get the product config and the platform config
+            ProductConfig productConfig = Config.Get<ProductConfig>();
+            PlatformConfig platformConfig = PlatformManager.GetPlatformConfig();
+
+            // Set the product name, version, and override thread affinity
+            initOptions.options.ProductName = productConfig.ProductName;
+            initOptions.options.ProductVersion = productConfig.ProductVersion;
+            initOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity.Unwrap();
+
+            initOptions.options.AllocateMemoryFunction = IntPtr.Zero;
+            initOptions.options.ReallocateMemoryFunction = IntPtr.Zero;
+            initOptions.options.ReleaseMemoryFunction = IntPtr.Zero;
+
+#if !EXTERNAL_TO_UNITY
+            IPlatformSpecifics platformSpecifics = EOSManagerPlatformSpecificsSingleton.Instance;
+            platformSpecifics.ConfigureSystemInitOptions(ref initOptions);
+#endif
+
+            // Return;
+            return initOptions;
+        }
+    }
+}

--- a/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs.meta
+++ b/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2a80b4f410801c4a9bc43800b725258
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR introduces a `ConfigurationUtility` class to simplify testing and make it possible to ensure parity between the native and managed implementations of the configuration system. The configuration values, stored in JSON and editable through the Unity Editor, impact primarily two processes:

1. Creating the EOS SDK platform.
2. Initializing the EOS SDK platform.

The logic for these processes, previously located in `EOSManager.EOSSingleton`, has been moved unchanged into the new `ConfigurationUtility` class. This refactor isolates the configuration logic, making it easier to test and maintain.

The compile conditional `EXTERNAL_TO_UNITY` has also been placed in files that make it possible to include `ConfigurationUtility.cs` in a build that is external to the Unity Editor. This will allow native code to test that there is parity between it and the managed code within the Unity project.

#EOS-1982