### PR TITLE
fix: IFDEF moved so that Android contains `ReadAllText`

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/FileSystemUtility.cs
@@ -504,6 +504,7 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
                 throw;
             }
         }
+#endif
 
         /// <summary>
         /// Reads all text from the indicated file.
@@ -530,7 +531,6 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
             }
 #endif
         }
-#endif
 
         #endregion
 


### PR DESCRIPTION
FileSystemUtility excluded Android for access to `ReadAllText`. This breaks building for Android in `player` mode, so the ifdef was moved to include `ReadAllText`.