### PR TITLE
Fix: update outdated git repository URL in documentation

### DIFF
--- a/com.playeveryware.eos/CHANGELOG.md
+++ b/com.playeveryware.eos/CHANGELOG.md
@@ -297,7 +297,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced support for `StatsManager` and async operations.
 - Implemented deployment overrides with `-epicdeploymentid` argument.
 
-**Full Changelog**: https://github.com/PlayEveryWare/eos_plugin_for_unity/compare/v3.2.1...v3.3.0
+**Full Changelog**: https://github.com/EOS-Contrib/eos_plugin_for_unity/compare/v3.2.1...v3.3.0
 
 # [3.2.1] - 2024-06-24
 

--- a/com.playeveryware.eos/Documentation~/add_plugin.md
+++ b/com.playeveryware.eos/Documentation~/add_plugin.md
@@ -25,7 +25,7 @@ The following document outlines the two methods with which you can add the plugi
 
 ## Adding the package from a tarball
 
-1. Download the latest release UPM tarball, `"com.playeveryware.eos-[version].tgz"` ([Releases](https://github.com/PlayEveryWare/eos_plugin_for_unity/releases)).
+1. Download the latest release UPM tarball, `"com.playeveryware.eos-[version].tgz"` ([Releases](https://github.com/EOS-Contrib/eos_plugin_for_unity/releases)).
 
     > [!WARNING]
     > Do *not* attempt to create a tarball yourself from the source, unless you know what you are doing with respect to [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/configuring-git-large-file-storage).

--- a/com.playeveryware.eos/Documentation~/add_plugin.md
+++ b/com.playeveryware.eos/Documentation~/add_plugin.md
@@ -16,7 +16,7 @@ The following document outlines the two methods with which you can add the plugi
     ![Unity Add Git Package](/com.playeveryware.eos/Documentation~/images/unity_package_git.gif)
 
 4. Select `Add Package from Git URL`.
-6. Paste in `git@github.com:PlayEveryWare/eos_plugin_for_unity_upm.git`.
+6. Paste in `git@github.com:EOS-Contrib/eos_plugin_for_unity_upm.git`.
 7. After the package has finished installing, [import the samples](/com.playeveryware.eos/Documentation~/samples.md).
 8. Finally, [Configure the Plugin](/com.playeveryware.eos/Documentation~/configure_plugin.md).
 

--- a/com.playeveryware.eos/Documentation~/configure_plugin.md
+++ b/com.playeveryware.eos/Documentation~/configure_plugin.md
@@ -47,4 +47,4 @@ Either:
 - Attach `EOSManager.cs (Script)` to a Unity object, and it will initialize the plugin with the specified configuration in `OnAwake()` (this is what `Singletons.prefab` does).
 
 > [!NOTE]
-> The included [samples](http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#samples) already have configuration values set for you to experiment with!
+> The included [samples](http://github.com/EOS-Contrib/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#samples) already have configuration values set for you to experiment with!

--- a/com.playeveryware.eos/Documentation~/dev_env/Ubuntu_Development_Environment.md
+++ b/com.playeveryware.eos/Documentation~/dev_env/Ubuntu_Development_Environment.md
@@ -75,7 +75,7 @@ It is important that you have the latest version of `git` installed, so that you
 > Simply installing `git` via apt is not sufficient.
 
 ```bash
-git clone git@github.com:PlayEveryWare/eos_plugin_for_unity_restricted
+git clone git@github.com:EOS-Contrib/eos_plugin_for_unity_restricted
 ```
 
 It is important that you follow the command format above instead of using something like [`https://github.com`](https://github.com), because it will otherwise fail. The format guarantees that the SSH protocol is used.

--- a/com.playeveryware.eos/Documentation~/frequently_asked_questions.md
+++ b/com.playeveryware.eos/Documentation~/frequently_asked_questions.md
@@ -26,7 +26,7 @@
 ## Why does the plugin fail to work after changing configuration?
 
 To rerun in UnityEditor without rebooting, we must reload the EOS SDK dll between runs.  
-To find out why and how to do so look see our documentation on [Unity Specific aspects of implementing EOS](https://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/Documentation~/unity_specific.md).
+To find out why and how to do so look see our documentation on [Unity Specific aspects of implementing EOS](https://github.com/EOS-Contrib/eos_plugin_for_unity/blob/development/com.playeveryware.eos/Documentation~/unity_specific.md).
 
 ## How do I override sandbox or deployment IDs when publishing on the Epic Games Store?
 
@@ -124,7 +124,7 @@ Which mainly happens when adding the UPM `via git url`
 To fix this you may do one of the following:
 
 - Initialize git lfs on the package folder (from a command window `git lfs install`).
-- Add the UPM `via tarball` downloaded the [releases](https://github.com/PlayEveryWare/eos_plugin_for_unity/releases) on GitHub instead.
+- Add the UPM `via tarball` downloaded the [releases](https://github.com/EOS-Contrib/eos_plugin_for_unity/releases) on GitHub instead.
 
 ## Why am I getting Overlay Errors?
 Overlay errors are most likely due to not having the overlay installed, this is done in two steps:

--- a/com.playeveryware.eos/Documentation~/getting_started_guide/README.md
+++ b/com.playeveryware.eos/Documentation~/getting_started_guide/README.md
@@ -158,7 +158,7 @@ For more information on the use of the Encryption Key, see [Epic's documentation
 ## Starting to Use the Samples
 
 At this moment your game is set up to utilize the EOS Plugin for Unity.
-The samples are documented [in the EOS Plugin for Unity Walkthrough documentation](https://github.com/PlayEveryWare/eos_plugin_for_unity/blob/stable/com.playeveryware.eos/Documentation~/Walkthrough.md), which leads to individual Scene walk throughs.
+The samples are documented [in the EOS Plugin for Unity Walkthrough documentation](https://github.com/EOS-Contrib/eos_plugin_for_unity/blob/stable/com.playeveryware.eos/Documentation~/Walkthrough.md), which leads to individual Scene walk throughs.
 Assuming your Client Policy is set up to be permissive, consider validating the plugin inclusion by using [the Lobbies Sample](/com.playeveryware.eos/Documentation~/scene_walkthrough/lobbies_walkthrough.md).
 Open the Lobbies sample in the scene, and start running the game. Note if there are any errors in the logs from the EOS SDK Plugin.
 

--- a/com.playeveryware.eos/Documentation~/player_authentication.md
+++ b/com.playeveryware.eos/Documentation~/player_authentication.md
@@ -30,11 +30,11 @@ For information on how to authenticate a user via Apple, check out our [Apple Si
 * Auth Login functions are declared in EOS Auth Interface
 * **Account Portal** (`EOS_LCT_AccountPortal`) and **Persistent Auth** (`EOS_LCT_PersistentAuth`) are the primary Auth Types (`LoginCredentialType`) to login  
   * **Persistent Auth** will login with credentials of the previous successful **Account Portal** login
-* **Dev Auth**(`EOS_LCT_Developer`) is for quick iteration for developers, which could be done by using the Dev-Auth tool provided with the EOS SDK. Read [this](https://github.com/PlayEveryWare/eos_plugin_for_unity/tree/development/com.playeveryware.eos/Documentation~/Walkthrough.md) for details
+* **Dev Auth**(`EOS_LCT_Developer`) is for quick iteration for developers, which could be done by using the Dev-Auth tool provided with the EOS SDK. Read [this](https://github.com/EOS-Contrib/eos_plugin_for_unity/tree/development/com.playeveryware.eos/Documentation~/Walkthrough.md) for details
 * **External Auth** is currently only for Steam session ticket login on these platforms
 * **Exchange Code** is for logging in on Epic Game Store deployments
 
-A list of which `LoginCredentialType` to use on which platform could be found in our documentation here: [Login Type by Platform](https://github.com/PlayEveryWare/eos_plugin_for_unity/tree/development/com.playeveryware.eos/Documentation~/login_type_by_platform.md)
+A list of which `LoginCredentialType` to use on which platform could be found in our documentation here: [Login Type by Platform](https://github.com/EOS-Contrib/eos_plugin_for_unity/tree/development/com.playeveryware.eos/Documentation~/login_type_by_platform.md)
 
 ### Connect Login
 

--- a/com.playeveryware.eos/Documentation~/samples.md
+++ b/com.playeveryware.eos/Documentation~/samples.md
@@ -34,7 +34,7 @@ The included samples show examples of fully functional [feature implementations]
 ## Running the samples
 
 > [!IMPORTANT]
-> The plugin must be <a href="/com.playeveryware.eos/Documentation~/configure_plugin.md">configured</a> for samples to be functional. Some Samples may not be accessible if the extra packs were not <a href="http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/com.playeveryware.eos/README.md#importing-samples">imported</a>.
+> The plugin must be <a href="/com.playeveryware.eos/Documentation~/configure_plugin.md">configured</a> for samples to be functional. Some Samples may not be accessible if the extra packs were not <a href="http://github.com/EOS-Contrib/eos_plugin_for_unity/blob/development/com.playeveryware.eos/com.playeveryware.eos/README.md#importing-samples">imported</a>.
 
 Checkout our [Sample Walkthroughs](/com.playeveryware.eos/Documentation~/Walkthrough.md) for a scene-by-scene walkthrough of each sample.
 
@@ -65,7 +65,7 @@ Checkout our [Sample Walkthroughs](/com.playeveryware.eos/Documentation~/Walkthr
 <br />
 
   > [!NOTE] 
-  > Check the [Prerequisites](http://github.com/PlayEveryWare/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#prerequisites) as there may be specific requirements for a player's computer.
+  > Check the [Prerequisites](http://github.com/EOS-Contrib/eos_plugin_for_unity/blob/development/com.playeveryware.eos/README.md#prerequisites) as there may be specific requirements for a player's computer.
   > For instance, Windows requires the players to have `The latest Microsoft Visual C++ Redistributable` installed on their computer in order to play any distributed builds.
 
   1. In the Unity editor menu bar, open `File -> Build Settings`.

--- a/com.playeveryware.eos/README.md
+++ b/com.playeveryware.eos/README.md
@@ -16,7 +16,7 @@
 
 The PlayEveryWare EOS Plugin for Unity brings the free services from Epic that connect players across all platforms and all stores to Unity in an easy-to-use package. Find more information on what services Epic Online Services encompasses, see here: [https://dev.epicgames.com/en-US/services](https://dev.epicgames.com/en-US/services) and to read the developer documentation on those services, see here: [https://dev.epicgames.com/docs/epic-online-services](https://dev.epicgames.com/docs/epic-online-services).
 
-This repository contains the source code for development and serves as a destination for support for the [PlayEveryWare EOS Plugin for Unity (UPM Package)](https://github.com/PlayEveryWare/eos_plugin_for_unity_upm).
+This repository contains the source code for development and serves as a destination for support for the [PlayEveryWare EOS Plugin for Unity (UPM Package)](https://github.com/EOS-Contrib/eos_plugin_for_unity_upm).
 
 Out of the box, this project demonstrates (through a collection of sample scenes) each feature of the Epic Online Services SDK[^1]. The sample scenes (coupled with accompanying documentation) can be used to get an idea of how you can implement all the online features you want in your game!
 
@@ -111,7 +111,7 @@ Once imported into your project, be sure to [Configure the Plugin](/com.playever
 
 PlayEveryWare EOS Plugin for Unity documentation can be found here on GitHub.
 
-For issues related to integration or usage of the EOS Unity plugin, please create a `New Issue` under the [Issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) tab.
+For issues related to integration or usage of the EOS Unity plugin, please create a `New Issue` under the [Issues](https://github.com/EOS-Contrib/eos_plugin_for_unity/issues) tab.
 
 For issues related to Epic Online Services SDK, Epic Dev Portal or for general EOS SDK information, see the [Epic Online Services Community Support](https://eoshelp.epicgames.com/).
 
@@ -119,7 +119,7 @@ Detailed descriptions and usage for EOS SDK Interfaces can be found on [Epic's d
 
 For issues of a confidential nature (for instance for support using this Plugin on restricted console platforms), please reach out to us directly at [eos-support@playeveryware.com](mailto:playeos-support@playeveryware.com).
 
-If it is _at all_ unclear to you where to go for support - do not hesitate to open a `New Issue` under the [Issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) tab, and we will make certain that you are properly (and promptly) assisted :)
+If it is _at all_ unclear to you where to go for support - do not hesitate to open a `New Issue` under the [Issues](https://github.com/EOS-Contrib/eos_plugin_for_unity/issues) tab, and we will make certain that you are properly (and promptly) assisted :)
 
 # Contributor Notes
 
@@ -135,4 +135,4 @@ For issues of API Level compatibility, please read our [document](/com.playevery
 
 For more FAQs see [Frequently Asked Questions](/com.playeveryware.eos/Documentation~/frequently_asked_questions.md).
 
-If you have any outstanding questions, please bring them up in the [Discussions](https://github.com/PlayEveryWare/eos_plugin_for_unity/discussions) tab.
+If you have any outstanding questions, please bring them up in the [Discussions](https://github.com/EOS-Contrib/eos_plugin_for_unity/discussions) tab.

--- a/etc/docfx/index.md
+++ b/etc/docfx/index.md
@@ -1,9 +1,9 @@
 # Epic Online Services Plugin for Unity (UPM package)
 
 ## Overview
-The [eos_plugin_for_unity_upm repository](https://github.com/PlayEveryWare/eos_plugin_for_unity_upm) contains a Unity Package Manager (UPM) plugin for enabling the use of the [Epic Online Services (EOS)](https://dev.epicgames.com/docs/services/en-US/GameServices/Overview/index.html) [C# SDK](https://dev.epicgames.com/docs/services/en-US/GameServices/CSharpGettingStarted/index.html) in Unity.
+The [eos_plugin_for_unity_upm repository](https://github.com/EOS-Contrib/eos_plugin_for_unity_upm) contains a Unity Package Manager (UPM) plugin for enabling the use of the [Epic Online Services (EOS)](https://dev.epicgames.com/docs/services/en-US/GameServices/Overview/index.html) [C# SDK](https://dev.epicgames.com/docs/services/en-US/GameServices/CSharpGettingStarted/index.html) in Unity.
 
-For [support issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) or contributing to this open source project, head over to the [source repository](https://github.com/PlayEveryWare/eos_plugin_for_unity).
+For [support issues](https://github.com/EOS-Contrib/eos_plugin_for_unity/issues) or contributing to this open source project, head over to the [source repository](https://github.com/PlayEveryWare/eos_plugin_for_unity).
 
 ## Highlights
 * Unity GUI tool for configuring EOS product settings, saved out to a JSON file.
@@ -76,12 +76,12 @@ Ensure you have property setup Unity for [Git Dependency](https://docs.unity3d.c
 
     ![Unity Add Git Package](images/unity_package_git.gif)
 
-6. Paste in ```git@github.com:PlayEveryWare/eos_plugin_for_unity_upm.git```
-   or ```https://github.com/PlayEveryWare/eos_plugin_for_unity_upm.git```.
+6. Paste in ```git@github.com:EOS-Contrib/eos_plugin_for_unity_upm.git```
+   or ```https://github.com/EOS-Contrib/eos_plugin_for_unity_upm.git```.
 
 
 ## Installing from a tarball
-Download the latest release tarball from https://github.com/PlayEveryWare/eos_plugin_for_unity/releases
+Download the latest release tarball from https://github.com/EOS-Contrib/eos_plugin_for_unity/releases
 1. From the Unity Editor, open the Package Manager.
     * It's listed under ```Window -> Package Manager```.
 2. Click the ```+``` button.
@@ -175,7 +175,7 @@ More specific and up-to-date instructions can also be found on Epic's [website](
 # Open Source: Contribute
 
 This is an Open Source project. If you would like to view and contribute to the development of the EOS Unity Plugin, you can enlist in the development repo located at
-https://github.com/PlayEveryWare/eos_plugin_for_unity
+https://github.com/EOS-Contrib/eos_plugin_for_unity
 
 
 ---
@@ -183,7 +183,7 @@ https://github.com/PlayEveryWare/eos_plugin_for_unity
 
 EOS Plugin for Unity API Documentation can be found at https://eospluginforunity.playeveryware.com
 
-For issues related to integration or usage of the Unity plugin, please create a ```New Issue``` under the [Issues](https://github.com/PlayEveryWare/eos_plugin_for_unity/issues) tab of the [main repo](https://github.com/PlayEveryWare/eos_plugin_for_unity).
+For issues related to integration or usage of the Unity plugin, please create a ```New Issue``` under the [Issues](https://github.com/EOS-Contrib/eos_plugin_for_unity/issues) tab of the [main repo](https://github.com/PlayEveryWare/eos_plugin_for_unity).
 
 For issues related to Epic Online Services SDK, Epic Dev Portal or general EOS SDK information, please go to [Epic Online Services Community Support](https://eoshelp.epicgames.com/).
 

--- a/etc/docfx/templates/modern/src/main.js
+++ b/etc/docfx/templates/modern/src/main.js
@@ -7,7 +7,7 @@ export default {
     iconlinks: [
         {
             icon: 'github',
-            href: 'https://github.com/PlayEveryWare/eos_plugin_for_unity',
+            href: 'https://github.com/EOS-Contrib/eos_plugin_for_unity',
             title: 'GitHub'
         }
     ]

--- a/etc/docfx/toc.yml
+++ b/etc/docfx/toc.yml
@@ -5,10 +5,10 @@
   href: api/
 
 - name: Source Repository
-  href: https://github.com/PlayEveryWare/eos_plugin_for_unity
+  href: https://github.com/EOS-Contrib/eos_plugin_for_unity
   
 - name: UPM Packages
-  href: https://github.com/PlayEveryWare/eos_plugin_for_unity_upm
+  href: https://github.com/EOS-Contrib/eos_plugin_for_unity_upm
 
 - name: Support Issues
-  href: https://github.com/PlayEveryWare/eos_plugin_for_unity/issues
+  href: https://github.com/EOS-Contrib/eos_plugin_for_unity/issues


### PR DESCRIPTION
The documentation still referenced the old Git URL. Updated it to the correct repository: git@github.com:EOS-Contrib/eos_plugin_for_unity_upm.git.