### PR TITLE
chore: Add `AssemblyInfo` files where appropriate

### DIFF
--- a/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedPluginCode/ManagedPluginCode.csproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedPluginCode/ManagedPluginCode.csproj
@@ -214,6 +214,7 @@
     </Compile>
     <Compile Include="Application.cs" />
     <Compile Include="Debug.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedPluginCode/Properties/AssemblyInfo.cs
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedPluginCode/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("PlayEveryWare, Inc.")]
 [assembly: AssemblyProduct("EOS Plugin for Unity")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("en-US")]
 

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedToUnmanagedBridge/AssemblyInfo.cpp
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedToUnmanagedBridge/AssemblyInfo.cpp
@@ -7,11 +7,11 @@ using namespace System::Runtime::InteropServices;
 using namespace System::Security::Permissions;
 
 [assembly:AssemblyTitleAttribute(L"ManagedToUnmanagedBridge")];
-[assembly:AssemblyDescriptionAttribute(L"Used as a proxy or bridge between managed and unmanaged code.")];
+[assembly:AssemblyDescriptionAttribute(L"Makes some managed plugin code accessible from a native context.")];
 [assembly:AssemblyConfigurationAttribute(L"")];
 [assembly:AssemblyCompanyAttribute(L"PlayEveryWare, Inc.")];
 [assembly:AssemblyProductAttribute(L"EOS Plugin for Unity")];
-[assembly:AssemblyCopyrightAttribute(L"Copyright (c)  2024")];
+[assembly:AssemblyCopyrightAttribute(L"Copyright © 2024")];
 [assembly:AssemblyTrademarkAttribute(L"")];
 [assembly:AssemblyCultureAttribute(L"en-US")];
 


### PR DESCRIPTION
This PR adds `AssemblyInfo` files where appropriate. The result is that generated class libraries will have proper meta-data set indicating the product the binary is a component, a brief description of what the binary does, locale information and other related meta-data.