### PR TITLE
chore: Correct the name of `EOSSettingsWindow` to omit the `NEW_` prefix

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -42,7 +42,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     /// Creates the view for showing the eos plugin editor config values.
     /// </summary>
     [Serializable]
-    public class NEW_EOSSettingsWindow : EOSEditorWindow
+    public class EOSSettingsWindow : EOSEditorWindow
     {
         /// <summary>
         /// The editor for the product information that is shared across all
@@ -83,12 +83,12 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             fixedHeight = 40
         };
 
-        public NEW_EOSSettingsWindow() : base("EOS Configuration") { }
+        public EOSSettingsWindow() : base("EOS Configuration") { }
 
         [MenuItem("EOS Plugin/EOS Configuration", priority = 1)]
         public static void ShowWindow()
         {
-            var window = GetWindow<NEW_EOSSettingsWindow>();
+            var window = GetWindow<EOSSettingsWindow>();
             window.SetIsEmbedded(false);
         }
 


### PR DESCRIPTION
Somewhere in the process of revamping the configuration user experience renaming the actual class was a step that was overlooked. This PR corrects that oversight.

#EOS-2359