### PR TITLE
fix: Achievements Only Refresh on Connect Login

### DIFF
--- a/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
+++ b/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
@@ -109,7 +109,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         protected async override void OnLoggedIn(AuthenticationListener.LoginChangeKind changeType)
         {
-            await RefreshAsync();
+            // Achievements require Epic Game Services to function, which requires a Connect login
+            if (changeType == AuthenticationListener.LoginChangeKind.Connect)
+            {
+                await RefreshAsync();
+            }
         }
 
         protected override void Reset()


### PR DESCRIPTION
The Achievements Service was attempting to refresh before connect logins were done. This commonly causes errors to appear relating to user account lookup failing. With this small change, we only refresh after a Connect login, which is when this'll actually be available.

#EOS-2199