### PR TITLE
fix: Client Credential auto-selection

### DIFF
--- a/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/IPlatformConfigEditor.cs
@@ -36,6 +36,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
         /// </returns>
         bool IsPlatformAvailable();
 
+        void SetClientCredentials(EOSClientCredentials credentials);
+        
         void SetDeployment(Deployment deployment);
 
         PlatformManager.Platform GetPlatform();

--- a/Assets/Plugins/Source/Editor/ConfigEditors/PlatformConfigEditor.cs
+++ b/Assets/Plugins/Source/Editor/ConfigEditors/PlatformConfigEditor.cs
@@ -59,6 +59,11 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
             config.deployment = deployment;
         }
 
+        public void SetClientCredentials(EOSClientCredentials credentials)
+        {
+            config.clientCredentials = credentials;
+        }
+
         public PlatformManager.Platform GetPlatform()
         {
             return config.Platform;

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -97,11 +97,13 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         {
             base.OnEnable();
             ProductConfig.DeploymentsUpdatedEvent += ReloadDeploymentSettingsForPlatformConfigEditors;
+            ProductConfig.ClientCredentialsUpdatedEvent += ReloadClientCredentialsForPlatformConfigEditors;
         }
 
         protected override void OnDestroy()
         {
             ProductConfig.DeploymentsUpdatedEvent -= ReloadDeploymentSettingsForPlatformConfigEditors;
+            ProductConfig.ClientCredentialsUpdatedEvent -= ReloadClientCredentialsForPlatformConfigEditors;
             base.OnDestroy();
         }
 

--- a/com.playeveryware.eos/Runtime/Core/Config/ProductConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/ProductConfig.cs
@@ -296,7 +296,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 // If the config already has a completely defined set of client
                 // credentials, then do not override, and move to the next
                 // platform config.
-                if (config.clientCredentials.IsComplete)
+                if (config.clientCredentials != null && config.clientCredentials.IsComplete)
                 {
                     continue;
                 }

--- a/com.playeveryware.eos/Runtime/Core/Config/ProductConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/ProductConfig.cs
@@ -111,23 +111,36 @@ namespace PlayEveryWare.EpicOnlineServices
         private bool _deploymentDefinedWhenLoaded;
 
         /// <summary>
+        /// This field member is used to determine when client credentials are
+        /// first defined by the user. This determination is used to trigger the
+        /// process of setting the default deployment for the platforms.
+        /// </summary>
+        [JsonIgnore]
+        private bool _clientCredentialsDefinedWhenLoaded;
+
+        /// <summary>
         /// Used to store information about what platform configs have been
         /// updated.
+        /// TODO: Implement via the Observable pattern instead.
         /// </summary>
-        public sealed class PlatformConfigsDeploymentUpdatedEventArgs : EventArgs
+        public sealed class PlatformConfigsUpdatedEventArgs : EventArgs
         {
             /// <summary>
             /// A list of all the platform configs that have been updated.
             /// </summary>
             public readonly IEnumerable<PlatformManager.Platform> PlatformConfigsUpdated;
 
-            public PlatformConfigsDeploymentUpdatedEventArgs(IEnumerable<PlatformManager.Platform> platformConfigsUpdated)
+            public PlatformConfigsUpdatedEventArgs(
+                IEnumerable<PlatformManager.Platform> platformConfigsUpdated)
             {
                 PlatformConfigsUpdated = platformConfigsUpdated;
             }
         }
 
-        public static event EventHandler<PlatformConfigsDeploymentUpdatedEventArgs> PlatformConfigsDeploymentUpdatedEvent;
+        public static event EventHandler<PlatformConfigsUpdatedEventArgs> DeploymentsUpdatedEvent;
+
+        public static event EventHandler<PlatformConfigsUpdatedEventArgs>
+            ClientCredentialsUpdatedEvent;
 
         static ProductConfig()
         {
@@ -147,6 +160,27 @@ namespace PlayEveryWare.EpicOnlineServices
             // out parameter is discarded because it is not needed at this 
             // juncture.
             _deploymentDefinedWhenLoaded = Environments.TryGetFirstDefinedNamedDeployment(out _);
+
+            // This tracks whether there is a single client credential
+            // completely defined when the product config is loaded. The out
+            // parameter is discarded because it is not needed at this juncture.
+            _clientCredentialsDefinedWhenLoaded = TryGetFirstCompleteNamedClientCredentials(out _);
+        }
+
+        public bool TryGetFirstCompleteNamedClientCredentials(out Named<EOSClientCredentials> credentials)
+        {
+            credentials = null;
+
+            foreach (var clientCredentials in Clients)
+            {
+                if (clientCredentials.Value.IsComplete)
+                {
+                    credentials = clientCredentials;
+                    break;
+                }
+            }
+
+            return (credentials != null);
         }
 
         // This compile conditional is here because the OnWriteCompleted method
@@ -165,7 +199,13 @@ namespace PlayEveryWare.EpicOnlineServices
             }
         }
 
