### PR TITLE
chore: Renaming "print" to "log" where applicable

### DIFF
--- a/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
+++ b/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
@@ -109,7 +109,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         [Conditional("ENABLE_DEBUG_EOSMANAGERANDROID")]
-        static void log(string toPrint)
+        static void Log(string toPrint)
         {
             UnityEngine.Debug.Log(toPrint);
         }

--- a/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
+++ b/Assets/Plugins/Android/Core/AndroidPlatformSpecifics.cs
@@ -109,7 +109,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         [Conditional("ENABLE_DEBUG_EOSMANAGERANDROID")]
-        static void print(string toPrint)
+        static void log(string toPrint)
         {
             UnityEngine.Debug.Log(toPrint);
         }

--- a/Assets/Plugins/Source/Editor/Build/BuildPackage.cs
+++ b/Assets/Plugins/Source/Editor/Build/BuildPackage.cs
@@ -179,7 +179,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
             // Validate file paths
             if (!File.Exists(jsonFile))
             {
-                ExportError("JSON file \"" + jsonFile + "\" does not appear to exist.");
+                LogError("JSON file \"" + jsonFile + "\" does not appear to exist.");
             }
 
             // If the output directory does not exist, try and create it.
@@ -219,7 +219,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Build
         /// Helper method to log and throw fatal errors that may occur during plugin export.
         /// </summary>
         /// <param name="message">The message to log / throw</param>
