### PR TITLE
fix: Properly auto-select the platform targeted in settings

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -200,7 +200,6 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
                 if (newlySelectedTabIndex != _selectedTab)
                 {
                     _selectedTab = newlySelectedTabIndex;
-                    Debug.Log($"Selected config tab changed to {_selectedTab}.");
                 }
 
                 GUILayout.Space(30);

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -138,15 +138,15 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             int tabIndex = 0;
             foreach (PlatformManager.Platform platform in Enum.GetValues(typeof(PlatformManager.Platform)))
             {
-                // This makes sure that the currently selected tab (upon first loading the window) is always the current platform.
-                if (_selectedTab != -1 || platform == PlatformManager.CurrentPlatform)
-                {
-                    _selectedTab = tabIndex;
-                }
-
                 if (!PlatformManager.TryGetConfigType(platform, out Type configType) || null == configType)
                 {
                     continue;
+                }
+
+                // This makes sure that the currently selected tab (upon first loading the window) is always the current platform.
+                if (_selectedTab == -1 && platform == PlatformManager.CurrentTargetedPlatform)
+                {
+                    _selectedTab = tabIndex;
                 }
 
                 Type constructedType =
@@ -162,17 +162,15 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
                 // Do not add the platform if it is not currently available.
                 if (!editor.IsPlatformAvailable())
                 {
-                    // We only increment the tab index if the editor has been
-                    // added to the tabs.
-                    tabIndex++;
                     continue;
                 }
 #endif
 
+                tabIndex++;
+
                 _platformConfigEditors.Add(editor);
 
                 tabContents.Add(new GUIContent($" {editor.GetLabelText()}", editor.GetPlatformIconTexture()));
-
             }
 
             // If (for some reason) a default platform was not selected, then
@@ -197,7 +195,14 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
             if (_platformTabs != null && _platformConfigEditors.Count != 0)
             {
-                _selectedTab = GUILayout.Toolbar(_selectedTab, _platformTabs, TAB_STYLE);
+                var newlySelectedTabIndex = GUILayout.Toolbar(_selectedTab, _platformTabs, TAB_STYLE);
+
+                if (newlySelectedTabIndex != _selectedTab)
+                {
+                    _selectedTab = newlySelectedTabIndex;
+                    Debug.Log($"Selected config tab changed to {_selectedTab}.");
+                }
+
                 GUILayout.Space(30);
 
                 _ = _platformConfigEditors[_selectedTab].RenderAsync();

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -159,11 +159,41 @@ namespace PlayEveryWare.EpicOnlineServices
                 }
                 else
                 {
+                    // Note that s_CurrentPlatform is not set in this context - making sure it's only set once.
+                    // TODO: Investigate whether this has unintended consequences - where setting the value is
+                    //       expected.
                     Debug.Log($"CurrentPlatform has already been assigned as {GetFullName(s_CurrentPlatform)}.");
                 }
 
             }
         }
+
+        /// <summary>
+        /// Backing value for the CurrentTargetedPlatform property.
+        /// </summary>
+        private static Platform s_CurrentTargetedPlatform;
+
+        // This compile conditional is here because this property is only 
+        // meaningful in the context of the Unity Editor running.
+#if UNITY_EDITOR
+        /// <summary>
+        /// Used to indicate what platform is currently being targeted for
+        /// compilation. Used primarily to select the appropriate platform in
+        /// config editors.
+        /// </summary>
+        public static Platform CurrentTargetedPlatform
+        {
+            get
+            {
+                if (!TryGetPlatform(EditorUserBuildSettings.activeBuildTarget, out Platform targetedPlatform))
+                {
+                    return Platform.Unknown;
+                }
+
+                return targetedPlatform;
+            }
+        }
+#endif
 
         /// <summary>
         /// To be accessible to the platform manager, the static constructors 
@@ -205,15 +235,9 @@ namespace PlayEveryWare.EpicOnlineServices
 #if EXTERNAL_TO_UNITY
             CurrentPlatform = Platform.Windows;
 #else
-            // If the Unity Editor is currently running, then the "active"
-            // Platform is whatever the current build target is.
-#if UNITY_EDITOR
-            if (TryGetPlatform(EditorUserBuildSettings.activeBuildTarget, out Platform platform))
-#else
             // If the Unity editor is _not_ currently running, then the "active"
             // platform is whatever the runtime application says it is
             if (TryGetPlatform(Application.platform, out Platform platform))
-#endif
             {
                 CurrentPlatform = platform;
             }


### PR DESCRIPTION
This PR addresses a current issue in the release wherein the incorrect platform config editor is auto-selected. 

With these changes, whenever a user opens the EOS Configuration window (`EOS Plugin` -> `EOS Configuration`) the platform selected by default should be the platform that the user has currently selected as their active build target in Build Settings.

#EOS-2368