### PR TITLE
fix: `PlatformSpecificBuildOrder` `callbackOrder` correction

### DIFF
--- a/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
+++ b/Assets/Plugins/Source/Editor/Build/PlatformSpecificBuilder.cs
@@ -67,7 +67,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         /// need to execute first in-order to register themselves as builders
         /// for their respective platforms.
         /// </summary>
-        public int callbackOrder => 1;
+        public int callbackOrder => 0;
 
         /// <summary>
         /// Stores the targets for which the builder can be used.


### PR DESCRIPTION
This PR resolves [this issue](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues/1027), which arises due to a misconfiguration of the `callbackOrder`.

Thanks to @joetaylor1987 for finding the fix!

#EOS-2260