-        private static void ExportError(string message)
+        private static void LogError(string message)
         {
             Debug.LogError(message);
             throw new BuildFailedException(message);

--- a/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransport.cs
+++ b/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransport.cs
@@ -103,19 +103,19 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         private Queue<Tuple<ProductUserId, ulong, bool>> ConnectedDisconnectedUserEvents = null;
 
         [System.Diagnostics.Conditional("EOS_TRANSPORT_DEBUG")]
-        private void print(string msg)
+        private void log(string msg)
         {
             Debug.Log(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORT_DEBUG")]
-        private void printWarning(string msg)
+        private void logWarning(string msg)
         {
             Debug.LogWarning(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORT_DEBUG")]
-        private void printError(string msg)
+        private void logError(string msg)
         {
             Debug.LogError(msg);
         }
@@ -138,7 +138,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             ProductUserId userId = GetUserId(clientId);
 
-            print($"EOSP2PTransport.Send: [ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', SendTimeSec='{Time.realtimeSinceStartup}']");
+            log($"EOSP2PTransport.Send: [ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', SendTimeSec='{Time.realtimeSinceStartup}']");
 
             Epic.OnlineServices.P2P.PacketReliability reliability = Epic.OnlineServices.P2P.PacketReliability.ReliableOrdered;
             if (networkDelivery == NetworkDelivery.Unreliable)
@@ -158,7 +158,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             {
                 if (reliability != Epic.OnlineServices.P2P.PacketReliability.ReliableOrdered)
                 {
-                    printError($"EOSP2PTransport.Send: Unable to send payload - The payload size ({payload.Count} bytes) exceeds the maxmimum packet size supported by EOS P2P ({EOSTransportManager.MaxPacketSize} bytes).");
+                    logError($"EOSP2PTransport.Send: Unable to send payload - The payload size ({payload.Count} bytes) exceeds the maxmimum packet size supported by EOS P2P ({EOSTransportManager.MaxPacketSize} bytes).");
                     return;
                 }
             }
@@ -196,7 +196,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 payload = new ArraySegment<byte>();
                 receiveTime = Time.realtimeSinceStartup;
                 NetworkEvent networkEventType = evntIsConnectionEvent ? NetworkEvent.Connect : NetworkEvent.Disconnect;
-                print($"EOSP2PTransport.PollEvent: [{networkEventType}, ClientId='{clientId}', UserId='{evntUserId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
+                log($"EOSP2PTransport.PollEvent: [{networkEventType}, ClientId='{clientId}', UserId='{evntUserId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
                 return networkEventType;
             }
 
@@ -208,7 +208,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 clientId = GetTransportId(userId);
                 payload = new ArraySegment<byte>(packet);
                 receiveTime = Time.realtimeSinceStartup;
-                print($"EOSP2PTransport.PollEvent: [{NetworkEvent.Data}, ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
+                log($"EOSP2PTransport.PollEvent: [{NetworkEvent.Data}, ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
                 return NetworkEvent.Data;
             }
 
@@ -216,7 +216,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             clientId = InvalidClientId;
             payload = new ArraySegment<byte>();
             receiveTime = 0;
-            print("EOSP2PTransport.PollEvent: []");
+            log("EOSP2PTransport.PollEvent: []");
             return NetworkEvent.Nothing;
         }
 
@@ -233,7 +233,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 #endif
             if (ServerUserIdToConnectTo == null)
             {
-                print("EOSP2PTransport.StartClient: No ServerUserIDToConnectTo set!");
+                log("EOSP2PTransport.StartClient: No ServerUserIDToConnectTo set!");
                 return false;
             }
 
@@ -253,17 +253,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Attempt to connect to the server hosted by ServerUserId - was the request successfully initiated?
                 if (result = P2PManager.OpenConnection(ServerUserId, P2PSocketName))
                 {
-                    print($"EOSP2PTransport.StartClient: Successful Client start up - REQUESTED outgoing '{P2PSocketName}' socket connection with Server UserId Server UserId='{ServerUserId}'.");
+                    log($"EOSP2PTransport.StartClient: Successful Client start up - REQUESTED outgoing '{P2PSocketName}' socket connection with Server UserId Server UserId='{ServerUserId}'.");
                     result = true;
                 }
                 else
                 {
-                    printError($"EOSP2PTransport.StartClient: Failed Client start up - Unable to initiate a connect request with Server UserId='{ServerUserId}'.");
+                    logError($"EOSP2PTransport.StartClient: Failed Client start up - Unable to initiate a connect request with Server UserId='{ServerUserId}'.");
                 }
             }
             else
             {
-                printError("EOSP2PTransport.StartClient: Failed Client start up - 'ServerUserIdToConnectTo' is null or invalid."
+                logError("EOSP2PTransport.StartClient: Failed Client start up - 'ServerUserIdToConnectTo' is null or invalid."
                     + " Please set a valid EOS ProductUserId of the Server host this Client should try connecting to in the 'ServerUserIdToConnectTo' property before calling StartClient"
                     + $" (ServerUserIdToConnectTo='{ServerUserIdToConnectTo}').");
             }
@@ -277,7 +277,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         public override bool StartServer()
         {
             Debug.Assert(IsInitialized);
-            print($"EOSP2PTransport.StartServer: Entering Server mode with EOS UserId='{OurUserId}'.");
+            log($"EOSP2PTransport.StartServer: Entering Server mode with EOS UserId='{OurUserId}'.");
 #if UNITY_EDITOR
             ServerUserIDForCopying = OurUserId.ToString();
 #endif
@@ -304,7 +304,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             ProductUserId userId = GetUserId(clientId);
 
-            print($"EOSP2PTransport.DisconnectRemoteClient: Disconnecting ClientId='{clientId}' (UserId='{userId}') from our Server.");
+            log($"EOSP2PTransport.DisconnectRemoteClient: Disconnecting ClientId='{clientId}' (UserId='{userId}') from our Server.");
             P2PManager.CloseConnection(userId, P2PSocketName, true);
         }
 
@@ -316,7 +316,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             Debug.Assert(IsInitialized);
             Debug.Assert(IsServer == false);
 
-            print($"EOSP2PTransport.DisconnectLocalClient: Disconnecting our Client from the Server (UserId='{ServerUserId}').");
+            log($"EOSP2PTransport.DisconnectLocalClient: Disconnecting our Client from the Server (UserId='{ServerUserId}').");
             P2PManager.CloseConnection(ServerUserId, P2PSocketName, true);
         }
 
@@ -355,7 +355,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         public override void Shutdown()
         {
             Debug.Assert(IsInitialized);
-            print("EOSP2PTransport.Shutdown: Shutting down Epic Online Services Peer-2-Peer NetworkTransport.");
+            log("EOSP2PTransport.Shutdown: Shutting down Epic Online Services Peer-2-Peer NetworkTransport.");
             IsInitialized = false;
 
             // Shutdown EOS Peer-2-Peer Manager
@@ -385,12 +385,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         public override void Initialize(NetworkManager networkManager)
         {
             Debug.Assert(IsInitialized == false);
-            print("EOSP2PTransport.Initialize: Initializing Epic Online Services Peer-2-Peer NetworkTransport.");
+            log("EOSP2PTransport.Initialize: Initializing Epic Online Services Peer-2-Peer NetworkTransport.");
 
             // EOSManager should already be initialized and exist by this point
             if (EOSManager.Instance == null)
             {
-                printError("EOSP2PTransport.Initialize: Unable to initialize - EOSManager singleton is null (has the EOSManager component been added to an object in your initial scene?)");
+                logError("EOSP2PTransport.Initialize: Unable to initialize - EOSManager singleton is null (has the EOSManager component been added to an object in your initial scene?)");
                 return;
             }
 
@@ -419,7 +419,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             P2PManager.OnConnectionClosedCb = OnConnectionClosedCallback;
             if (P2PManager.Initialize() == false)
             {
-                printError("EOSP2PTransport.Initialize: Unable to initialize - EOSP2PManager failed to initialize.");
+                logError("EOSP2PTransport.Initialize: Unable to initialize - EOSP2PManager failed to initialize.");
                 P2PManager.OnIncomingConnectionRequestedCb = null;
                 P2PManager.OnConnectionOpenedCb = null;
                 P2PManager.OnConnectionClosedCb = null;
@@ -444,7 +444,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             {
                 if (data.ResultCode == Result.Success)
                 {
-                    print("Logout Successful. [" + data.ResultCode + "]");
+                    log("Logout Successful. [" + data.ResultCode + "]");
                     GameStateManager.ChangeScene("MainMenu", false);
                 }
             });
@@ -464,13 +464,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             if (IsServer && socketName == P2PSocketName)
             {
                 // Accept connection request
-                print($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: ACCEPTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
+                log($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: ACCEPTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
                 P2PManager.OpenConnection(userId, socketName);
             }
             else
             {
                 // Reject connection request
-                print($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: REJECTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
+                log($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: REJECTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
                 P2PManager.CloseConnection(userId, socketName);
             }
         }
@@ -484,7 +484,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             Debug.Assert(IsInitialized);
 
-            print($"EOSP2PTransport.OnConnectionOpenedCallback: '{socketName}' socket connection OPENED with UserId='{userId}'.");
+            log($"EOSP2PTransport.OnConnectionOpenedCallback: '{socketName}' socket connection OPENED with UserId='{userId}'.");
             if (socketName == P2PSocketName)
             {
                 if (IsServer)
@@ -520,7 +520,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             Debug.Assert(IsInitialized);
 
-            print($"EOSP2PTransport.OnConnectionClosedCallback: '{socketName}' socket connection CLOSED with UserId='{userId}'.");
+            log($"EOSP2PTransport.OnConnectionClosedCallback: '{socketName}' socket connection CLOSED with UserId='{userId}'.");
             if (socketName == P2PSocketName)
             {
                 // We're the Server?

--- a/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransport.cs
+++ b/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransport.cs
@@ -103,19 +103,19 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         private Queue<Tuple<ProductUserId, ulong, bool>> ConnectedDisconnectedUserEvents = null;
 
         [System.Diagnostics.Conditional("EOS_TRANSPORT_DEBUG")]
-        private void log(string msg)
+        private void Log(string msg)
         {
             Debug.Log(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORT_DEBUG")]
-        private void logWarning(string msg)
+        private void LogWarning(string msg)
         {
             Debug.LogWarning(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORT_DEBUG")]
-        private void logError(string msg)
+        private void LogError(string msg)
         {
             Debug.LogError(msg);
         }
@@ -138,7 +138,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             ProductUserId userId = GetUserId(clientId);
 
-            log($"EOSP2PTransport.Send: [ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', SendTimeSec='{Time.realtimeSinceStartup}']");
+            Log($"EOSP2PTransport.Send: [ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', SendTimeSec='{Time.realtimeSinceStartup}']");
 
             Epic.OnlineServices.P2P.PacketReliability reliability = Epic.OnlineServices.P2P.PacketReliability.ReliableOrdered;
             if (networkDelivery == NetworkDelivery.Unreliable)
@@ -158,7 +158,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             {
                 if (reliability != Epic.OnlineServices.P2P.PacketReliability.ReliableOrdered)
                 {
-                    logError($"EOSP2PTransport.Send: Unable to send payload - The payload size ({payload.Count} bytes) exceeds the maxmimum packet size supported by EOS P2P ({EOSTransportManager.MaxPacketSize} bytes).");
+                    LogError($"EOSP2PTransport.Send: Unable to send payload - The payload size ({payload.Count} bytes) exceeds the maxmimum packet size supported by EOS P2P ({EOSTransportManager.MaxPacketSize} bytes).");
                     return;
                 }
             }
@@ -196,7 +196,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 payload = new ArraySegment<byte>();
                 receiveTime = Time.realtimeSinceStartup;
                 NetworkEvent networkEventType = evntIsConnectionEvent ? NetworkEvent.Connect : NetworkEvent.Disconnect;
-                log($"EOSP2PTransport.PollEvent: [{networkEventType}, ClientId='{clientId}', UserId='{evntUserId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
+                Log($"EOSP2PTransport.PollEvent: [{networkEventType}, ClientId='{clientId}', UserId='{evntUserId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
                 return networkEventType;
             }
 
@@ -208,7 +208,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 clientId = GetTransportId(userId);
                 payload = new ArraySegment<byte>(packet);
                 receiveTime = Time.realtimeSinceStartup;
-                log($"EOSP2PTransport.PollEvent: [{NetworkEvent.Data}, ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
+                Log($"EOSP2PTransport.PollEvent: [{NetworkEvent.Data}, ClientId='{clientId}', UserId='{userId}', PayloadBytes='{payload.Count}', RecvTimeSec='{receiveTime}']");
                 return NetworkEvent.Data;
             }
 
@@ -216,7 +216,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             clientId = InvalidClientId;
             payload = new ArraySegment<byte>();
             receiveTime = 0;
-            log("EOSP2PTransport.PollEvent: []");
+            Log("EOSP2PTransport.PollEvent: []");
             return NetworkEvent.Nothing;
         }
 
@@ -233,7 +233,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 #endif
             if (ServerUserIdToConnectTo == null)
             {
-                log("EOSP2PTransport.StartClient: No ServerUserIDToConnectTo set!");
+                Log("EOSP2PTransport.StartClient: No ServerUserIDToConnectTo set!");
                 return false;
             }
 
@@ -253,17 +253,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Attempt to connect to the server hosted by ServerUserId - was the request successfully initiated?
                 if (result = P2PManager.OpenConnection(ServerUserId, P2PSocketName))
                 {
-                    log($"EOSP2PTransport.StartClient: Successful Client start up - REQUESTED outgoing '{P2PSocketName}' socket connection with Server UserId Server UserId='{ServerUserId}'.");
+                    Log($"EOSP2PTransport.StartClient: Successful Client start up - REQUESTED outgoing '{P2PSocketName}' socket connection with Server UserId Server UserId='{ServerUserId}'.");
                     result = true;
                 }
                 else
                 {
-                    logError($"EOSP2PTransport.StartClient: Failed Client start up - Unable to initiate a connect request with Server UserId='{ServerUserId}'.");
+                    LogError($"EOSP2PTransport.StartClient: Failed Client start up - Unable to initiate a connect request with Server UserId='{ServerUserId}'.");
                 }
             }
             else
             {
-                logError("EOSP2PTransport.StartClient: Failed Client start up - 'ServerUserIdToConnectTo' is null or invalid."
+                LogError("EOSP2PTransport.StartClient: Failed Client start up - 'ServerUserIdToConnectTo' is null or invalid."
                     + " Please set a valid EOS ProductUserId of the Server host this Client should try connecting to in the 'ServerUserIdToConnectTo' property before calling StartClient"
                     + $" (ServerUserIdToConnectTo='{ServerUserIdToConnectTo}').");
             }
@@ -277,7 +277,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         public override bool StartServer()
         {
             Debug.Assert(IsInitialized);
-            log($"EOSP2PTransport.StartServer: Entering Server mode with EOS UserId='{OurUserId}'.");
+            Log($"EOSP2PTransport.StartServer: Entering Server mode with EOS UserId='{OurUserId}'.");
 #if UNITY_EDITOR
             ServerUserIDForCopying = OurUserId.ToString();
 #endif
@@ -304,7 +304,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             ProductUserId userId = GetUserId(clientId);
 
-            log($"EOSP2PTransport.DisconnectRemoteClient: Disconnecting ClientId='{clientId}' (UserId='{userId}') from our Server.");
+            Log($"EOSP2PTransport.DisconnectRemoteClient: Disconnecting ClientId='{clientId}' (UserId='{userId}') from our Server.");
             P2PManager.CloseConnection(userId, P2PSocketName, true);
         }
 
@@ -316,7 +316,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             Debug.Assert(IsInitialized);
             Debug.Assert(IsServer == false);
 
-            log($"EOSP2PTransport.DisconnectLocalClient: Disconnecting our Client from the Server (UserId='{ServerUserId}').");
+            Log($"EOSP2PTransport.DisconnectLocalClient: Disconnecting our Client from the Server (UserId='{ServerUserId}').");
             P2PManager.CloseConnection(ServerUserId, P2PSocketName, true);
         }
 
@@ -355,7 +355,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         public override void Shutdown()
         {
             Debug.Assert(IsInitialized);
-            log("EOSP2PTransport.Shutdown: Shutting down Epic Online Services Peer-2-Peer NetworkTransport.");
+            Log("EOSP2PTransport.Shutdown: Shutting down Epic Online Services Peer-2-Peer NetworkTransport.");
             IsInitialized = false;
 
             // Shutdown EOS Peer-2-Peer Manager
@@ -385,12 +385,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         public override void Initialize(NetworkManager networkManager)
         {
             Debug.Assert(IsInitialized == false);
-            log("EOSP2PTransport.Initialize: Initializing Epic Online Services Peer-2-Peer NetworkTransport.");
+            Log("EOSP2PTransport.Initialize: Initializing Epic Online Services Peer-2-Peer NetworkTransport.");
 
             // EOSManager should already be initialized and exist by this point
             if (EOSManager.Instance == null)
             {
-                logError("EOSP2PTransport.Initialize: Unable to initialize - EOSManager singleton is null (has the EOSManager component been added to an object in your initial scene?)");
+                LogError("EOSP2PTransport.Initialize: Unable to initialize - EOSManager singleton is null (has the EOSManager component been added to an object in your initial scene?)");
                 return;
             }
 
@@ -419,7 +419,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             P2PManager.OnConnectionClosedCb = OnConnectionClosedCallback;
             if (P2PManager.Initialize() == false)
             {
-                logError("EOSP2PTransport.Initialize: Unable to initialize - EOSP2PManager failed to initialize.");
+                LogError("EOSP2PTransport.Initialize: Unable to initialize - EOSP2PManager failed to initialize.");
                 P2PManager.OnIncomingConnectionRequestedCb = null;
                 P2PManager.OnConnectionOpenedCb = null;
                 P2PManager.OnConnectionClosedCb = null;
@@ -444,7 +444,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             {
                 if (data.ResultCode == Result.Success)
                 {
-                    log("Logout Successful. [" + data.ResultCode + "]");
+                    Log("Logout Successful. [" + data.ResultCode + "]");
                     GameStateManager.ChangeScene("MainMenu", false);
                 }
             });
@@ -464,13 +464,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             if (IsServer && socketName == P2PSocketName)
             {
                 // Accept connection request
-                log($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: ACCEPTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
+                Log($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: ACCEPTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
                 P2PManager.OpenConnection(userId, socketName);
             }
             else
             {
                 // Reject connection request
-                log($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: REJECTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
+                Log($"EOSP2PTransport.OnIncomingConnectionRequestedCallback: REJECTING incoming '{socketName}' socket connection request from UserId='{userId}'.");
                 P2PManager.CloseConnection(userId, socketName);
             }
         }
@@ -484,7 +484,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             Debug.Assert(IsInitialized);
 
-            log($"EOSP2PTransport.OnConnectionOpenedCallback: '{socketName}' socket connection OPENED with UserId='{userId}'.");
+            Log($"EOSP2PTransport.OnConnectionOpenedCallback: '{socketName}' socket connection OPENED with UserId='{userId}'.");
             if (socketName == P2PSocketName)
             {
                 if (IsServer)
@@ -520,7 +520,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             Debug.Assert(IsInitialized);
 
-            log($"EOSP2PTransport.OnConnectionClosedCallback: '{socketName}' socket connection CLOSED with UserId='{userId}'.");
+            Log($"EOSP2PTransport.OnConnectionClosedCallback: '{socketName}' socket connection CLOSED with UserId='{userId}'.");
             if (socketName == P2PSocketName)
             {
                 // We're the Server?

--- a/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
+++ b/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
@@ -254,19 +254,19 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         private const byte ConnectionConfirmationChannel = byte.MaxValue;
 
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
-        private void log(string msg)
+        private void Log(string msg)
         {
             Debug.Log(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
-        private void logWarning(string msg)
+        private void LogWarning(string msg)
         {
             Debug.LogWarning(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
-        private void logError(string msg)
+        private void LogError(string msg)
         {
             Debug.LogError(msg);
         }
@@ -363,7 +363,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             if (IsInitialized)
             {
-                logWarning("EOSTransportManager.Initialize: Already initialized - Shutting down EOSTransportManager first before proceeding.");
+                LogWarning("EOSTransportManager.Initialize: Already initialized - Shutting down EOSTransportManager first before proceeding.");
                 Shutdown();
             }
 
@@ -373,12 +373,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 #endif
 
             Debug.Assert(IsInitialized == false);
-            log("EOSTransportManager.Initialize: Initializing EOSTransportManager...");
+            Log("EOSTransportManager.Initialize: Initializing EOSTransportManager...");
             bool result;
 
             if (EOSManager.Instance == null)
             {
-                logError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOSManager singleton instance.");
+                LogError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOSManager singleton instance.");
                 result = false;
             }
             else
@@ -401,12 +401,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             if (P2PHandle == null)
             {
-                logError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOS P2PInterface handle.");
+                LogError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOS P2PInterface handle.");
                 result = false;
             }
             else if (LocalUserId == null || LocalUserId.IsValid() == false)
             {
-                logError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Invalid local ProductUserId.");
+                LogError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Invalid local ProductUserId.");
                 result = false;
             }
             else
@@ -436,11 +436,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             if (IsInitialized == false)
             {
-                logWarning("EOSTransportManager.Shutdown: EOSTransportManager is already shutdown or was never initialized.");
+                LogWarning("EOSTransportManager.Shutdown: EOSTransportManager is already shutdown or was never initialized.");
                 return;
             }
 
-            log($"EOSTransportManager.Shutdown: Shutting down EOSTransportManager... | EOSTransportManager={GetDebugString()}");
+            Log($"EOSTransportManager.Shutdown: Shutting down EOSTransportManager... | EOSTransportManager={GetDebugString()}");
             CloseAllConnections();
             UnsubscribeFromConnectionClosedNotifications();
             UnsubscribeFromConnectionRequestNotifications();
@@ -460,7 +460,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// </summary>
         public void OnLoggedIn()
         {
-            log($"EOSTransportManager.OnLoggedIn: Logged in with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Initializing EOSTransportManager.");
+            Log($"EOSTransportManager.OnLoggedIn: Logged in with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Initializing EOSTransportManager.");
             Initialize();
         }
 
@@ -469,7 +469,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// </summary>
         public void OnLoggedOut()
         {
-            log($"EOSTransportManager.OnLoggedOut: Logging out with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Shutting down EOSTransportManager.");
+            Log($"EOSTransportManager.OnLoggedOut: Logging out with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Shutting down EOSTransportManager.");
             Shutdown();
         }
 
@@ -482,7 +482,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// </summary>
         public void QueryNATType()
         {
-            log("EOSTransportManager.QueryNATType: Querying our NAT type...");
+            Log("EOSTransportManager.QueryNATType: Querying our NAT type...");
             var options = new QueryNATTypeOptions();
             P2PHandle.QueryNATType(ref options, null, OnQueryNATTypeCompleted);
         }
@@ -494,11 +494,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Don't warn for certain errors if they're common
                 if (data.ResultCode != Result.NoConnection)
                 {
-                    logWarning($"EOSTransportManager.OnQueryNATTypeCompleted: Error result, {data.ResultCode}");
+                    LogWarning($"EOSTransportManager.OnQueryNATTypeCompleted: Error result, {data.ResultCode}");
                 }
                 return;
             }
-            log($"EOSTransportManager.OnQueryNATTypeCompleted: Successfully retrieved NATType '{data.NATType}' (previous value was '{NATType}').");
+            Log($"EOSTransportManager.OnQueryNATTypeCompleted: Successfully retrieved NATType '{data.NATType}' (previous value was '{NATType}').");
             NATType = data.NATType;
         }
 
@@ -519,10 +519,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             if (result != Result.Success)
             {
-                logWarning($"EOSTransportManager.GetNATType: Error while retrieving NATType, {result}.");
+                LogWarning($"EOSTransportManager.GetNATType: Error while retrieving NATType, {result}.");
                 return NATType.Unknown;
             }
-            log($"EOSTransportManager.GetNATType: Successfully retrieved NATType '{natType}'.");
+            Log($"EOSTransportManager.GetNATType: Successfully retrieved NATType '{natType}'.");
             return natType;
         }
 
@@ -599,7 +599,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// <returns><c>true</c> if a connection was requested, a pending connection request was successfully accepted, or the connection has already been locally opened (this case will log a warning), otherwise <c>false</c>.</returns>
         public bool OpenConnection(ProductUserId remoteUserId, string socketName)
         {
-            log($"EOSTransportManager.OpenConnection: Attempting to locally open (outgoing) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+            Log($"EOSTransportManager.OpenConnection: Attempting to locally open (outgoing) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
             return Internal_OpenConnection(remoteUserId, socketName, true, out Connection _);
         }
 
@@ -610,14 +610,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                logError("EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                LogError("EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
             // Socket name is invalid?
             if (IsValidSocketName(socketName) == false)
             {
-                logError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Socket name '{socketName}' is invalid (EOS socket names may only contain 1-32 alphanumeric characters).");
+                LogError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Socket name '{socketName}' is invalid (EOS socket names may only contain 1-32 alphanumeric characters).");
                 return false;
             }
 
@@ -632,7 +632,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Max number of connections reached for this remote peer?
                 if (connections.Count >= MaxConnections)
                 {
-                    logError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Reached maximum number of open connections ({MaxConnections}) with the specified remote peer.");
+                    LogError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Reached maximum number of open connections ({MaxConnections}) with the specified remote peer.");
                     return false;
                 }
             }
@@ -662,7 +662,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 if (connection.IsFullyOpened)
                 {
                     // Nothing left to do
-                    logWarning($"EOSTransportManager.Internal_OpenConnection: Already have a fully opened socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
+                    LogWarning($"EOSTransportManager.Internal_OpenConnection: Already have a fully opened socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
                     return true;
                 }
 
@@ -673,7 +673,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     if (connection.OpenedOutgoing)
                     {
                         // Nothing left to do
-                        logWarning($"EOSTransportManager.Internal_OpenConnection: Already have a locally opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we're just awaiting a response to our connect request.");
+                        LogWarning($"EOSTransportManager.Internal_OpenConnection: Already have a locally opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we're just awaiting a response to our connect request.");
                         return true;
                     }
 
@@ -687,7 +687,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     if (connection.OpenedIncoming)
                     {
                         // Nothing left to do
-                        logWarning($"EOSTransportManager.Internal_OpenConnection: Already have a remotely opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we just need to respond to their connect request.");
+                        LogWarning($"EOSTransportManager.Internal_OpenConnection: Already have a remotely opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we just need to respond to their connect request.");
                         return true;
                     }
 
@@ -711,7 +711,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 Result result = P2PHandle.AcceptConnection(ref options);
                 if (result != Result.Success)
                 {
-                    logError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - P2PInterface.AcceptConnection error result '{result}'.");
+                    LogError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - P2PInterface.AcceptConnection error result '{result}'.");
 
                     // We just added this connection? (it would still be invalid at this point)
                     if (connection.IsValid == false)
@@ -766,18 +766,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// <returns><c>true</c> if a matching remote peer connection was found and closed, <c>false</c> if not.</returns>
         public bool CloseConnection(ProductUserId remoteUserId, string socketName, bool forceClose = true)
         {
-            log($"EOSTransportManager.CloseConnection: Attempting to close (cancel or reject) a socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+            Log($"EOSTransportManager.CloseConnection: Attempting to close (cancel or reject) a socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
 
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                logError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                LogError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
             if (remoteUserId == null)
             {
-                logError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - remoteUserId is null.");
+                LogError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - remoteUserId is null.");
                 return false;
             }
 
@@ -800,7 +800,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     Result result = P2PHandle?.CloseConnection(ref options) ?? Result.NetworkDisconnected;
                     if (result != Result.Success)
                     {
-                        logError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - P2PInterface.CloseConnection error result '{result}'.");
+                        LogError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - P2PInterface.CloseConnection error result '{result}'.");
                         if (forceClose)
                         {
                             // Continue with local connection cleanup even though P2PInterface.CloseConnection failed
@@ -843,7 +843,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
 
             success = false;
-            logError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - Unable to find a socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
+            LogError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - Unable to find a socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
             return false;
         }
 
@@ -857,7 +857,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                logError($"EOSTransportManager.CloseAllConnections: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                LogError($"EOSTransportManager.CloseAllConnections: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
@@ -884,7 +884,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                logError("EOSTransportManager.CloseAllConnectionsWithSocketName: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                LogError("EOSTransportManager.CloseAllConnectionsWithSocketName: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
@@ -915,7 +915,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                logError("EOSTransportManager.CloseAllConnectionsWithRemotePeer: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                LogError("EOSTransportManager.CloseAllConnectionsWithRemotePeer: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
@@ -996,18 +996,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             if (remoteUserId.IsValid() == false)
             {
-                logError($"EOSTransportManager.SendPacket: Invalid parameters, RemoteUserId '{remoteUserId}' is invalid.");
+                LogError($"EOSTransportManager.SendPacket: Invalid parameters, RemoteUserId '{remoteUserId}' is invalid.");
                 return;
             }
 
             if (packet.Count <= 0)
             {
-                logError("EOSTransportManager.SendPacket: Invalid parameters, packet is empty.");
+                LogError("EOSTransportManager.SendPacket: Invalid parameters, packet is empty.");
                 return;
             }
             if (packet.Count > (MaxPacketSize - FragmentHeaderSize) * MaxFragments)
             {
-                logError($"EOSTransportManager.SendPacket: Fragmenting packet of size {packet.Count} would require more than {MaxFragments} fragments and cannot be sent.");
+                LogError($"EOSTransportManager.SendPacket: Fragmenting packet of size {packet.Count} would require more than {MaxFragments} fragments and cannot be sent.");
                 return;
             }
 
@@ -1015,13 +1015,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             Connection connection = null;
             if (!Connections.TryGetValue(remoteUserId, out List<Connection> userConnections))
             {
-                logError($"EOSTransportManager.SendPacket: Connection not found to remote user {remoteUserId}.");
+                LogError($"EOSTransportManager.SendPacket: Connection not found to remote user {remoteUserId}.");
                 return;
             }
             connection = userConnections.Find(x => x.SocketName == socketName);
             if (connection == null)
             {
-                logError($"EOSTransportManager.SendPacket: Connection not found on socket {socketName} to remote user {remoteUserId}.");
+                LogError($"EOSTransportManager.SendPacket: Connection not found on socket {socketName} to remote user {remoteUserId}.");
                 return;
             }
 
@@ -1078,7 +1078,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 Result result = P2PHandle.SendPacket(ref options);
                 if (result != Result.Success)
                 {
-                    logError($"EOSTransportManager.SendPacket: Unable to send {options.Data.Count} byte packet to RemoteUserId '{options.RemoteUserId}' - Error result, {result}.");
+                    LogError($"EOSTransportManager.SendPacket: Unable to send {options.Data.Count} byte packet to RemoteUserId '{options.RemoteUserId}' - Error result, {result}.");
                     return;
                 }
 
@@ -1151,7 +1151,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // Packet is smaller than expected
             if (packet.Length < FragmentHeaderSize)
             {
-                logError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet. Should be at least {FragmentHeaderSize} bytes.");
+                LogError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet. Should be at least {FragmentHeaderSize} bytes.");
                 remoteUserId = null;
                 socketName = null;
                 channel = 0;
@@ -1162,7 +1162,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // Internal EOS P2P error?
             if (result != Result.Success)
             {
-                logError($"EOSTransportManager.TryReceivePacket: Error result, {result}.");
+                LogError($"EOSTransportManager.TryReceivePacket: Error result, {result}.");
                 remoteUserId = null;
                 socketName = null;
                 channel = 0;
@@ -1173,7 +1173,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // Invalid user?
             if (remoteUserId.IsValid() == false)
             {
-                logError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet from invalid RemoteUserId '{remoteUserId}'.");
+                LogError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet from invalid RemoteUserId '{remoteUserId}'.");
                 remoteUserId = null;
                 socketName = null;
                 channel = 0;
@@ -1198,13 +1198,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Is this a connection confirmation packet?
                 if (channel == ConnectionConfirmationChannel && payload.SequenceEqual(ConnectionConfirmationPacket))
                 {
-                    log($"EOSTransportManager.TryReceivePacket: Connection confirmation packet received for socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
+                    Log($"EOSTransportManager.TryReceivePacket: Connection confirmation packet received for socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
 
                     // We've been waiting for our connect request to be accepted on this connection?
                     if (connection.IsPendingOutgoing)
                     {
                         // They've accepted our connection, so we're no longer pending
-                        log($"EOSTransportManager.TryReceivePacket: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+                        Log($"EOSTransportManager.TryReceivePacket: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
                         bool success = Internal_OpenConnection(remoteUserId, socketName, false, out _);
 
                         // Our connection should now be considered fully open
@@ -1221,12 +1221,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
             else
             {
-                logWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from unknown RemoteUserId '{remoteUserId}', discarding packet.");
+                LogWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from unknown RemoteUserId '{remoteUserId}', discarding packet.");
             }
 
             if (connection == null || connection.IsFullyOpened == false)
             {
-                logWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from RemoteUserId '{remoteUserId}', discarding packet.");
+                LogWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from RemoteUserId '{remoteUserId}', discarding packet.");
 
                 // Discard this packet, we only return to the user packets from fully open peer connections
                 remoteUserId = null;
@@ -1270,7 +1270,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             InProgressPackets[index].Clear();
             InProgressPackets.Remove(index);
             // Success
-            log($"EOSTransportManager.TryReceivePacket: Successfully received {packet.Length} byte packet from RemoteUserId '{remoteUserId}'.");
+            Log($"EOSTransportManager.TryReceivePacket: Successfully received {packet.Length} byte packet from RemoteUserId '{remoteUserId}'.");
             return true;
         }
 
@@ -1303,7 +1303,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             var remoteUserId = data.RemoteUserId;
 
             // Get/add the connection internally from the incoming direction
-            log($"EOSTransportManager.OnConnectionRequestNotification: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+            Log($"EOSTransportManager.OnConnectionRequestNotification: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
             bool success = Internal_OpenConnection(remoteUserId, socketName, false, out Connection connection);
 
             // Successfully found/added? And is now awaiting our connect accept response?
@@ -1317,7 +1317,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
             else
             {
-                logError($"EOSTransportManager.OnConnectionRequestNotification: Failed to process connection request notification for socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+                LogError($"EOSTransportManager.OnConnectionRequestNotification: Failed to process connection request notification for socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
             }
         }
 

--- a/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
+++ b/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
@@ -254,19 +254,19 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         private const byte ConnectionConfirmationChannel = byte.MaxValue;
 
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
-        private void print(string msg)
+        private void log(string msg)
         {
             Debug.Log(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
-        private void printWarning(string msg)
+        private void logWarning(string msg)
         {
             Debug.LogWarning(msg);
         }
 
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
-        private void printError(string msg)
+        private void logError(string msg)
         {
             Debug.LogError(msg);
         }
@@ -363,7 +363,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             if (IsInitialized)
             {
-                printWarning("EOSTransportManager.Initialize: Already initialized - Shutting down EOSTransportManager first before proceeding.");
+                logWarning("EOSTransportManager.Initialize: Already initialized - Shutting down EOSTransportManager first before proceeding.");
                 Shutdown();
             }
 
@@ -373,12 +373,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 #endif
 
             Debug.Assert(IsInitialized == false);
-            print("EOSTransportManager.Initialize: Initializing EOSTransportManager...");
+            log("EOSTransportManager.Initialize: Initializing EOSTransportManager...");
             bool result;
 
             if (EOSManager.Instance == null)
             {
-                printError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOSManager singleton instance.");
+                logError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOSManager singleton instance.");
                 result = false;
             }
             else
@@ -401,12 +401,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             if (P2PHandle == null)
             {
-                printError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOS P2PInterface handle.");
+                logError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Unable to get EOS P2PInterface handle.");
                 result = false;
             }
             else if (LocalUserId == null || LocalUserId.IsValid() == false)
             {
-                printError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Invalid local ProductUserId.");
+                logError("EOSTransportManager.Initialize: Failed to initialize EOSTransportManager - Invalid local ProductUserId.");
                 result = false;
             }
             else
@@ -436,11 +436,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             if (IsInitialized == false)
             {
-                printWarning("EOSTransportManager.Shutdown: EOSTransportManager is already shutdown or was never initialized.");
+                logWarning("EOSTransportManager.Shutdown: EOSTransportManager is already shutdown or was never initialized.");
                 return;
             }
 
-            print($"EOSTransportManager.Shutdown: Shutting down EOSTransportManager... | EOSTransportManager={GetDebugString()}");
+            log($"EOSTransportManager.Shutdown: Shutting down EOSTransportManager... | EOSTransportManager={GetDebugString()}");
             CloseAllConnections();
             UnsubscribeFromConnectionClosedNotifications();
             UnsubscribeFromConnectionRequestNotifications();
@@ -460,7 +460,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// </summary>
         public void OnLoggedIn()
         {
-            print($"EOSTransportManager.OnLoggedIn: Logged in with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Initializing EOSTransportManager.");
+            log($"EOSTransportManager.OnLoggedIn: Logged in with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Initializing EOSTransportManager.");
             Initialize();
         }
 
@@ -469,7 +469,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// </summary>
         public void OnLoggedOut()
         {
-            print($"EOSTransportManager.OnLoggedOut: Logging out with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Shutting down EOSTransportManager.");
+            log($"EOSTransportManager.OnLoggedOut: Logging out with LocalUserId '{EOSManager.Instance.GetProductUserId()}' - Shutting down EOSTransportManager.");
             Shutdown();
         }
 
@@ -482,7 +482,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// </summary>
         public void QueryNATType()
         {
-            print("EOSTransportManager.QueryNATType: Querying our NAT type...");
+            log("EOSTransportManager.QueryNATType: Querying our NAT type...");
             var options = new QueryNATTypeOptions();
             P2PHandle.QueryNATType(ref options, null, OnQueryNATTypeCompleted);
         }
@@ -494,11 +494,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Don't warn for certain errors if they're common
                 if (data.ResultCode != Result.NoConnection)
                 {
-                    printWarning($"EOSTransportManager.OnQueryNATTypeCompleted: Error result, {data.ResultCode}");
+                    logWarning($"EOSTransportManager.OnQueryNATTypeCompleted: Error result, {data.ResultCode}");
                 }
                 return;
             }
-            print($"EOSTransportManager.OnQueryNATTypeCompleted: Successfully retrieved NATType '{data.NATType}' (previous value was '{NATType}').");
+            log($"EOSTransportManager.OnQueryNATTypeCompleted: Successfully retrieved NATType '{data.NATType}' (previous value was '{NATType}').");
             NATType = data.NATType;
         }
 
@@ -519,10 +519,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             if (result != Result.Success)
             {
-                printWarning($"EOSTransportManager.GetNATType: Error while retrieving NATType, {result}.");
+                logWarning($"EOSTransportManager.GetNATType: Error while retrieving NATType, {result}.");
                 return NATType.Unknown;
             }
-            print($"EOSTransportManager.GetNATType: Successfully retrieved NATType '{natType}'.");
+            log($"EOSTransportManager.GetNATType: Successfully retrieved NATType '{natType}'.");
             return natType;
         }
 
@@ -599,7 +599,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// <returns><c>true</c> if a connection was requested, a pending connection request was successfully accepted, or the connection has already been locally opened (this case will log a warning), otherwise <c>false</c>.</returns>
         public bool OpenConnection(ProductUserId remoteUserId, string socketName)
         {
-            print($"EOSTransportManager.OpenConnection: Attempting to locally open (outgoing) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+            log($"EOSTransportManager.OpenConnection: Attempting to locally open (outgoing) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
             return Internal_OpenConnection(remoteUserId, socketName, true, out Connection _);
         }
 
@@ -610,14 +610,14 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                printError("EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                logError("EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
             // Socket name is invalid?
             if (IsValidSocketName(socketName) == false)
             {
-                printError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Socket name '{socketName}' is invalid (EOS socket names may only contain 1-32 alphanumeric characters).");
+                logError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Socket name '{socketName}' is invalid (EOS socket names may only contain 1-32 alphanumeric characters).");
                 return false;
             }
 
@@ -632,7 +632,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Max number of connections reached for this remote peer?
                 if (connections.Count >= MaxConnections)
                 {
-                    printError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Reached maximum number of open connections ({MaxConnections}) with the specified remote peer.");
+                    logError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - Reached maximum number of open connections ({MaxConnections}) with the specified remote peer.");
                     return false;
                 }
             }
@@ -662,7 +662,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 if (connection.IsFullyOpened)
                 {
                     // Nothing left to do
-                    printWarning($"EOSTransportManager.Internal_OpenConnection: Already have a fully opened socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
+                    logWarning($"EOSTransportManager.Internal_OpenConnection: Already have a fully opened socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
                     return true;
                 }
 
@@ -673,7 +673,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     if (connection.OpenedOutgoing)
                     {
                         // Nothing left to do
-                        printWarning($"EOSTransportManager.Internal_OpenConnection: Already have a locally opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we're just awaiting a response to our connect request.");
+                        logWarning($"EOSTransportManager.Internal_OpenConnection: Already have a locally opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we're just awaiting a response to our connect request.");
                         return true;
                     }
 
@@ -687,7 +687,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     if (connection.OpenedIncoming)
                     {
                         // Nothing left to do
-                        printWarning($"EOSTransportManager.Internal_OpenConnection: Already have a remotely opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we just need to respond to their connect request.");
+                        logWarning($"EOSTransportManager.Internal_OpenConnection: Already have a remotely opened socket connection named '{socketName}' with remote peer '{remoteUserId}'. Now we just need to respond to their connect request.");
                         return true;
                     }
 
@@ -711,7 +711,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 Result result = P2PHandle.AcceptConnection(ref options);
                 if (result != Result.Success)
                 {
-                    printError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - P2PInterface.AcceptConnection error result '{result}'.");
+                    logError($"EOSTransportManager.Internal_OpenConnection: Failed to open remote peer connection - P2PInterface.AcceptConnection error result '{result}'.");
 
                     // We just added this connection? (it would still be invalid at this point)
                     if (connection.IsValid == false)
@@ -766,18 +766,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         /// <returns><c>true</c> if a matching remote peer connection was found and closed, <c>false</c> if not.</returns>
         public bool CloseConnection(ProductUserId remoteUserId, string socketName, bool forceClose = true)
         {
-            print($"EOSTransportManager.CloseConnection: Attempting to close (cancel or reject) a socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+            log($"EOSTransportManager.CloseConnection: Attempting to close (cancel or reject) a socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
 
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                printError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                logError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
             if (remoteUserId == null)
             {
-                printError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - remoteUserId is null.");
+                logError("EOSTransportManager.CloseConnection: Failed to close remote peer connection - remoteUserId is null.");
                 return false;
             }
 
@@ -800,7 +800,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                     Result result = P2PHandle?.CloseConnection(ref options) ?? Result.NetworkDisconnected;
                     if (result != Result.Success)
                     {
-                        printError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - P2PInterface.CloseConnection error result '{result}'.");
+                        logError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - P2PInterface.CloseConnection error result '{result}'.");
                         if (forceClose)
                         {
                             // Continue with local connection cleanup even though P2PInterface.CloseConnection failed
@@ -843,7 +843,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
 
             success = false;
-            printError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - Unable to find a socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
+            logError($"EOSTransportManager.CloseConnection: Failed to close remote peer connection - Unable to find a socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
             return false;
         }
 
@@ -857,7 +857,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                printError($"EOSTransportManager.CloseAllConnections: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                logError($"EOSTransportManager.CloseAllConnections: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
@@ -884,7 +884,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                printError("EOSTransportManager.CloseAllConnectionsWithSocketName: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                logError("EOSTransportManager.CloseAllConnectionsWithSocketName: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
@@ -915,7 +915,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // EOSTransportManager is not initialized?
             if (IsInitialized == false)
             {
-                printError("EOSTransportManager.CloseAllConnectionsWithRemotePeer: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
+                logError("EOSTransportManager.CloseAllConnectionsWithRemotePeer: Failed to close remote peer connections - EOSTransportManager is uninitialized (has OnLoggedIn been called?).");
                 return false;
             }
 
@@ -996,18 +996,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
         {
             if (remoteUserId.IsValid() == false)
             {
-                printError($"EOSTransportManager.SendPacket: Invalid parameters, RemoteUserId '{remoteUserId}' is invalid.");
+                logError($"EOSTransportManager.SendPacket: Invalid parameters, RemoteUserId '{remoteUserId}' is invalid.");
                 return;
             }
 
             if (packet.Count <= 0)
             {
-                printError("EOSTransportManager.SendPacket: Invalid parameters, packet is empty.");
+                logError("EOSTransportManager.SendPacket: Invalid parameters, packet is empty.");
                 return;
             }
             if (packet.Count > (MaxPacketSize - FragmentHeaderSize) * MaxFragments)
             {
-                printError($"EOSTransportManager.SendPacket: Fragmenting packet of size {packet.Count} would require more than {MaxFragments} fragments and cannot be sent.");
+                logError($"EOSTransportManager.SendPacket: Fragmenting packet of size {packet.Count} would require more than {MaxFragments} fragments and cannot be sent.");
                 return;
             }
 
@@ -1015,13 +1015,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             Connection connection = null;
             if (!Connections.TryGetValue(remoteUserId, out List<Connection> userConnections))
             {
-                printError($"EOSTransportManager.SendPacket: Connection not found to remote user {remoteUserId}.");
+                logError($"EOSTransportManager.SendPacket: Connection not found to remote user {remoteUserId}.");
                 return;
             }
             connection = userConnections.Find(x => x.SocketName == socketName);
             if (connection == null)
             {
-                printError($"EOSTransportManager.SendPacket: Connection not found on socket {socketName} to remote user {remoteUserId}.");
+                logError($"EOSTransportManager.SendPacket: Connection not found on socket {socketName} to remote user {remoteUserId}.");
                 return;
             }
 
@@ -1078,7 +1078,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 Result result = P2PHandle.SendPacket(ref options);
                 if (result != Result.Success)
                 {
-                    printError($"EOSTransportManager.SendPacket: Unable to send {options.Data.Count} byte packet to RemoteUserId '{options.RemoteUserId}' - Error result, {result}.");
+                    logError($"EOSTransportManager.SendPacket: Unable to send {options.Data.Count} byte packet to RemoteUserId '{options.RemoteUserId}' - Error result, {result}.");
                     return;
                 }
 
@@ -1151,7 +1151,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // Packet is smaller than expected
             if (packet.Length < FragmentHeaderSize)
             {
-                printError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet. Should be at least {FragmentHeaderSize} bytes.");
+                logError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet. Should be at least {FragmentHeaderSize} bytes.");
                 remoteUserId = null;
                 socketName = null;
                 channel = 0;
@@ -1162,7 +1162,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // Internal EOS P2P error?
             if (result != Result.Success)
             {
-                printError($"EOSTransportManager.TryReceivePacket: Error result, {result}.");
+                logError($"EOSTransportManager.TryReceivePacket: Error result, {result}.");
                 remoteUserId = null;
                 socketName = null;
                 channel = 0;
@@ -1173,7 +1173,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             // Invalid user?
             if (remoteUserId.IsValid() == false)
             {
-                printError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet from invalid RemoteUserId '{remoteUserId}'.");
+                logError($"EOSTransportManager.TryReceivePacket: Received {packet.Length} byte packet from invalid RemoteUserId '{remoteUserId}'.");
                 remoteUserId = null;
                 socketName = null;
                 channel = 0;
@@ -1198,13 +1198,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 // Is this a connection confirmation packet?
                 if (channel == ConnectionConfirmationChannel && payload.SequenceEqual(ConnectionConfirmationPacket))
                 {
-                    print($"EOSTransportManager.TryReceivePacket: Connection confirmation packet received for socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
+                    log($"EOSTransportManager.TryReceivePacket: Connection confirmation packet received for socket connection named '{socketName}' with remote peer '{remoteUserId}'.");
 
                     // We've been waiting for our connect request to be accepted on this connection?
                     if (connection.IsPendingOutgoing)
                     {
                         // They've accepted our connection, so we're no longer pending
-                        print($"EOSTransportManager.TryReceivePacket: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+                        log($"EOSTransportManager.TryReceivePacket: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
                         bool success = Internal_OpenConnection(remoteUserId, socketName, false, out _);
 
                         // Our connection should now be considered fully open
@@ -1221,12 +1221,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
             else
             {
-                printWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from unknown RemoteUserId '{remoteUserId}', discarding packet.");
+                logWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from unknown RemoteUserId '{remoteUserId}', discarding packet.");
             }
 
             if (connection == null || connection.IsFullyOpened == false)
             {
-                printWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from RemoteUserId '{remoteUserId}', discarding packet.");
+                logWarning($"EOSTransportManager.TryReceivePacket: Received a {packet.Length} byte packet from RemoteUserId '{remoteUserId}', discarding packet.");
 
                 // Discard this packet, we only return to the user packets from fully open peer connections
                 remoteUserId = null;
@@ -1270,7 +1270,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             InProgressPackets[index].Clear();
             InProgressPackets.Remove(index);
             // Success
-            print($"EOSTransportManager.TryReceivePacket: Successfully received {packet.Length} byte packet from RemoteUserId '{remoteUserId}'.");
+            log($"EOSTransportManager.TryReceivePacket: Successfully received {packet.Length} byte packet from RemoteUserId '{remoteUserId}'.");
             return true;
         }
 
@@ -1303,7 +1303,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             var remoteUserId = data.RemoteUserId;
 
             // Get/add the connection internally from the incoming direction
-            print($"EOSTransportManager.OnConnectionRequestNotification: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+            log($"EOSTransportManager.OnConnectionRequestNotification: Attempting to remotely open (incoming) socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
             bool success = Internal_OpenConnection(remoteUserId, socketName, false, out Connection connection);
 
             // Successfully found/added? And is now awaiting our connect accept response?
@@ -1317,7 +1317,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             }
             else
             {
-                printError($"EOSTransportManager.OnConnectionRequestNotification: Failed to process connection request notification for socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
+                logError($"EOSTransportManager.OnConnectionRequestNotification: Failed to process connection request notification for socket connection named '{socketName}' with remote peer '{remoteUserId}'...");
             }
         }
 

--- a/com.playeveryware.eos/Runtime/Core/DLLHandle.cs
+++ b/com.playeveryware.eos/Runtime/Core/DLLHandle.cs
@@ -40,7 +40,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         [Conditional("ENABLE_DLLHANDLE_PRINT")]
-        private static void log(string toPrint)
+        private static void Log(string toPrint)
         {
             UnityEngine.Debug.Log(toPrint);
         }
@@ -64,7 +64,7 @@ namespace PlayEveryWare.EpicOnlineServices
             for (int i = pluginPaths.Count - 1; i >= 0; --i)
             {
                 string value = pluginPaths[i];
-                log("print " + value);
+                Log("print " + value);
             }
 
             // Do a validation check after giving the 
@@ -72,7 +72,7 @@ namespace PlayEveryWare.EpicOnlineServices
             for (int i = pluginPaths.Count - 1; i >= 0; --i)
             {
                 string value = pluginPaths[i];
-                log("Evaluating " + value);
+                Log("Evaluating " + value);
                 if (!FileSystemUtility.DirectoryExists(value))
                 {
                     pluginPaths.RemoveAt(i);
@@ -128,7 +128,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public static DLLHandle LoadDynamicLibrary(string libraryName)
         {
-            log("Loading Library " + libraryName);
+            Log("Loading Library " + libraryName);
 
             string libraryPath = GetPathForLibrary(libraryName);
 
@@ -137,7 +137,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 return null;
             }
 
-            log("Trying to load with entry " + libraryPath);
+            Log("Trying to load with entry " + libraryPath);
             IntPtr libraryHandle = SystemDynamicLibrary.Instance.LoadLibraryAtPath(libraryPath);
 
             if (IntPtr.Zero == libraryHandle)
@@ -151,7 +151,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public DLLHandle(IntPtr intPtr) : base(intPtr, true)
         {
-            log("Creating a dll handle");
+            Log("Creating a dll handle");
             SetHandle(intPtr);
         }
 
@@ -166,7 +166,7 @@ namespace PlayEveryWare.EpicOnlineServices
             bool didUnload = true;
 #if !UNITY_EDITOR
             didUnload = SystemDynamicLibrary.Instance.UnloadLibrary(handle);
-            log("Unloading a Dll with result : " + didUnload);
+            Log("Unloading a Dll with result : " + didUnload);
 #endif
             SetHandle(IntPtr.Zero);
             return didUnload;
@@ -198,7 +198,7 @@ namespace PlayEveryWare.EpicOnlineServices
             Type delegateType, string functionName)
         {
             var aDelegate = LoadFunctionAsDelegate(libraryHandle, delegateType, functionName);
-            //log("Delegate found is : " + aDelegate);
+            //Log("Delegate found is : " + aDelegate);
             var field = clazz.GetField(functionName);
             field.SetValue(null, aDelegate);
         }
@@ -206,7 +206,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         static public Delegate LoadFunctionAsDelegate(IntPtr libraryHandle, Type functionType, string functionName)
         {
-            log("Attempt to load " + functionName);
+            Log("Attempt to load " + functionName);
             if (libraryHandle == IntPtr.Zero)
             {
                 throw new Exception("libraryHandle is null");

--- a/com.playeveryware.eos/Runtime/Core/DLLHandle.cs
+++ b/com.playeveryware.eos/Runtime/Core/DLLHandle.cs
@@ -40,7 +40,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
         //-------------------------------------------------------------------------
         [Conditional("ENABLE_DLLHANDLE_PRINT")]
-        private static void print(string toPrint)
+        private static void log(string toPrint)
         {
             UnityEngine.Debug.Log(toPrint);
         }
@@ -64,7 +64,7 @@ namespace PlayEveryWare.EpicOnlineServices
             for (int i = pluginPaths.Count - 1; i >= 0; --i)
             {
                 string value = pluginPaths[i];
-                print("print " + value);
+                log("print " + value);
             }
 
             // Do a validation check after giving the 
@@ -72,7 +72,7 @@ namespace PlayEveryWare.EpicOnlineServices
             for (int i = pluginPaths.Count - 1; i >= 0; --i)
             {
                 string value = pluginPaths[i];
-                print("Evaluating " + value);
+                log("Evaluating " + value);
                 if (!FileSystemUtility.DirectoryExists(value))
                 {
                     pluginPaths.RemoveAt(i);
@@ -128,7 +128,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public static DLLHandle LoadDynamicLibrary(string libraryName)
         {
-            print("Loading Library " + libraryName);
+            log("Loading Library " + libraryName);
 
             string libraryPath = GetPathForLibrary(libraryName);
 
@@ -137,7 +137,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 return null;
             }
 
-            print("Trying to load with entry " + libraryPath);
+            log("Trying to load with entry " + libraryPath);
             IntPtr libraryHandle = SystemDynamicLibrary.Instance.LoadLibraryAtPath(libraryPath);
 
             if (IntPtr.Zero == libraryHandle)
@@ -151,7 +151,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         public DLLHandle(IntPtr intPtr) : base(intPtr, true)
         {
-            print("Creating a dll handle");
+            log("Creating a dll handle");
             SetHandle(intPtr);
         }
 
@@ -166,7 +166,7 @@ namespace PlayEveryWare.EpicOnlineServices
             bool didUnload = true;
 #if !UNITY_EDITOR
             didUnload = SystemDynamicLibrary.Instance.UnloadLibrary(handle);
-            print("Unloading a Dll with result : " + didUnload);
+            log("Unloading a Dll with result : " + didUnload);
 #endif
             SetHandle(IntPtr.Zero);
             return didUnload;
@@ -198,7 +198,7 @@ namespace PlayEveryWare.EpicOnlineServices
             Type delegateType, string functionName)
         {
             var aDelegate = LoadFunctionAsDelegate(libraryHandle, delegateType, functionName);
-            //print("Delegate found is : " + aDelegate);
+            //log("Delegate found is : " + aDelegate);
             var field = clazz.GetField(functionName);
             field.SetValue(null, aDelegate);
         }
@@ -206,7 +206,7 @@ namespace PlayEveryWare.EpicOnlineServices
         //-------------------------------------------------------------------------
         static public Delegate LoadFunctionAsDelegate(IntPtr libraryHandle, Type functionType, string functionName)
         {
-            print("Attempt to load " + functionName);
+            log("Attempt to load " + functionName);
             if (libraryHandle == IntPtr.Zero)
             {
                 throw new Exception("libraryHandle is null");

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -255,7 +255,7 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <param name="localProductUserId"></param>
             protected void SetLocalProductUserId(ProductUserId localProductUserId)
             {
-                print("Changing PUID: " + PUIDToString(s_localProductUserId) + " => " +
+                log("Changing PUID: " + PUIDToString(s_localProductUserId) + " => " +
                       PUIDToString(localProductUserId));
                 s_localProductUserId = localProductUserId;
             }
@@ -341,7 +341,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
             //-------------------------------------------------------------------------
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void print(string toPrint, LogType type = LogType.Log)
+            internal static void log(string toPrint, LogType type = LogType.Log)
             {
                 Debug.LogFormat(type, LogOption.None, null, toPrint);
             }
@@ -540,7 +540,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 if (GetEOSPlatformInterface() != null)
                 {
-                    print("Init completed with existing EOS PlatformInterface");
+                    log("Init completed with existing EOS PlatformInterface");
 
                     if (!hasSetLoggingCallback)
                     {
@@ -607,7 +607,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     }
                 }
 
-                print($"EOSManager::Init: InitializePlatformInterface: initResult = {initResult}");
+                log($"EOSManager::Init: InitializePlatformInterface: initResult = {initResult}");
 
 
                 s_hasInitializedPlatform = true;
@@ -627,7 +627,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 InitializeOverlay(coroutineOwner);
 
-                print("EOS loaded");
+                log("EOS loaded");
             }
 
             //-------------------------------------------------------------------------
@@ -640,7 +640,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 IPlatformSpecifics platformSpecifics = EOSManagerPlatformSpecificsSingleton.Instance;
                 if (platformSpecifics != null)
                 {
-                    print("EOSManager: Registering for platform-specific notifications");
+                    log("EOSManager: Registering for platform-specific notifications");
                     platformSpecifics.RegisterForPlatformNotifications();
                 }
             }
@@ -790,7 +790,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 var dateTime = DateTime.Now;
                 var messageCategory = message.Category.Length == 0 ? new Utf8String() : message.Category;
 
-                print(string.Format("{0:O} {1}({2}): {3}", dateTime, messageCategory, message.Level, message.Message));
+                log(string.Format("{0:O} {1}({2}): {3}", dateTime, messageCategory, message.Level, message.Message));
             }
 
             //-------------------------------------------------------------------------
@@ -1021,7 +1021,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (result == Result.NotFound)
                 {
-                    print("No User Auth tokens found to login");
+                    log("No User Auth tokens found to login");
                     if (onConnectLoginCallback != null)
                     {
                         var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
@@ -1032,11 +1032,11 @@ namespace PlayEveryWare.EpicOnlineServices
                     return;
                 }
 
-                print($"CopyUserAuthToken result code: {result}");
+                log($"CopyUserAuthToken result code: {result}");
 
                 if (!authToken.HasValue)
                 {
-                    print("authToken was not found, unable to login");
+                    log("authToken was not found, unable to login");
 
                     var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
                     dummyLoginCallbackInfo.ResultCode = Result.InvalidAuth;
@@ -1057,7 +1057,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 // One or the other should be provided, but if neither is available then fail to login
                 if (authToken.Value.RefreshToken != null)
                 {
-                    print("Attempting to use refresh token to login with connect");
+                    log("Attempting to use refresh token to login with connect");
 
                     connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
                     {
@@ -1069,7 +1069,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else if (authToken.Value.AccessToken != null)
                 {
-                    print("Attempting to use access token to login with connect");
+                    log("Attempting to use access token to login with connect");
 
                     connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
                     {
@@ -1081,7 +1081,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else
                 {
-                    print("authToken has a value, but neither the refresh token nor the access token was provided. Cannot login.");
+                    log("authToken has a value, but neither the refresh token nor the access token was provided. Cannot login.");
 
                     var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
                     dummyLoginCallbackInfo.ResultCode = Result.InvalidAuth;
@@ -1154,7 +1154,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     {
                         if (connectLoginData.ResultCode != Result.Success)
                         {
-                            print($"Connect login was not successful. ResultCode: {connectLoginData.ResultCode}", LogType.Error);
+                            log($"Connect login was not successful. ResultCode: {connectLoginData.ResultCode}", LogType.Error);
                         }
 
                         if (connectLoginData.LocalUserId != null)
@@ -1364,7 +1364,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 };
                 Instance.GetEOSPlatformInterface().GetUIInterface().SetDisplayPreference(ref displayOptions);
 
-                print("StartLoginWithLoginTypeAndToken");
+                log("StartLoginWithLoginTypeAndToken");
 
 #if UNITY_IOS && !UNITY_EDITOR
                 IOSLoginOptions modifiedLoginOptions = EOS_iOSLoginOptionsHelper.MakeIOSLoginOptionsFromDefault(loginOptions);
@@ -1375,7 +1375,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 EOSAuthInterface.Login(ref loginOptions, null, (ref LoginCallbackInfo data) =>
                 {
 #endif
-                    print("LoginCallBackResult : " + data.ResultCode);
+                    log("LoginCallBackResult : " + data.ResultCode);
                     if (data.ResultCode == Result.Success)
                     {
                         loggedInAccountIDs.Add(data.LocalUserId);
@@ -1412,7 +1412,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (createPresenceModificationResult != Result.Success)
                 {
-                    print("Unable to create presence modfication handle", LogType.Error);
+                    log("Unable to create presence modfication handle", LogType.Error);
                 }
 
                 var presenceModificationSetStatUsOptions = new PresenceModificationSetStatusOptions();
@@ -1421,7 +1421,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (setStatusResult != Result.Success)
                 {
-                    print("unable to set status", LogType.Error);
+                    log("unable to set status", LogType.Error);
                 }
 
                 var richTextOptions = new PresenceModificationSetRawRichTextOptions();
@@ -1435,7 +1435,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 {
                     if (callbackInfo.ResultCode != Result.Success)
                     {
-                        print("Unable to set presence: " + callbackInfo.ResultCode, LogType.Error);
+                        log("Unable to set presence: " + callbackInfo.ResultCode, LogType.Error);
                     }
                 });
             }
@@ -1489,13 +1489,13 @@ namespace PlayEveryWare.EpicOnlineServices
                     {
                         if (deletePersistentAuthCallbackInfo.ResultCode != Result.Success)
                         {
-                            print("Unable to delete persistent token, Result : " +
+                            log("Unable to delete persistent token, Result : " +
                                            deletePersistentAuthCallbackInfo.ResultCode,
                                            LogType.Error);
                         }
                         else
                         {
-                            print("Successfully deleted persistent token");
+                            log("Successfully deleted persistent token");
                         }
                     });
             }
@@ -1527,7 +1527,7 @@ namespace PlayEveryWare.EpicOnlineServices
             //-------------------------------------------------------------------------
             public void OnShutdown()
             {
-                print("Shutting down");
+                log("Shutting down");
 
                 foreach (Action callback in s_onApplicationShutdownCallbacks)
                 {
@@ -1550,7 +1550,7 @@ namespace PlayEveryWare.EpicOnlineServices
                         {
                             if (data.ResultCode != Result.Success)
                             {
-                                print("failed to logout ");
+                                log("failed to logout ");
                             }
                         });
                     }
@@ -1570,22 +1570,22 @@ namespace PlayEveryWare.EpicOnlineServices
                 if (!HasShutdown())
                 {
                     s_state = EOSState.ShuttingDown;
-                    print("Shutting down eos and releasing handles");
+                    log("Shutting down eos and releasing handles");
                     // Not doing this in the editor, because it doesn't seem to be an issue there
 #if !UNITY_EDITOR_OSX
 #if !UNITY_EDITOR
-                    print("Running garbage collection.");
+                    log("Running garbage collection.");
                     System.GC.Collect();
 
-                    print("Waiting for pending finalizers.");
+                    log("Waiting for pending finalizers.");
                     System.GC.WaitForPendingFinalizers();
 #endif
-                    print("Releasing the EOS Platform Interface.");
+                    log("Releasing the EOS Platform Interface.");
                     GetEOSPlatformInterface()?.Release();
 
                     if (s_eosUnloadSDKOnShutdown)
                     {
-                        print("Shutting down the platform interface.");
+                        log("Shutting down the platform interface.");
                         ShutdownPlatformInterface();
                     }
 
@@ -1596,11 +1596,11 @@ namespace PlayEveryWare.EpicOnlineServices
 #if UNITY_EDITOR
                     if (s_eosUnloadSDKOnShutdown)
                     {
-                        print("Unloading all libraries.");
+                        log("Unloading all libraries.");
                         UnloadAllLibraries();
                     }
 #endif
-                    print("Finished shutdown.");
+                    log("Finished shutdown.");
                     s_state = EOSState.Shutdown;
                 }
             }
@@ -1632,12 +1632,12 @@ namespace PlayEveryWare.EpicOnlineServices
                 ApplicationStatus currentStatus = GetEOSApplicationStatus();
                 if (currentStatus != newStatus)
                 {
-                    print($"EOSSingleton.SetEOSApplicationStatus: {currentStatus} -> {newStatus}");
+                    log($"EOSSingleton.SetEOSApplicationStatus: {currentStatus} -> {newStatus}");
 
                     Result result = GetEOSPlatformInterface().SetApplicationStatus(newStatus);
                     if (result != Result.Success)
                     {
-                        print(
+                        log(
                             $"EOSSingleton.SetEOSApplicationStatus: Error setting EOS application status (Result = {result})",
                             LogType.Error);
                     }
@@ -1688,7 +1688,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 bool wasPaused = s_isPaused;
                 s_isPaused = isPaused;
-                print($"EOSSingleton.OnApplicationPause: IsPaused {wasPaused} -> {s_isPaused}");
+                log($"EOSSingleton.OnApplicationPause: IsPaused {wasPaused} -> {s_isPaused}");
 
                 //                // Poll for the latest application constrained state as we're about
                 //                // to need it to determine the appropriate EOS application status
@@ -1704,7 +1704,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
 #if LOG_APPLICATION_FOCUS_CHANGE
                 bool hadFocus = s_hasFocus;
-                print($"EOSSingleton.OnApplicationFocus: HasFocus {hadFocus} -> {s_hasFocus}");
+                log($"EOSSingleton.OnApplicationFocus: HasFocus {hadFocus} -> {s_hasFocus}");
 #endif
                 s_hasFocus = hasFocus;
 
@@ -1722,7 +1722,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 bool wasConstrained = s_isConstrained;
                 s_isConstrained = isConstrained;
-                print($"EOSSingleton.OnApplicationConstrained: IsConstrained {wasConstrained} -> {s_isConstrained}");
+                log($"EOSSingleton.OnApplicationConstrained: IsConstrained {wasConstrained} -> {s_isConstrained}");
 
                 if (shouldUpdateEOSAppStatus)
                 {
@@ -1749,7 +1749,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 if (wasConstrained != isConstrained)
                 {
                     s_isConstrained = isConstrained;
-                    print(
+                    log(
                         $"EOSSingleton.OnApplicationConstrained: IsConstrained {wasConstrained} -> {s_isConstrained}");
                     UpdateEOSApplicationStatus();
                 }
@@ -1795,7 +1795,7 @@ namespace PlayEveryWare.EpicOnlineServices
             // disable this behaviour so that it doesn't fire Unity messages
             if (s_EOSManagerInstance != null)
             {
-                EOSSingleton.print($"{nameof(EOSManager)} {(nameof(Awake))}: An EOSManager instance already exists and is running, so this behaviour is marking as inactive to not perform duplicate work.");
+                EOSSingleton.log($"{nameof(EOSManager)} {(nameof(Awake))}: An EOSManager instance already exists and is running, so this behaviour is marking as inactive to not perform duplicate work.");
                 enabled = false;
                 return;
             }
@@ -1877,15 +1877,15 @@ namespace PlayEveryWare.EpicOnlineServices
             if (ShouldShutdownOnApplicationQuit)
             {
 #if EOS_CAN_SHUTDOWN
-                EOSSingleton.print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is true, so the EOS SDK will now be shut down fully.");
+                EOSSingleton.log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is true, so the EOS SDK will now be shut down fully.");
 #else
-                EOSSingleton.print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is false, so the EOS SDK will not be shut down.");
+                EOSSingleton.log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is false, so the EOS SDK will not be shut down.");
 #endif
                 Instance.OnShutdown();
             }
             else
             {
-                EOSSingleton.print($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
+                EOSSingleton.log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
             }
         }
 #endif

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -255,7 +255,7 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <param name="localProductUserId"></param>
             protected void SetLocalProductUserId(ProductUserId localProductUserId)
             {
-                log("Changing PUID: " + PUIDToString(s_localProductUserId) + " => " +
+                Log("Changing PUID: " + PUIDToString(s_localProductUserId) + " => " +
                       PUIDToString(localProductUserId));
                 s_localProductUserId = localProductUserId;
             }
@@ -341,7 +341,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
             //-------------------------------------------------------------------------
             [Conditional("ENABLE_DEBUG_EOSMANAGER")]
-            internal static void log(string toPrint, LogType type = LogType.Log)
+            internal static void Log(string toPrint, LogType type = LogType.Log)
             {
                 Debug.LogFormat(type, LogOption.None, null, toPrint);
             }
@@ -540,7 +540,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 if (GetEOSPlatformInterface() != null)
                 {
-                    log("Init completed with existing EOS PlatformInterface");
+                    Log("Init completed with existing EOS PlatformInterface");
 
                     if (!hasSetLoggingCallback)
                     {
@@ -607,7 +607,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     }
                 }
 
-                log($"EOSManager::Init: InitializePlatformInterface: initResult = {initResult}");
+                Log($"EOSManager::Init: InitializePlatformInterface: initResult = {initResult}");
 
 
                 s_hasInitializedPlatform = true;
@@ -627,7 +627,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 InitializeOverlay(coroutineOwner);
 
-                log("EOS loaded");
+                Log("EOS loaded");
             }
 
             //-------------------------------------------------------------------------
@@ -640,7 +640,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 IPlatformSpecifics platformSpecifics = EOSManagerPlatformSpecificsSingleton.Instance;
                 if (platformSpecifics != null)
                 {
-                    log("EOSManager: Registering for platform-specific notifications");
+                    Log("EOSManager: Registering for platform-specific notifications");
                     platformSpecifics.RegisterForPlatformNotifications();
                 }
             }
@@ -790,7 +790,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 var dateTime = DateTime.Now;
                 var messageCategory = message.Category.Length == 0 ? new Utf8String() : message.Category;
 
-                log(string.Format("{0:O} {1}({2}): {3}", dateTime, messageCategory, message.Level, message.Message));
+                Log(string.Format("{0:O} {1}({2}): {3}", dateTime, messageCategory, message.Level, message.Message));
             }
 
             //-------------------------------------------------------------------------
@@ -1021,7 +1021,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (result == Result.NotFound)
                 {
-                    log("No User Auth tokens found to login");
+                    Log("No User Auth tokens found to login");
                     if (onConnectLoginCallback != null)
                     {
                         var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
@@ -1032,11 +1032,11 @@ namespace PlayEveryWare.EpicOnlineServices
                     return;
                 }
 
-                log($"CopyUserAuthToken result code: {result}");
+                Log($"CopyUserAuthToken result code: {result}");
 
                 if (!authToken.HasValue)
                 {
-                    log("authToken was not found, unable to login");
+                    Log("authToken was not found, unable to login");
 
                     var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
                     dummyLoginCallbackInfo.ResultCode = Result.InvalidAuth;
@@ -1057,7 +1057,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 // One or the other should be provided, but if neither is available then fail to login
                 if (authToken.Value.RefreshToken != null)
                 {
-                    log("Attempting to use refresh token to login with connect");
+                    Log("Attempting to use refresh token to login with connect");
 
                     connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
                     {
@@ -1069,7 +1069,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else if (authToken.Value.AccessToken != null)
                 {
-                    log("Attempting to use access token to login with connect");
+                    Log("Attempting to use access token to login with connect");
 
                     connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
                     {
@@ -1081,7 +1081,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else
                 {
-                    log("authToken has a value, but neither the refresh token nor the access token was provided. Cannot login.");
+                    Log("authToken has a value, but neither the refresh token nor the access token was provided. Cannot login.");
 
                     var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
                     dummyLoginCallbackInfo.ResultCode = Result.InvalidAuth;
@@ -1154,7 +1154,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     {
                         if (connectLoginData.ResultCode != Result.Success)
                         {
-                            log($"Connect login was not successful. ResultCode: {connectLoginData.ResultCode}", LogType.Error);
+                            Log($"Connect login was not successful. ResultCode: {connectLoginData.ResultCode}", LogType.Error);
                         }
 
                         if (connectLoginData.LocalUserId != null)
@@ -1364,7 +1364,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 };
                 Instance.GetEOSPlatformInterface().GetUIInterface().SetDisplayPreference(ref displayOptions);
 
-                log("StartLoginWithLoginTypeAndToken");
+                Log("StartLoginWithLoginTypeAndToken");
 
 #if UNITY_IOS && !UNITY_EDITOR
                 IOSLoginOptions modifiedLoginOptions = EOS_iOSLoginOptionsHelper.MakeIOSLoginOptionsFromDefault(loginOptions);
@@ -1375,7 +1375,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 EOSAuthInterface.Login(ref loginOptions, null, (ref LoginCallbackInfo data) =>
                 {
 #endif
-                    log("LoginCallBackResult : " + data.ResultCode);
+                    Log("LoginCallBackResult : " + data.ResultCode);
                     if (data.ResultCode == Result.Success)
                     {
                         loggedInAccountIDs.Add(data.LocalUserId);
@@ -1412,7 +1412,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (createPresenceModificationResult != Result.Success)
                 {
-                    log("Unable to create presence modfication handle", LogType.Error);
+                    Log("Unable to create presence modfication handle", LogType.Error);
                 }
 
                 var presenceModificationSetStatUsOptions = new PresenceModificationSetStatusOptions();
@@ -1421,7 +1421,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (setStatusResult != Result.Success)
                 {
-                    log("unable to set status", LogType.Error);
+                    Log("unable to set status", LogType.Error);
                 }
 
                 var richTextOptions = new PresenceModificationSetRawRichTextOptions();
@@ -1435,7 +1435,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 {
                     if (callbackInfo.ResultCode != Result.Success)
                     {
-                        log("Unable to set presence: " + callbackInfo.ResultCode, LogType.Error);
+                        Log("Unable to set presence: " + callbackInfo.ResultCode, LogType.Error);
                     }
                 });
             }
@@ -1489,13 +1489,13 @@ namespace PlayEveryWare.EpicOnlineServices
                     {
                         if (deletePersistentAuthCallbackInfo.ResultCode != Result.Success)
                         {
-                            log("Unable to delete persistent token, Result : " +
+                            Log("Unable to delete persistent token, Result : " +
                                            deletePersistentAuthCallbackInfo.ResultCode,
                                            LogType.Error);
                         }
                         else
                         {
-                            log("Successfully deleted persistent token");
+                            Log("Successfully deleted persistent token");
                         }
                     });
             }
@@ -1527,7 +1527,7 @@ namespace PlayEveryWare.EpicOnlineServices
             //-------------------------------------------------------------------------
             public void OnShutdown()
             {
-                log("Shutting down");
+                Log("Shutting down");
 
                 foreach (Action callback in s_onApplicationShutdownCallbacks)
                 {
@@ -1550,7 +1550,7 @@ namespace PlayEveryWare.EpicOnlineServices
                         {
                             if (data.ResultCode != Result.Success)
                             {
-                                log("failed to logout ");
+                                Log("failed to logout ");
                             }
                         });
                     }
@@ -1570,22 +1570,22 @@ namespace PlayEveryWare.EpicOnlineServices
                 if (!HasShutdown())
                 {
                     s_state = EOSState.ShuttingDown;
-                    log("Shutting down eos and releasing handles");
+                    Log("Shutting down eos and releasing handles");
                     // Not doing this in the editor, because it doesn't seem to be an issue there
 #if !UNITY_EDITOR_OSX
 #if !UNITY_EDITOR
-                    log("Running garbage collection.");
+                    Log("Running garbage collection.");
                     System.GC.Collect();
 
-                    log("Waiting for pending finalizers.");
+                    Log("Waiting for pending finalizers.");
                     System.GC.WaitForPendingFinalizers();
 #endif
-                    log("Releasing the EOS Platform Interface.");
+                    Log("Releasing the EOS Platform Interface.");
                     GetEOSPlatformInterface()?.Release();
 
                     if (s_eosUnloadSDKOnShutdown)
                     {
-                        log("Shutting down the platform interface.");
+                        Log("Shutting down the platform interface.");
                         ShutdownPlatformInterface();
                     }
 
@@ -1596,11 +1596,11 @@ namespace PlayEveryWare.EpicOnlineServices
 #if UNITY_EDITOR
                     if (s_eosUnloadSDKOnShutdown)
                     {
-                        log("Unloading all libraries.");
+                        Log("Unloading all libraries.");
                         UnloadAllLibraries();
                     }
 #endif
-                    log("Finished shutdown.");
+                    Log("Finished shutdown.");
                     s_state = EOSState.Shutdown;
                 }
             }
@@ -1632,12 +1632,12 @@ namespace PlayEveryWare.EpicOnlineServices
                 ApplicationStatus currentStatus = GetEOSApplicationStatus();
                 if (currentStatus != newStatus)
                 {
-                    log($"EOSSingleton.SetEOSApplicationStatus: {currentStatus} -> {newStatus}");
+                    Log($"EOSSingleton.SetEOSApplicationStatus: {currentStatus} -> {newStatus}");
 
                     Result result = GetEOSPlatformInterface().SetApplicationStatus(newStatus);
                     if (result != Result.Success)
                     {
-                        log(
+                        Log(
                             $"EOSSingleton.SetEOSApplicationStatus: Error setting EOS application status (Result = {result})",
                             LogType.Error);
                     }
@@ -1688,7 +1688,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 bool wasPaused = s_isPaused;
                 s_isPaused = isPaused;
-                log($"EOSSingleton.OnApplicationPause: IsPaused {wasPaused} -> {s_isPaused}");
+                Log($"EOSSingleton.OnApplicationPause: IsPaused {wasPaused} -> {s_isPaused}");
 
                 //                // Poll for the latest application constrained state as we're about
                 //                // to need it to determine the appropriate EOS application status
@@ -1704,7 +1704,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
 #if LOG_APPLICATION_FOCUS_CHANGE
                 bool hadFocus = s_hasFocus;
-                log($"EOSSingleton.OnApplicationFocus: HasFocus {hadFocus} -> {s_hasFocus}");
+                Log($"EOSSingleton.OnApplicationFocus: HasFocus {hadFocus} -> {s_hasFocus}");
 #endif
                 s_hasFocus = hasFocus;
 
@@ -1722,7 +1722,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 bool wasConstrained = s_isConstrained;
                 s_isConstrained = isConstrained;
-                log($"EOSSingleton.OnApplicationConstrained: IsConstrained {wasConstrained} -> {s_isConstrained}");
+                Log($"EOSSingleton.OnApplicationConstrained: IsConstrained {wasConstrained} -> {s_isConstrained}");
 
                 if (shouldUpdateEOSAppStatus)
                 {
@@ -1749,7 +1749,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 if (wasConstrained != isConstrained)
                 {
                     s_isConstrained = isConstrained;
-                    log(
+                    Log(
                         $"EOSSingleton.OnApplicationConstrained: IsConstrained {wasConstrained} -> {s_isConstrained}");
                     UpdateEOSApplicationStatus();
                 }
@@ -1795,7 +1795,7 @@ namespace PlayEveryWare.EpicOnlineServices
             // disable this behaviour so that it doesn't fire Unity messages
             if (s_EOSManagerInstance != null)
             {
-                EOSSingleton.log($"{nameof(EOSManager)} {(nameof(Awake))}: An EOSManager instance already exists and is running, so this behaviour is marking as inactive to not perform duplicate work.");
+                EOSSingleton.Log($"{nameof(EOSManager)} {(nameof(Awake))}: An EOSManager instance already exists and is running, so this behaviour is marking as inactive to not perform duplicate work.");
                 enabled = false;
                 return;
             }
@@ -1877,15 +1877,15 @@ namespace PlayEveryWare.EpicOnlineServices
             if (ShouldShutdownOnApplicationQuit)
             {
 #if EOS_CAN_SHUTDOWN
-                EOSSingleton.log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is true, so the EOS SDK will now be shut down fully.");
+                EOSSingleton.Log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is true, so the EOS SDK will now be shut down fully.");
 #else
-                EOSSingleton.log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is false, so the EOS SDK will not be shut down.");
+                EOSSingleton.Log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is true, so the plugin is being shut down. EOS_CAN_SHUTDOWN is false, so the EOS SDK will not be shut down.");
 #endif
                 Instance.OnShutdown();
             }
             else
             {
-                EOSSingleton.log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
+                EOSSingleton.Log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
             }
         }
 #endif

--- a/com.playeveryware.eos/Runtime/Core/EOSManager_DynamicLoading.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager_DynamicLoading.cs
@@ -132,7 +132,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 if(LoadedDLLs.ContainsKey(libraryName))
                 {
-                    log("Found existing handle for " + libraryName);
+                    Log("Found existing handle for " + libraryName);
                     return LoadedDLLs[libraryName];
                 }
                 else
@@ -162,7 +162,7 @@ namespace PlayEveryWare.EpicOnlineServices
             static public void LoadDelegatesWithEOSBindingAPI()
             {
 #if EOS_DYNAMIC_BINDINGS
-                log($"Loading EOS binary {EOSBinaryName}");
+                Log($"Loading EOS binary {EOSBinaryName}");
                 var eosLibraryHandle = LoadDynamicLibrary(EOSBinaryName);
 
                 Epic.OnlineServices.Bindings.Hook<DLLHandle>(eosLibraryHandle, (DLLHandle handle, string functionName) => {

--- a/com.playeveryware.eos/Runtime/Core/EOSManager_DynamicLoading.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager_DynamicLoading.cs
@@ -132,7 +132,7 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 if(LoadedDLLs.ContainsKey(libraryName))
                 {
-                    print("Found existing handle for " + libraryName);
+                    log("Found existing handle for " + libraryName);
                     return LoadedDLLs[libraryName];
                 }
                 else
@@ -162,7 +162,7 @@ namespace PlayEveryWare.EpicOnlineServices
             static public void LoadDelegatesWithEOSBindingAPI()
             {
 #if EOS_DYNAMIC_BINDINGS
-                print($"Loading EOS binary {EOSBinaryName}");
+                log($"Loading EOS binary {EOSBinaryName}");
                 var eosLibraryHandle = LoadDynamicLibrary(EOSBinaryName);
 
                 Epic.OnlineServices.Bindings.Hook<DLLHandle>(eosLibraryHandle, (DLLHandle handle, string functionName) => {


### PR DESCRIPTION
Where applicable, rename "print" and other logging functions to "log".

Intentionally not adjusting:
- SteamManager.SteamAPIDebugTextHook
- FileInfoExtensions.LogInequalityReason
- EOSManager.SimplePrintStringCallback

#EOS-2086