### PR TITLE
Use `await Task.FromResult(false)` when not within Unity Editor on Windows

### DIFF
--- a/Assets/Plugins/Source/Editor/Utility/SigningUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/SigningUtility.cs
@@ -66,7 +66,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor
                 return false;
             }
 #else
-            return false;
+            return await Task.FromResult(false);
 #endif
         }
 


### PR DESCRIPTION
Currently on non-windows versions of the editor, a function marked `async` returns `false` without containing an `await` call, which generates a compiler warning. 

This PR resolves that issue by replacing the `return false;` statement with the following:

```c#
await Task.FromResult(false);
```