### PR TITLE
fix: Use `PresenceVal.isOn` while calling `CreateSession`

### DIFF
--- a/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/MatchMaking/UISessionsMatchmakingMenu.cs
@@ -258,7 +258,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
             session.Attributes.Add(attribute);
 
-            GetEOSSessionsManager.CreateSession(session, UIOnSessionCreated);
+            GetEOSSessionsManager.CreateSession(session, UIOnSessionCreated, this.PresenceVal.isOn);
         }
 
         private void UIOnSessionCreated(SessionsManagerCreateSessionCallbackInfo info)


### PR DESCRIPTION
The sample has an optional argument for whether or not a Session is a Presence Session, but it wasn't being set. This fixes that, making the samples correctly handle Presence Session creation.

#EOS-2325