### PR TITLE
Fix: `RenderSetOfNamed` can render empty set

### DIFF
--- a/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
@@ -823,8 +823,26 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
                 list.DoLayoutList();
             }
             else
-            {
-                // TODO here
+            {                
+                // If there are no items in the list, then the user needs to add an entry
+                // before they can start modifying.
+                EditorGUILayout.BeginHorizontal();
+
+                Rect rect = EditorGUILayout.GetControlRect();
+                rect.height = EditorGUIUtility.singleLineHeight;
+
+                // Render the "+" button to add a new item
+                if (GUILayout.Button("+", GUILayout.Width(24)))
+                {
+                    addNewItemFn();
+                }
+
+                if (!string.IsNullOrEmpty(helpUrl))
+                {
+                    RenderHelpIcon(helpUrl);
+                }
+
+                EditorGUILayout.EndHorizontal();
             }
         }
 


### PR DESCRIPTION
Before: `RenderSetOfNamed` required at least one entry, or it wouldn't render.
Now: If the list is empty, only the + to add things will be displayed.

#EOS-2339