### PR TITLE
fix: If `definition.StatThresholds` is null, don't iterate on it for selectedDescription

### DIFF
--- a/Assets/Scripts/StandardSamples/UI/Achievements/UIAchievementsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Achievements/UIAchievementsMenu.cs
@@ -292,9 +292,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 "Id: {0}\nUnlocked Display Name: {1}\nUnlocked Description: {2}\nLocked Display Name: {3}\nLocked Description: {4}\nHidden: {5}\n",
                 definition.AchievementId, definition.UnlockedDisplayName, definition.UnlockedDescription, definition.LockedDisplayName, definition.LockedDescription, definition.IsHidden);
 
-            foreach (StatThresholds st in definition.StatThresholds)
+            if (definition.StatThresholds != null)
             {
-                selectedDescription += string.Format("Stat Thresholds: '{0}': {1}\n", st.Name, st.Threshold);
+                foreach (StatThresholds st in definition.StatThresholds)
+                {
+                    selectedDescription += string.Format("Stat Thresholds: '{0}': {1}\n", st.Name, st.Threshold);
+                }
             }
 
             definitionsDescription.text = selectedDescription;


### PR DESCRIPTION
Not all achievements have StatThresholds. This fixes an issue with the achievements sample where a null reference exception is thrown on trying to display an achievement with a null statthresholds.

#EOS-2299