### PR TITLE
fix: Properly conditionally compile things for ManagedPluginCode proj…

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/Config/Config.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/Config.cs
@@ -669,11 +669,12 @@ namespace PlayEveryWare.EpicOnlineServices
             return thisMembers.SequenceEqual(otherMembers);
         }
 
+#if !EXTERNAL_TO_UNITY
         public override int GetHashCode()
         {
             return HashCode.Combine(IteratePropertiesAndFields(this));
         }
-
+#endif
         public static bool operator ==(Config left, Config right)
         {
             if (ReferenceEquals(left, right))
@@ -694,7 +695,7 @@ namespace PlayEveryWare.EpicOnlineServices
             return !(left == right);
         }
 
-        #endregion
+#endregion
 
         #region Reflection utility functions
 
@@ -753,12 +754,15 @@ namespace PlayEveryWare.EpicOnlineServices
                 return a.MemberValue == b.MemberValue;
             }
 
+#if !EXTERNAL_TO_UNITY
             public int GetHashCode(MemberInfo memberInfo)
             {
                 return HashCode.Combine(
                     memberInfo.MemberType,
                     memberInfo.MemberValue);
             }
+#endif
+
         }
 
         /// <summary>
@@ -806,7 +810,7 @@ namespace PlayEveryWare.EpicOnlineServices
             }
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/JsonConverter/ListOfStringsToEnumConverters.cs
@@ -197,7 +197,9 @@ namespace PlayEveryWare.EpicOnlineServices
             // Ensure value is within range
             if (Comparer<object>.Default.Compare(value, lowestUnderlyingValue) < 0 || Comparer<object>.Default.Compare(value, highestUnderlyingValue) > 0)
             {
+#if !EXTERNAL_TO_UNITY
                 UnityEngine.Debug.LogWarning($"Value {value} is out of range for {nameof(TEnum)}, setting to 0.");
+#endif
                 finalEnumValue = (TEnum)Enum.ToObject(typeof(TEnum), 0);
             }
             else

--- a/com.playeveryware.eos/Runtime/Core/Config/ProductConfig.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/ProductConfig.cs
@@ -146,10 +146,18 @@ namespace PlayEveryWare.EpicOnlineServices
             }
         }
 
+#if EXTERNAL_TO_UNITY
+#pragma warning disable CS0067
+#endif
+
         public static event EventHandler<PlatformConfigsUpdatedEventArgs> DeploymentsUpdatedEvent;
 
         public static event EventHandler<PlatformConfigsUpdatedEventArgs>
             ClientCredentialsUpdatedEvent;
+
+#if EXTERNAL_TO_UNITY
+#pragma warning restore CS0067
+#endif
 
         static ProductConfig()
         {

--- a/com.playeveryware.eos/Runtime/Core/Config/SandboxId.cs
+++ b/com.playeveryware.eos/Runtime/Core/Config/SandboxId.cs
@@ -77,8 +77,10 @@ namespace PlayEveryWare.EpicOnlineServices
                     logMessage += $"Restoring to previous value of \"{previousValue}\".";
                 }
 
+#if !EXTERNAL_TO_UNITY
                 // Actually log the composed message.
                 UnityEngine.Debug.LogWarning(logMessage);
+#endif
 
                 _value = previousValue;
             }

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedPluginCode/ManagedPluginCode.csproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/ManagedPluginCode/ManagedPluginCode.csproj
@@ -98,26 +98,35 @@
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\ExpandFieldAttribute.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\ExpandFieldAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\FieldValidator.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\FieldValidator.cs</Link>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\FieldValidator.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\FieldValidator.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\FieldValidatorAttribute.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\FieldValidatorAttribute.cs</Link>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\FieldValidatorAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\FieldValidatorAttribute.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\FilePathFieldAttribute.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\FilePathFieldAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\GUIDFieldValidatorAttribute.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\GUIDFieldValidatorAttribute.cs</Link>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\GUIDFieldValidatorAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\GUIDFieldValidatorAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\NonEmptyStringFieldValidatorAttribute.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\NonEmptyStringFieldValidatorAttribute.cs</Link>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\LengthValidationAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\LengthValidationAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\RegexValidationAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\RegexValidationAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\StringValidationAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\StringValidationAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\NonEmptyStringFieldValidatorAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\NonEmptyStringFieldValidatorAttribute.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\PlatformDependentConfigFieldAttribute.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\PlatformDependentConfigFieldAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\SandboxIDFieldValidatorAttribute.cs">
-      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\SandboxIDFieldValidatorAttribute.cs</Link>
+    <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\SandboxIDFieldValidatorAttribute.cs">
+      <Link>com.playeveryware.eos\Runtime\Core\Config\Attributes\Validators\SandboxIDFieldValidatorAttribute.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\com.playeveryware.eos\Runtime\Core\Config\Config.cs">
       <Link>com.playeveryware.eos\Runtime\Core\Config\Config.cs</Link>


### PR DESCRIPTION
This PR restores the ability to compile the `ManagedPluginCode` project, which primarily was not compiling because some files were moved within the Unity project.