### PR TITLE
Correct the usage of `EOS_DISABLE`

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/BatchBuilder.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/BatchBuilder.cs
@@ -20,6 +20,8 @@
 * SOFTWARE.
 */
 
+#if !EOS_DISABLE
+
 using UnityEngine;
 using UnityEditor;
 
@@ -258,3 +260,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/Source/Editor/EditorWindows/EncryptionKeyWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EncryptionKeyWindow.cs
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 {
     using PlayEveryWare.EpicOnlineServices.Editor.Utility;
@@ -78,3 +80,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
     }
 
 }
+
+#endif

--- a/Assets/Plugins/Source/Editor/EditorWindows/ModalEOSEditorWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/ModalEOSEditorWindow.cs
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#if !EOS_DISABLE
 
 namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 {
@@ -243,3 +244,5 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         }
     }
 }
+
+#endif

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -1946,14 +1946,8 @@ namespace PlayEveryWare.EpicOnlineServices
                 EOSSingleton.Log($"{nameof(EOSManager)} ({nameof(OnApplicationQuitting)}): Application is quitting. {nameof(ShouldShutdownOnApplicationQuit)} is false, so this manager will not shut down the EOS SDK.");
             }
         }
-#endif
 
-        //-------------------------------------------------------------------------
-        void IEOSCoroutineOwner.StartCoroutine(IEnumerator routine)
-        {
-            base.StartCoroutine(routine);
-        }
-
+        
         /// <summary>
         /// Enqueues an Action to be executed on the main thread.
         /// </summary>
@@ -1993,6 +1987,13 @@ namespace PlayEveryWare.EpicOnlineServices
             {
                 action.Invoke();
             }
+        }
+#endif
+
+        //-------------------------------------------------------------------------
+        void IEOSCoroutineOwner.StartCoroutine(IEnumerator routine)
+        {
+            base.StartCoroutine(routine);
         }
     }
 }


### PR DESCRIPTION
This PR corrects the usage of the `EOS_DISABLE` scripting define. 

When `EOS_DISABLE` is defined currently, it leads to compilation errors. This change corrects that.

Resolves issue #1137 