### PR TITLE
fix: Remove `EOSPSNManagerPS5` reference in EOSManager

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -1804,10 +1804,6 @@ namespace PlayEveryWare.EpicOnlineServices
             s_EOSManagerInstance = this;
             DontDestroyOnLoad(this.gameObject);
 
-#if UNITY_PS5 && !UNITY_EDITOR
-            EOSPSNManagerPS5.EnsurePS5Initialized();
-#endif
-
             Instance.Init(this);
         }
 


### PR DESCRIPTION
There used to be a need for PS5 to run initialization code inside `EOSManager`. It now relies on code inside another repository. This existing causes compilation errors, and should not be carried forward in the new version.

#EOS-2340