-        protected override void OnWriteCompleted()
+        // TODO: Refactor to reduce massive overlap between this function and
+        //       the more recently introduced
+        //       UpdatePlatformConfigClientCredentials function.
+        //       The Observable pattern would be appropriate - but such a change
+        //       would constitute a not insignificant refactor and should be
+        //       avoided until there is a time to properly review it.
+        private void UpdatePlatformConfigDeployments()
         {
             bool definedDeploymentExists =
                 Environments.TryGetFirstDefinedNamedDeployment(out Named<Deployment> deploymentToSetPlatformsTo);
@@ -173,7 +213,7 @@ namespace PlayEveryWare.EpicOnlineServices
             // If when the config was last read there was a deployment defined,
             // or there is not now one defined - then there is no need to try
             // and set the deployment values for each platform config.
-            if (_deploymentDefinedWhenLoaded || 
+            if (_deploymentDefinedWhenLoaded ||
                 !definedDeploymentExists)
             {
                 return;
@@ -217,8 +257,80 @@ namespace PlayEveryWare.EpicOnlineServices
             // the event that indicates as much
             if (platformConfigsUpdated.Count > 0)
             {
-                PlatformConfigsDeploymentUpdatedEvent?.Invoke(this, new PlatformConfigsDeploymentUpdatedEventArgs(platformConfigsUpdated));
+                DeploymentsUpdatedEvent?.Invoke(this, new PlatformConfigsUpdatedEventArgs(platformConfigsUpdated));
             }
+        }
+
+        // TODO: Refactor to reduce massive overlap between this function and
+        //       the older UpdatePlatformConfigDeployments function.
+        //       The Observable pattern would be appropriate - but such a change
+        //       would constitute a not insignificant refactor and should be
+        //       avoided until there is a time to properly review it.
+        private void UpdatePlatformConfigClientCredentials()
+        {
+            bool completeClientCredentialsExist =
+                TryGetFirstCompleteNamedClientCredentials(out Named<EOSClientCredentials> credentialsToSetPlatformsTo);
+
+            // If when the config was last read there was a set of client
+            // credentials already defined, or there is not now one defined -
+            // then there is no need to try and set the client credential values
+            // for each platform config.
+            if (_deploymentDefinedWhenLoaded ||
+                !completeClientCredentialsExist)
+            {
+                return;
+            }
+
+            List<PlatformManager.Platform> platformConfigsUpdated = new();
+
+            // For each platform for which configuration can be done
+            foreach (var platform in PlatformManager.ConfigurablePlatforms)
+            {
+                // If the PlatformConfig could not be retrieved, continue to the
+                // next.
+                if (!PlatformManager.TryGetConfig(platform, out PlatformConfig config))
+                {
+                    continue;
+                }
+
+                // If the config already has a completely defined set of client
+                // credentials, then do not override, and move to the next
+                // platform config.
+                if (config.clientCredentials.IsComplete)
+                {
+                    continue;
+                }
+
+                // Add to the list of platform configs that have been updated
+                platformConfigsUpdated.Add(platform);
+
+                // Set the client credentials.
+                config.clientCredentials = credentialsToSetPlatformsTo.Value;
+
+                // Tell the user
+                Debug.Log($"Client credentials for platform " +
+                          $"\"{config.Platform}\" has been defaulted to " +
+                          $"{credentialsToSetPlatformsTo}.");
+
+                // Save the config
+                config.Write();
+            }
+
+            // If at least one platform config was updated as a result, trigger
+            // the event that indicates as much
+            if (platformConfigsUpdated.Count > 0)
+            {
+                ClientCredentialsUpdatedEvent?.Invoke(this, new PlatformConfigsUpdatedEventArgs(platformConfigsUpdated));
+            }
+        }
+
+        protected override void OnWriteCompleted()
+        {
+            // Update the platform config deployments if needed.
+            UpdatePlatformConfigDeployments();
+
+            // Update the platform config client credentials if needed.
+            UpdatePlatformConfigClientCredentials();
         }
 
 #endif


### PR DESCRIPTION
This PR addresses an issue nearly identical to the previous PR - but instead of applying to first time users defining their first deployment and having that deployment selected for each platform - this does the same thing for the first time client credentials are defined.

Notes are heavily added to emphasize the importance of reducing the duplicated code that this introduces, and the intent is to have that refactor be part of the planning for a future release.

#EOS-2367