### PR TITLE
fix: `WrappedInitializeThreadAffinity` `null` case

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -266,6 +266,14 @@ namespace PlayEveryWare.EpicOnlineServices
             Platform = platform;
         }
 
+        protected override void OnReadCompleted()
+        {
+            base.OnReadCompleted();
+
+            // If thread affinity is null then instantiate it.
+            threadAffinity = new();
+        }
+
         #region Logic for Migrating Override Values from Previous Structure
 
         // This warning is suppressed because while EOSConfig is marked as 

--- a/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/PlatformConfig.cs
@@ -271,7 +271,7 @@ namespace PlayEveryWare.EpicOnlineServices
             base.OnReadCompleted();
 
             // If thread affinity is null then instantiate it.
-            threadAffinity = new();
+            threadAffinity ??= new();
         }
 
         #region Logic for Migrating Override Values from Previous Structure


### PR DESCRIPTION
This PR corrects an issue where after a new `PlatformConfig` is loaded `WrappedInitializeThreadAffinity` is null and subsequently errors in the config editor are generated.

The fix checks the value for null inside `OnReadComplete`, and if it is null, then a new instance is made. This works properly because `WrappedInitializeThreadAffinity` is a reference type that encloses a struct - so it is appropriate for it to have default values when first created.

#EOS-2369