### PR TITLE
fix: Complete application of command line arguments from the Epic Games Launcher

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/SandboxId.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/SandboxId.cs
@@ -101,6 +101,13 @@ namespace PlayEveryWare.EpicOnlineServices
             return IsNullOrEmpty(sandboxId._value);
         }
 
+        public static SandboxId FromString(string sandboxString)
+        {
+            SandboxId retVal = default;
+            retVal.Value = sandboxString;
+            return retVal;
+        }
+
         /// <summary>
         /// Indicates whether the sandbox id is empty. A sandbox id is empty if
         /// either the underlying value is null or empty, or if the underlying

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -78,7 +78,6 @@ namespace PlayEveryWare.EpicOnlineServices
     using Extensions;
     using System.Diagnostics;
     using System.Globalization;
-    using System.IO.Pipes;
     using UnityEngine.Assertions;
     using AddNotifyLoginStatusChangedOptions = Epic.OnlineServices.Auth.AddNotifyLoginStatusChangedOptions;
     using Credentials = Epic.OnlineServices.Auth.Credentials;

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -558,7 +558,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     //       on whether the Guid is a valid Guid. This
                     //       implementation has been written to provide
                     //       verisimilitude with the native implementation on
-                    //       Windows. Regardless - a warning is  logged here -
+                    //       Windows. Regardless - a warning is logged here -
                     //       despite the fact that it could be arguably be
                     //       logged as an error.
                     if (!Guid.TryParse(epicArgs.epicDeploymentID, out Guid deploymentFromCommandLine))

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -549,6 +549,7 @@ namespace PlayEveryWare.EpicOnlineServices
                         {
                             Debug.Log($"{namedDeployment} selected as deployment.");
                             deploymentDefined = true;
+                            break;
                         }
                     }
 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -491,11 +491,11 @@ namespace PlayEveryWare.EpicOnlineServices
                     });
             }
 
-            private void ConfigureCommandLineOptions()
+            private void ApplyCommandLineArguments()
             {
                 // TODO: Make more complete the support for command line arguments.
-                var epicArgs = GetCommandLineArgsFromEpicLauncher();
-
+                EpicLauncherArgs epicArgs = GetCommandLineArgsFromEpicLauncher();
+                
                 if (string.IsNullOrWhiteSpace(epicArgs.epicSandboxID))
                 {
                     return;
@@ -560,7 +560,7 @@ namespace PlayEveryWare.EpicOnlineServices
                 InitializeLogLevels();
 #endif
 
-                ConfigureCommandLineOptions();
+                ApplyCommandLineArguments();
 
                 Result initResult = InitializePlatformInterface();
 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -78,6 +78,7 @@ namespace PlayEveryWare.EpicOnlineServices
     using Extensions;
     using System.Diagnostics;
     using System.Globalization;
+    using System.IO.Pipes;
     using UnityEngine.Assertions;
     using AddNotifyLoginStatusChangedOptions = Epic.OnlineServices.Auth.AddNotifyLoginStatusChangedOptions;
     using Credentials = Epic.OnlineServices.Auth.Credentials;
@@ -491,40 +492,97 @@ namespace PlayEveryWare.EpicOnlineServices
                     });
             }
 
