### PR TITLE
fix: Smarter Enum Conversion

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Common/Utility/EnumUtility.cs
+++ b/com.playeveryware.eos/Runtime/Core/Common/Utility/EnumUtility.cs
@@ -248,23 +248,45 @@ namespace PlayEveryWare.EpicOnlineServices.Utility
         /// Gets the lowest value in an enum type.
         /// </summary>
         /// <returns>
-        /// The lowest type within an enum. If the enum is empty, default is
-        /// returned.
+        /// The lowest value within an enum. If the enum is empty, default is returned.
         /// </returns>
         public static TEnum GetLowest()
         {
-            object lowest = null;
+            return GetExtreme((current, extreme) => Comparer<object>.Default.Compare(current, extreme) < 0);
+        }
+
+        /// <summary>
+        /// Gets the highest value in an enum type.
+        /// </summary>
+        /// <returns>
+        /// The highest value within an enum. If the enum is empty, default is returned.
+        /// </returns>
+        public static TEnum GetHighest()
+        {
+            return GetExtreme((current, extreme) => Comparer<object>.Default.Compare(current, extreme) > 0);
+        }
+
+        /// <summary>
+        /// Private helper method to determine the extreme (lowest or highest) value in an enum.
+        /// </summary>
+        /// <param name="comparison">A comparison delegate to determine the extreme value.</param>
+        /// <returns>
+        /// The extreme value within an enum. If the enum is empty, default is returned.
+        /// </returns>
+        private static TEnum GetExtreme(Func<object, object, bool> comparison)
+        {
+            object extreme = null;
             foreach (var value in Enum.GetValues(typeof(TEnum)))
             {
-                if (lowest == null || Comparer<object>.Default.Compare(value, lowest) < 0)
+                if (extreme == null || comparison(value, extreme))
                 {
-                    lowest = value;
+                    extreme = value;
                 }
             }
 
-            if (lowest != null)
+            if (extreme != null)
             {
-                return (TEnum)Enum.ToObject(typeof(TEnum), lowest);
+                return (TEnum)Enum.ToObject(typeof(TEnum), extreme);
             }
 
             return default;

--- a/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
@@ -192,19 +192,20 @@ namespace PlayEveryWare.EpicOnlineServices
             object lowestUnderlyingValue = Convert.ChangeType(lowestEnumValue, underlyingType);
             object highestUnderlyingValue = Convert.ChangeType(highestEnumValue, underlyingType);
 
+            TEnum finalEnumValue;
+
             // Ensure value is within range
-            if (Comparer<object>.Default.Compare(value, lowestUnderlyingValue) < 0)
+            if (Comparer<object>.Default.Compare(value, lowestUnderlyingValue) < 0 || Comparer<object>.Default.Compare(value, highestUnderlyingValue) > 0)
             {
-                UnityEngine.Debug.LogWarning($"Value {value} is out of range for {nameof(TEnum)}, setting to lowest value in enum \"{lowestEnumValue}\".");
-                value = lowestUnderlyingValue;
+                UnityEngine.Debug.LogWarning($"Value {value} is out of range for {nameof(TEnum)}, setting to 0.");
+                finalEnumValue = (TEnum)Enum.ToObject(typeof(TEnum), 0);
             }
-            else if (Comparer<object>.Default.Compare(value, highestUnderlyingValue) > 0)
+            else
             {
-                UnityEngine.Debug.LogWarning($"Value {value} is out of range for {nameof(TEnum)}, setting to highest value in enum \"{highestEnumValue}\".");
-                value = highestUnderlyingValue;
+                finalEnumValue = (TEnum)value;
             }
 
-            return (TEnum)Enum.ToObject(typeof(TEnum), value);
+            return finalEnumValue;
         }
 
         /// <summary>

--- a/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
@@ -36,6 +36,7 @@ namespace PlayEveryWare.EpicOnlineServices
     using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using Utility;
 
     // This compile conditional is here so that when EOS is disabled, nothing is
@@ -184,15 +185,26 @@ namespace PlayEveryWare.EpicOnlineServices
             Type underlyingType = Enum.GetUnderlyingType(typeof(TEnum));
             object value = Convert.ChangeType(token, underlyingType);
 
+            // Get the lowest and highest values
             TEnum lowestEnumValue = EnumUtility<TEnum>.GetLowest();
-            object lowestUnderlyingValue = Convert.ChangeType(lowestEnumValue, underlyingType);
+            TEnum highestEnumValue = EnumUtility<TEnum>.GetHighest();
 
+            object lowestUnderlyingValue = Convert.ChangeType(lowestEnumValue, underlyingType);
+            object highestUnderlyingValue = Convert.ChangeType(highestEnumValue, underlyingType);
+
+            // Ensure value is within range
             if (Comparer<object>.Default.Compare(value, lowestUnderlyingValue) < 0)
             {
+                UnityEngine.Debug.LogWarning($"Value {value} is out of range for {nameof(TEnum)}, setting to lowest value in enum \"{lowestEnumValue}\".");
                 value = lowestUnderlyingValue;
             }
+            else if (Comparer<object>.Default.Compare(value, highestUnderlyingValue) > 0)
+            {
+                UnityEngine.Debug.LogWarning($"Value {value} is out of range for {nameof(TEnum)}, setting to highest value in enum \"{highestEnumValue}\".");
+                value = highestUnderlyingValue;
+            }
 
-            return (TEnum)value;
+            return (TEnum)Enum.ToObject(typeof(TEnum), value);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR improves the way in which a number value is cast into an `enum` type via `EnumUtility`.

Currently, when an attempt is made to convert a value that does not correspond to a _named value_ within the `enum`, the lowest value in the `enum` is selected.

This change checks not just for if the value is out of range by being too low, but also checking for if the value is out of range by being too high. If either is the case, then instead of selecting the highest or lowest value accordingly, a value of 0 is selected.

Despite not _necessarily_ being a _named value_ within an `enum`, `0` is _always_ a valid value for any `enum`, and is used to indicate a value that is **not set**.

#EOS-2381