### PR TITLE
feat: Enable PlatformConfigs to Provide Default `IntegratedPlatformManagementFlags`

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -412,8 +412,15 @@ namespace PlayEveryWare.EpicOnlineServices
 
             MigratePlatformFlags(overrideValuesFromFieldMember, mainNonOverrideableConfig);
 
-            integratedPlatformManagementFlags = IntegratedPlatformManagementFlags.Disabled;
-            integratedPlatformManagementFlags |= mainNonOverrideableConfig.integratedPlatformManagementFlags;
+            // If there are no Integrated Platform Management Flags in the original config, apply a set of default per-platform IMPFs
+            if ((int)mainNonOverrideableConfig.integratedPlatformManagementFlags == 0 || mainNonOverrideableConfig.integratedPlatformManagementFlags == IntegratedPlatformManagementFlags.Disabled)
+            {
+                integratedPlatformManagementFlags = GetDefaultIntegratedPlatformManagementFlags();
+            }
+            else
+            {
+                integratedPlatformManagementFlags = mainNonOverrideableConfig.integratedPlatformManagementFlags;
+            }
 
             ProductConfig productConfig = Get<ProductConfig>();
             string compDeploymentString = mainNonOverrideableConfig.deploymentID?.ToLower();
@@ -533,7 +540,12 @@ namespace PlayEveryWare.EpicOnlineServices
                 "Plugin -> EOS Configuration to make sure that the " +
                 "migration was successful.");
         }
-        
+
+        public virtual Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformManagementFlags GetDefaultIntegratedPlatformManagementFlags()
+        {
+            return IntegratedPlatformManagementFlags.Disabled;
+        }
+
 
 #endif
 

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -541,7 +541,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 "migration was successful.");
         }
 
-        public virtual Epic.OnlineServices.IntegratedPlatform.IntegratedPlatformManagementFlags GetDefaultIntegratedPlatformManagementFlags()
+        public virtual IntegratedPlatformManagementFlags GetDefaultIntegratedPlatformManagementFlags()
         {
             return IntegratedPlatformManagementFlags.Disabled;
         }


### PR DESCRIPTION
While migrating, if the old config had no IntegratedPlatformManagementFlags, or the previous value was `Disabled`, try to set the value to a provideable set of default flags. Otherwise, use the old config's IPMFs. This set up currently always provides `Disabled` as the default, but it enables flexibility in platform management of default flags.

#EOS-2344