### PR TITLE
fix: Upgrade Visual Studio version to 2022.

### DIFF
--- a/lib/NativeCode/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.sln
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31025.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DynamicLibraryLoaderHelper", "DynamicLibraryLoaderHelper\DynamicLibraryLoaderHelper.vcxproj", "{3C24168C-C23B-4F82-9E8D-15B900621C93}"
 EndProject


### PR DESCRIPTION
This PR includes a change that _was supposed to be_ included in [this PR](https://github.com/PlayEveryWare/eos_plugin_for_unity/pull/1050). It upgrades the version of visual studio utilized for the native plugin component. The documentation has already been updated - this makes the solution file match the documentation.