+            /// <summary>
+            /// This function applies any command line arguments that may have
+            /// been provided to the application from the Epic Games Launcher.
+            /// </summary>
             private void ApplyCommandLineArguments()
             {
-                // TODO: Make more complete the support for command line arguments.
                 EpicLauncherArgs epicArgs = GetCommandLineArgsFromEpicLauncher();
-                
-                if (string.IsNullOrWhiteSpace(epicArgs.epicSandboxID))
+
+                // If neither the sandbox id nor the deployment id have been specified on the command line, the application of the arguments can stop here.
+                if (string.IsNullOrEmpty(epicArgs.epicSandboxID) && string.IsNullOrEmpty(epicArgs.epicDeploymentID))
                 {
                     return;
                 }
 
-                var definedProductionEnvironments = Config.Get<ProductConfig>().Environments;
-                bool sandboxOverridden = false;
-                foreach (Named<SandboxId> sandbox in definedProductionEnvironments.Sandboxes)
+                ProductConfig productConfig = Config.Get<ProductConfig>();
+
+                if (!string.IsNullOrEmpty(epicArgs.epicSandboxID))
                 {
-                    if (sandbox.Value.ToString() != epicArgs.epicSandboxID.ToLower())
+                    bool sandboxDefined = false;
+                    SandboxId sandboxFromCommandLine = SandboxId.FromString(epicArgs.epicSandboxID);
+                    foreach (var namedSandbox in productConfig.Environments.Sandboxes)
                     {
-                        continue;
+                        if (namedSandbox.Value.Equals(sandboxFromCommandLine))
+                        {
+                            Debug.Log($"{namedSandbox} selected as sandbox.");
+                            sandboxDefined = true;
+                            break;
+                        }
                     }
 
-                    PlatformManager.GetPlatformConfig().deployment.SandboxId = sandbox.Value;
-                    sandboxOverridden = true;
-                    Debug.Log($"SandboxID was overridden to be \"{sandbox.Value}\" by a command line parameter.");
-                    break;
+                    PlatformManager.GetPlatformConfig().deployment.SandboxId = sandboxFromCommandLine;
+
+                    if (!sandboxDefined)
+                    {
+                        Debug.LogWarning(
+                            $"Sandbox Id \"{sandboxFromCommandLine}\" was " +
+                            $"provided on the command line, but was not " +
+                            $"found in the product config. Attempting to use " +
+                            $"it regardless.");
+                    }
                 }
 
-                if (!sandboxOverridden)
+                if (!string.IsNullOrEmpty(epicArgs.epicDeploymentID))
                 {
-                    Debug.LogWarning(
-                        $"The SandboxID " +
-                        $"\"{epicArgs.epicSandboxID}\" specified by " +
-                        $"command line argument is not a valid id. " +
-                        $"Defaulting to SandboxID " +
-                        $"\"{PlatformManager.GetPlatformConfig().deployment.SandboxId}\" " +
-                        $"defined in the configuration.");
+                    bool deploymentDefined = false;
+
+                    foreach (var namedDeployment in productConfig.Environments.Deployments)
+                    {
+                        // Check for equality regardless of case - and
+                        // regardless of whether the dashes are included in the
+                        // Guid for the purposes of comparison.
+                        if (namedDeployment.Value.DeploymentId.ToString().Equals(epicArgs.epicDeploymentID,
+                                StringComparison.OrdinalIgnoreCase) ||
+                            namedDeployment.Value.DeploymentId.ToString("N").Equals(epicArgs.epicDeploymentID,
+                                StringComparison.OrdinalIgnoreCase))
+                        {
+                            Debug.Log($"{namedDeployment} selected as deployment.");
+                            deploymentDefined = true;
+                        }
+                    }
+
+                    // NOTE: An empty guid is known to cause the EOS SDK to fail
+                    //       to initialize - however in the native code when
+                    //       this same operation is done, no check is performed
+                    //       on whether the Guid is a valid Guid. This
+                    //       implementation has been written to provide
+                    //       verisimilitude with the native implementation on
+                    //       Windows. Regardless - a warning is  logged here -
+                    //       despite the fact that it could be arguably be
+                    //       logged as an error.
+                    if (!Guid.TryParse(epicArgs.epicDeploymentID, out Guid deploymentFromCommandLine))
+                    {
+                        Debug.LogWarning(
+                            $"ERROR: Invalid Guid " +
+                            $"\"{epicArgs.epicDeploymentID}\" for Deployment " +
+                            $"Id was provided on the command line. EOS SDK " +
+                            $"will almost certainly fail to initialize.");
+
+                        deploymentFromCommandLine = Guid.Empty;
+                    }
+
+                    PlatformManager.GetPlatformConfig().deployment.DeploymentId = deploymentFromCommandLine;
+
+                    if (!deploymentFromCommandLine.Equals(Guid.Empty) && !deploymentDefined)
+                    {
+                        Debug.LogWarning(
+                            $"Deployment \"{deploymentFromCommandLine}\" was " +
+                            $"provided on the command line, but was not " +
+                            $"found in the product config. Attempting to use " +
+                            $"it regardless.");
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR completes the implementation of the application of deployment and sandbox values from the Epic Games Launcher.

Prior to this fix, only the sandbox would be applied - and only if the sandbox was also defined in `ProductConfig`.

#EOS-2371