### PR TITLE
fix: Prevent generation of empty `EpicOnlineServicesConfig.json` file.

### DIFF
--- a/Assets/Tests/PlayMode/Config/EOSConfigTests.cs
+++ b/Assets/Tests/PlayMode/Config/EOSConfigTests.cs
@@ -22,21 +22,23 @@
 
 namespace PlayEveryWare.EpicOnlineServices.Tests.Config
 {
-    using Epic.OnlineServices.Platform;
     using NUnit.Framework;
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using static PlayEveryWare.EpicOnlineServices.EOSConfig;
-    using Config = EpicOnlineServices.Config;
 
     public class EOSConfigTests
     {
+        // This warning suppression is here because with EOSConfig being obsolete,
+        // it will generate a warning. Because EOSConfig still exists for the 
+        // purposes of migration, it is important that the tests remain intact.
+#pragma warning disable CS0618 // Type or member is obsolete
+
         [Test]
         public void ProductName_MustNotBeEmpty()
         {
+
             EOSConfig config = EOSConfig.Get<EOSConfig>();
+
             config.productName = string.Empty;
 
             if (!FieldValidator.TryGetFailingValidatorAttributes(config, out List<FieldValidatorFailure> failingAttributes))
@@ -49,6 +51,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Config
                 failingAttributes,
                 NonEmptyStringFieldValidatorAttribute.FieldIsEmptyMessage),
                 "There should be a failure of the expected type and message.");
+
         }
 
         [Test]
@@ -306,6 +309,8 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Config
                 GUIDFieldValidatorAttribute.NotAGuidMessage),
                 "There should be a failure of the expected type and message.");
         }
+
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Determines if the provided list of failures contains an expected failure

--- a/com.playeveryware.eos/Runtime/Core/Config/Config.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Config.cs
@@ -449,7 +449,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// editor is running, then create the file.
         /// </summary>
         /// <returns>Task.</returns>
-        private async Task EnsureConfigFileExistsAsync()
+        protected virtual async Task EnsureConfigFileExistsAsync()
         {
             bool fileExists = await FileSystemUtility.FileExistsAsync(FilePath);
 

--- a/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/EOSConfig.cs
@@ -48,6 +48,7 @@ namespace PlayEveryWare.EpicOnlineServices
     using System.Text.RegularExpressions;
     using Newtonsoft.Json;
     using PlayEveryWare.EpicOnlineServices.Utility;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Represents the default deployment ID to use when a given sandbox ID is
@@ -74,6 +75,7 @@ namespace PlayEveryWare.EpicOnlineServices
         "Thread Affinity & Tick Budgets",
         "Overlay Options"
     }, false)]
+    [Obsolete("EOSConfig is obsolete. It has been replaced by PlatformConfig and ProductConfig. It remains here for migration purposes.")]
     public class EOSConfig : Config
     {
         static EOSConfig()
@@ -95,6 +97,18 @@ namespace PlayEveryWare.EpicOnlineServices
             // never migrated. Non-obsolete code makes exclusive use of the new
             // classes.
             return false;
+        }
+
+        /// <summary>
+        /// Override the function that writes a config file if it doesn't exist,
+        /// because now that EOSConfig is obsolete, we do not want an empty file
+        /// being generated automatically - it would inevitably lead to some
+        /// confusion.
+        /// </summary>
+        /// <returns>Returns a completed task.</returns>
+        protected override Task EnsureConfigFileExistsAsync()
+        {
+            return Task.CompletedTask;
         }
 
         #region Product Information

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -268,6 +268,10 @@ namespace PlayEveryWare.EpicOnlineServices
 
         #region Logic for Migrating Override Values from Previous Structure
 
+        // This warning is suppressed because while EOSConfig is marked as 
+        // obsolete - it is important that it remain and be used within this
+        // section of code so that things can be properly migrated.
+#pragma warning disable CS0618 // Type or member is obsolete
 #if !EOS_DISABLE
 
         protected sealed class NonOverrideableConfigValues : Config
@@ -340,7 +344,9 @@ namespace PlayEveryWare.EpicOnlineServices
             return !overrideValuesFromFieldMember.Equals(default) ? overrideValuesFromFieldMember : mainConfigValue;
         }
 
+
         private void MigrateButtonDelays(EOSConfig overrideValuesFromFieldMember, OverrideableConfigValues mainOverrideableConfig)
+
         {
             // Import the values for initial button delay and repeat button
             // delay


### PR DESCRIPTION
This PR corrects a problem that exists within the current release branch where an empty `EpicOnlineServicesConfig.json` file is always being generated. 

It is critical that this be avoided, since the generation and inclusion of the file in the project despite it being deprecated will otherwise be a major source of confusion for many users.