### PR TITLE
fix: Parse Enums as Integers for Comparison in `ListOfStringsToEnumConverters.FromNumberValue`

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
@@ -184,11 +184,12 @@ namespace PlayEveryWare.EpicOnlineServices
             Type underlyingType = Enum.GetUnderlyingType(typeof(TEnum));
             object value = Convert.ChangeType(token, underlyingType);
 
-            object lowestValue = EnumUtility<TEnum>.GetLowest();
+            TEnum lowestEnumValue = EnumUtility<TEnum>.GetLowest();
+            object lowestUnderlyingValue = Convert.ChangeType(lowestEnumValue, underlyingType);
 
-            if (Comparer<object>.Default.Compare(value, lowestValue) < 0)
+            if (Comparer<object>.Default.Compare(value, lowestUnderlyingValue) < 0)
             {
-                value = lowestValue;
+                value = lowestUnderlyingValue;
             }
 
             return (TEnum)value;


### PR DESCRIPTION
`ListOfStringsToEnumConverters.FromNumberValue` converts a string to an enum, and then compares that enum to find the "lowest" value. If the enum fails to parse, it will set itself properly to the lowest value. This was trying to compare an Enum to an integer, and was previously failing when the integer was 0 but the Enum didn't have a "0" defined. This fix explicitly compares the underlying value instead of comparing the enum, which covers this scenario.

#EOS-2337