### PR TITLE
chore: Default to not show unavailable platforms in `EOSSettingsWindow`.

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -22,7 +22,7 @@
 
 // Uncomment the following line to see all platforms, even ones that are not
 // available
-#define DEBUG_SHOW_UNAVAILABLE_PLATFORMS
+//#define DEBUG_SHOW_UNAVAILABLE_PLATFORMS
 
 #if !EOS_DISABLE
 


### PR DESCRIPTION
During development of the changes to `EOSSettingsWindow` a compile conditional that was supposed to be turned off was errantly left on. This PR addresses that oversight.

The effect of this change is that (as originally designed) options for platforms that are unavailable to the user as build targets will be omitted from the settings window - reducing clutter and making the configuration more straightforward.

#EOS-2360