### PR TITLE
fix: PlatformManager Internals

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -61,7 +61,7 @@ namespace PlayEveryWare.EpicOnlineServices
             Any = Unknown | Windows | Android | XboxOne | XboxSeriesX | iOS | Linux | macOS | PS4 | PS5 | Switch | Steam
         }
 
-        private readonly struct PlatformInfo
+        internal readonly struct PlatformInfo
         {
             public string FullName { get;  }
             public string ConfigFileName { get; }
@@ -91,7 +91,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <summary>
         /// Private collection to store information about each platform.
         /// </summary>
-        private static IDictionary<Platform, PlatformInfo> PlatformInformation = new Dictionary<Platform, PlatformInfo>();
+        internal static IDictionary<Platform, PlatformInfo> PlatformInformation = new Dictionary<Platform, PlatformInfo>();
 
         /// <summary>
         /// Backing value for the CurrentPlatform property.
@@ -405,7 +405,12 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <returns>Full name of platform.</returns>
         public static string GetFullName(Platform platform)
         {
-            return PlatformInformation[platform].FullName;
+            if (PlatformInformation.TryGetValue(platform, out PlatformInfo value))
+            {
+                return value.FullName;
+            }
+
+            return platform.ToString();
         }
     }
 }


### PR DESCRIPTION
Setting `PlatformManager.PlatformInfo` and `PlatformInformation` to be `internal`, such that other code can reference it and add to it.