### PR TITLE
fix: Resolve race conditions for file IO.

### DIFF
--- a/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/ConfigEditor.cs
@@ -179,7 +179,12 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
             Task.Run(LoadAsync).GetAwaiter().GetResult();
         }
 
-        public async Task Save(bool prettyPrint = true)
+        public void Save(bool prettyPrint = true)
+        {
+            config.Write(prettyPrint);
+        }
+
+        public async Task SaveAsync(bool prettyPrint = true)
         {
             await config.WriteAsync(prettyPrint);
         }

--- a/Assets/Plugins/Source/Editor/ConfigEditors/IConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/IConfigEditor.cs
@@ -61,12 +61,20 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         void Load();
 
         /// <summary>
-        /// Saves the configuration to disk.
+        /// Saves the configuration to disk synchronously.
+        /// </summary>
+        /// <param name="prettyPrint">
+        /// Whether to format the JSON in a more human-readable manner.
+        /// </param>
+        void Save(bool prettyPrint = true);
+
+        /// <summary>
+        /// Saves the configuration to disk asynchronously.
         /// </summary>
         /// <param name="prettyPrint">
         /// Whether or not to format the JSON in a more human-readable manner.
         /// </param>
-        Task Save(bool prettyPrint = true);
+        Task SaveAsync(bool prettyPrint = true);
 
         /// <summary>
         /// Render the editor for the configuration values.

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSPluginSettingsWindow.cs
@@ -155,7 +155,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         {
             foreach (var configurationSectionEditor in configEditors)
             {
-                configurationSectionEditor.Save();
+                configurationSectionEditor.SaveAsync();
             }
 
             AssetDatabase.SaveAssets();

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -173,7 +173,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             }
         }
 
-        private async void Save()
+        private void Save()
         {
             // Save the product config editor
             _productConfigEditor.Save();

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -42,7 +42,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     /// Creates the view for showing the eos plugin editor config values.
     /// </summary>
     [Serializable]
-    public class EOSSettingsWindow : EOSEditorWindow
+    public class NEW_EOSSettingsWindow : EOSEditorWindow
     {
         /// <summary>
         /// The editor for the product information that is shared across all
@@ -83,12 +83,12 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             fixedHeight = 40
         };
 
-        public EOSSettingsWindow() : base("EOS Configuration") { }
+        public NEW_EOSSettingsWindow() : base("EOS Configuration") { }
 
         [MenuItem("EOS Plugin/EOS Configuration", priority = 1)]
         public static void ShowWindow()
         {
-            var window = GetWindow<EOSSettingsWindow>();
+            var window = GetWindow<NEW_EOSSettingsWindow>();
             window.SetIsEmbedded(false);
         }
 
@@ -181,7 +181,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             // Save each of the platform config editors.
             foreach (IConfigEditor editor in _platformConfigEditors)
             {
-                await editor.SaveAsync();
+                editor.Save();
             }
         }
     }

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -42,7 +42,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     /// Creates the view for showing the eos plugin editor config values.
     /// </summary>
     [Serializable]
-    public class NEW_EOSSettingsWindow : EOSEditorWindow
+    public class EOSSettingsWindow : EOSEditorWindow
     {
         /// <summary>
         /// The editor for the product information that is shared across all
@@ -83,12 +83,12 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             fixedHeight = 40
         };
 
-        public NEW_EOSSettingsWindow() : base("EOS Configuration") { }
+        public EOSSettingsWindow() : base("EOS Configuration") { }
 
         [MenuItem("EOS Plugin/EOS Configuration", priority = 1)]
         public static void ShowWindow()
         {
-            var window = GetWindow<NEW_EOSSettingsWindow>();
+            var window = GetWindow<EOSSettingsWindow>();
             window.SetIsEmbedded(false);
         }
 
@@ -176,12 +176,12 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         private async void Save()
         {
             // Save the product config editor
-            await _productConfigEditor.Save();
+            _productConfigEditor.Save();
 
             // Save each of the platform config editors.
             foreach (IConfigEditor editor in _platformConfigEditors)
             {
-                await editor.Save();
+                await editor.SaveAsync();
             }
         }
     }

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow_DEPRECATED.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow_DEPRECATED.cs
@@ -204,7 +204,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
             foreach (var platformSpecificConfigEditor in platformSpecificConfigEditors)
             {
-                await platformSpecificConfigEditor.Save(usePrettyFormat);
+                await platformSpecificConfigEditor.SaveAsync(usePrettyFormat);
             }
 
 #if ALLOW_CREATION_OF_EOS_CONFIG_AS_C_FILE

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSUnitTestSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSUnitTestSettingsWindow.cs
@@ -57,7 +57,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests.Editor
 
             if (GUILayout.Button("Save", GUILayout.Width(100)))
             {
-                await _testConfigEditor.Save();
+                await _testConfigEditor.SaveAsync();
             }
         }
     }

--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -511,9 +511,12 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             try
             {
 #if NET_STANDARD_2_0
-                return await File.ReadAllTextAsync(path);
+                await using FileStream fileStream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using StreamReader reader = new(fileStream);
+                string content = await reader.ReadToEndAsync();
+                return content;
 #else
-                return await Task.Run(() => File.ReadAllText(path));
+                return await Task.Run(() => ReadAllText(path));
 #endif
             }
             catch (Exception e)
@@ -535,9 +538,13 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
 #else
             try
             {
-                return File.ReadAllText(path);
+                // Open the file with explicit FileStream and sharing options
+                using FileStream fileStream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using StreamReader reader = new(fileStream);
+                string content = reader.ReadToEnd();
+                return content;
             }
-            catch (Exception e)
+            catch (IOException e)
             {
                 Debug.LogException(e);
                 throw;


### PR DESCRIPTION
This PR addresses an issue with the release branch that can cause a bad race condition between asynchronous IO activity regarding the reading and writing of `eos_product_config.json`.

To reproduce the problem, open `EOSSettingsWindow` (via `EOS Plugin` -> `EOS Configuration`). Click the "+" button next to any of the `SetOfNamed` rendered input fields (Deployment, Client, or Sandbox), and pressing the "Save" button.

The solution was to make more explicit the name of the function that saves `ConfigEditor` classes asynchronously (it used to be `Save`, now it is `SaveAsync`, and switch `EOSSettingsWindow` to use the non-asynchronous method for each of the config editors it hosts.

As additional protection, the `ReadAllText` and `ReadAllTextAsync` functions were appropriately updated to make use of a `FileStream`, wherein FileAccess sharing can be specified.

It's possible that this means the `SaveAsync` method could be removed altogether - but it is still utilized effectively in other areas of the project, and its removal is beyond the scope of addressing the issue.

#EOS-2361