### PR TITLE
fix: Auto select deployment and client credentials for newly introduced platforms

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -235,12 +235,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 
             if (_platformTabs != null && _platformConfigEditors.Count != 0)
             {
-                var newlySelectedTabIndex = GUILayout.Toolbar(_selectedTab, _platformTabs, TAB_STYLE);
-
-                if (newlySelectedTabIndex != _selectedTab)
-                {
-                    _selectedTab = newlySelectedTabIndex;
-                }
+                _selectedTab = GUILayout.Toolbar(_selectedTab, _platformTabs, TAB_STYLE);
 
                 GUILayout.Space(30);
 

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -266,6 +266,46 @@ namespace PlayEveryWare.EpicOnlineServices
             Platform = platform;
         }
 
+        protected override void OnReadCompleted()
+        {
+            base.OnReadCompleted();
+
+            // If the deployment and client credentials are complete, there is
+            // nothing to do.
+            if (deployment.IsComplete && clientCredentials.IsComplete)
+            {
+                return;
+            }
+
+            ProductConfig productConfig = Get<ProductConfig>();
+            bool valuesImported = false;
+
+            if (!deployment.IsComplete && 
+                productConfig.Environments.TryGetFirstDefinedNamedDeployment(out Named<Deployment> namedDeployment))
+            {
+                deployment = namedDeployment.Value;
+                Debug.Log($"Platform {Platform} has no defined deployment, " +
+                          $"so one was selected: {namedDeployment}.");
+                valuesImported = true;
+            }
+
+            if (!clientCredentials.IsComplete &&
+                productConfig.TryGetFirstCompleteNamedClientCredentials(
+                    out Named<EOSClientCredentials> namedCredentials))
+            {
+                clientCredentials = namedCredentials.Value;
+                Debug.Log($"Platform {Platform} has no defined client " +
+                          $"credentials, so one was selected: " +
+                          $"{namedCredentials}.");
+                valuesImported = true;
+            }
+
+            if (valuesImported)
+            {
+                Write();
+            }
+        }
+
         #region Logic for Migrating Override Values from Previous Structure
 
         // This warning is suppressed because while EOSConfig is marked as 

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -272,7 +272,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
             // If the deployment and client credentials are complete, there is
             // nothing to do.
-            if (deployment.IsComplete && clientCredentials.IsComplete)
+            if (deployment.IsComplete && clientCredentials is { IsComplete: true })
             {
                 return;
             }
@@ -289,7 +289,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 valuesImported = true;
             }
 
-            if (!clientCredentials.IsComplete &&
+            if (clientCredentials is not { IsComplete: true } &&
                 productConfig.TryGetFirstCompleteNamedClientCredentials(
                     out Named<EOSClientCredentials> namedCredentials))
             {

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -300,10 +300,14 @@ namespace PlayEveryWare.EpicOnlineServices
                 valuesImported = true;
             }
 
+            // This compile conditional is here because writing configs to disk
+            // is only allowed within the context of the unity editor.
+#if UNITY_EDITOR
             if (valuesImported)
             {
                 Write();
             }
+#endif
         }
 
         #region Logic for Migrating Override Values from Previous Structure


### PR DESCRIPTION
This small PR includes a fix that was errantly omitted from a set of recently merged PRs

[PR that auto-selected deployment](https://github.com/PlayEveryWare/eos_plugin_for_unity/pull/1085)
[PR that auto-selected client credentials](https://github.com/PlayEveryWare/eos_plugin_for_unity/pull/1095) 

#EOS-2355
#EOS-2367