### PR TITLE
fix: Correct error introduced from merge

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -522,7 +522,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 throw;
             }
         }
-#endif
 
         /// <summary>
         /// Reads all text from the indicated file.
@@ -544,8 +543,8 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 throw;
             }
 #endif
-
         }
+#endif
 
         #endregion
 

--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -545,30 +545,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 #endif
 
         }
-#endif
-
-        /// <summary>
-        /// Reads all text from the indicated file.
-        /// </summary>
-        /// <param name="path">Filepath to the file to read from.</param>
-        /// <returns>The contents of the file at the indicated path as a string.</returns>
-        public static string ReadAllText(string path)
-        {
-#if UNITY_ANDROID && !UNITY_EDITOR
-            return AndroidFileIOHelper.ReadAllText(path);
-#else
-            try
-            {
-                return File.ReadAllText(path);
-            }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-                throw;
-            }
-#endif
-
-        }
 
 
 

--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -482,6 +482,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 #endif
 
         #region File Read Functionality
+
         // NOTE: This compile conditional is here because on Android devices
         //       async IO doesn't work well.
 #if !UNITY_ANDROID || UNITY_EDITOR
@@ -546,11 +547,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 
         }
 
-
-
-
-
-#endregion
+        #endregion
 
         #region Get File System Entries Functionality
 


### PR DESCRIPTION
In one of the most recent merges into `development`, a compilation error slipped pass. The error originated from incorrectly resolving merge conflicts.

This PR resolves the issue.