### PR TITLE
Fix/nullcheck migration

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -419,7 +419,7 @@ namespace PlayEveryWare.EpicOnlineServices
             string compDeploymentString = mainNonOverrideableConfig.deploymentID?.ToLower();
 
             foreach(Named<Deployment> dep in productConfig.Environments.Deployments)
-            
+            {
                 if (!string.IsNullOrEmpty(compDeploymentString) && !compDeploymentString.Equals(dep.Value.DeploymentId.ToString("N").ToLowerInvariant()))
                 {
                     continue;

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -416,7 +416,7 @@ namespace PlayEveryWare.EpicOnlineServices
             integratedPlatformManagementFlags |= mainNonOverrideableConfig.integratedPlatformManagementFlags;
 
             ProductConfig productConfig = Get<ProductConfig>();
-            string compDeploymentString = mainNonOverrideableConfig.deploymentID.ToLower();
+            string compDeploymentString = mainNonOverrideableConfig.deploymentID?.ToLower();
 
             foreach(Named<Deployment> dep in productConfig.Environments.Deployments)
             {

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -419,8 +419,8 @@ namespace PlayEveryWare.EpicOnlineServices
             string compDeploymentString = mainNonOverrideableConfig.deploymentID?.ToLower();
 
             foreach(Named<Deployment> dep in productConfig.Environments.Deployments)
-            {
-                if (!compDeploymentString.Equals(dep.Value.DeploymentId.ToString("N").ToLowerInvariant()))
+            
+                if (!string.IsNullOrEmpty(compDeploymentString) && !compDeploymentString.Equals(dep.Value.DeploymentId.ToString("N").ToLowerInvariant()))
                 {
                     continue;
                 }

--- a/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
@@ -147,7 +147,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             // Set the product name, version, and override thread affinity
             initOptions.options.ProductName = productConfig.ProductName;
             initOptions.options.ProductVersion = productConfig.ProductVersion;
-            initOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity.Unwrap();
+            initOptions.options.OverrideThreadAffinity = platformConfig.threadAffinity?.Unwrap();
 
             initOptions.options.AllocateMemoryFunction = IntPtr.Zero;
             initOptions.options.ReallocateMemoryFunction = IntPtr.Zero;

--- a/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/ConfigurationUtility.cs
@@ -77,7 +77,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             platformConfig.platformOptionsFlags.Unwrap();
 #endif
 
-            if (!platformConfig.clientCredentials.IsEncryptionKeyValid())
+            if (platformConfig.clientCredentials == null || platformConfig.clientCredentials.IsEncryptionKeyValid() == false)
             {
                 Debug.LogError("The encryption key used for the selected client credentials is invalid. Please see your platform configuration.");
             }


### PR DESCRIPTION
While migrating, do some nullchecking to ensure that values are present before trying to import them.
`platformConfig.threadAffinity` can be null, so do a null check before unwrapping.

#EOS-2338