### PR TITLE
fix: Disable Application Focus Logging by Default

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -20,6 +20,12 @@
  * SOFTWARE.
  */
 
+// Uncomment the following line to enable logging of application focus state 
+// changes. If this is on it can clutter the log window and make debugging 
+// difficult, so please enable it when you need to diagnose application focus
+// state-related issues.
+//#define LOG_APPLICATION_FOCUS_CHANGE
+
 // Don't shut down the interface if running in the editor.
 // According to the Epic documentation, shutting down this will disable a given loaded
 // instance of the SDK from ever initializing again. Which is bad because Unity often (always?) loads a library just once
@@ -1770,9 +1776,11 @@ namespace PlayEveryWare.EpicOnlineServices
             //-------------------------------------------------------------------------
             public void OnApplicationFocus(bool hasFocus)
             {
+#if LOG_APPLICATION_FOCUS_CHANGE
                 bool hadFocus = s_hasFocus;
-                s_hasFocus = hasFocus;
                 print($"EOSSingleton.OnApplicationFocus: HasFocus {hadFocus} -> {s_hasFocus}");
+#endif
+                s_hasFocus = hasFocus;
 
                 //                // Poll for the latest application constrained state as we're about
                 //                // to need it to determine the appropriate EOS application status


### PR DESCRIPTION
This very small change turns off by default the logging that indicates when the demo application has had it's focus state change. When diagnosing issues regarding native code - or other things external to the sample application - it is useful to be tabbing away from the application but still monitor the debug console window. Currently, this is difficult because everytime you change focus the log gets populated, and quickly the text you need is out of scope. 

This puts the logging of the state change inside a compile conditional, and adds a commented-out define at the top of the file documenting how to turn on the logging if you need it.