### PR TITLE
fix(macos): ensure that the Info.plist and the CodeResources are always

### DIFF
--- a/etc/PlatformSpecificAssets/EOS/Mac/.gitattributes
+++ b/etc/PlatformSpecificAssets/EOS/Mac/.gitattributes
@@ -1,0 +1,4 @@
+text eol=lf
+Info.plist text
+CodeResources text
+


### PR DESCRIPTION
This change makes sure that both the Info.plist and the CodeResources files are unix style line endings, so that it won't break code signing.