### PR TITLE
Fix: Use EOS_Auth_CopyIdToken instead of CopyUserAuthToken for Connec…

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -1061,83 +1061,45 @@ namespace PlayEveryWare.EpicOnlineServices
             /// Also contains the information needed to set ProductUserId.
             /// <see cref="s_localProductUserId"/>
             /// </param>
-            public async void StartConnectLoginWithEpicAccount(EpicAccountId epicAccountId,
-                OnConnectLoginCallback onConnectLoginCallback)
+            public async void StartConnectLoginWithEpicAccount(EpicAccountId epicAccountId, OnConnectLoginCallback onConnectLoginCallback)
             {
-                var EOSAuthInterface = GetEOSPlatformInterface().GetAuthInterface();
-                var copyUserTokenOptions = new CopyUserAuthTokenOptions();
-                var result =
-                    EOSAuthInterface.CopyUserAuthToken(ref copyUserTokenOptions, epicAccountId, out Token? authToken);
-                var connectLoginOptions = new Epic.OnlineServices.Connect.LoginOptions();
+                var authInterface = GetEOSPlatformInterface().GetAuthInterface();
 
-                if (result == Result.NotFound)
+                var idOpts = new Epic.OnlineServices.Auth.CopyIdTokenOptions
                 {
-                    Log("No User Auth tokens found to login");
-                    if (onConnectLoginCallback != null)
+                    AccountId = epicAccountId
+                };
+
+                var result = authInterface.CopyIdToken(ref idOpts, out Epic.OnlineServices.Auth.IdToken? idToken);
+
+                if (result != Result.Success || !idToken.HasValue)
+                {
+                    Debug.LogError("[EOS] CopyIdToken failed" + result);
+                    var dummy = new Epic.OnlineServices.Connect.LoginCallbackInfo
                     {
-                        var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
-                        dummyLoginCallbackInfo.ResultCode = Result.ConnectAuthExpired;
-                        onConnectLoginCallback(dummyLoginCallbackInfo);
-                    }
-
+                        ResultCode = Result.InvalidAuth
+                    };
+                    onConnectLoginCallback?.Invoke(dummy);
                     return;
                 }
 
-                Log($"CopyUserAuthToken result code: {result}");
+                Debug.Log("[EOS] Using ID Token for Connect Login");
 
-                if (!authToken.HasValue)
+                var connectLoginOptions = new Epic.OnlineServices.Connect.LoginOptions
                 {
-                    Log("authToken was not found, unable to login");
+                    Credentials = new Epic.OnlineServices.Connect.Credentials
+                    {
+                        Token = idToken.Value.JsonWebToken,
+                        Type = Epic.OnlineServices.ExternalCredentialType.EpicIdToken
+                    }
+                };
 
-                    var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
-                    dummyLoginCallbackInfo.ResultCode = Result.InvalidAuth;
-                    onConnectLoginCallback(dummyLoginCallbackInfo);
-
-                    return;
-                }
-
-                // If the GetUserLoginInfo delegate is set, the UserLoginInfo can
-                // be provided here for platforms that require it in this scenario.
                 if (EOSManager.GetUserLoginInfo != null)
                 {
                     connectLoginOptions.UserLoginInfo = await EOSManager.GetUserLoginInfo();
                 }
 
-                // If the authToken returned a value, and there is a RefreshToken, then try to login using that
-                // Otherwise, try to use the AccessToken if that's available
-                // One or the other should be provided, but if neither is available then fail to login
-                if (authToken.Value.RefreshToken != null)
-                {
-                    Log("Attempting to use refresh token to login with connect");
-
-                    connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
-                    {
-                        Token = authToken.Value.RefreshToken,
-                        Type = ExternalCredentialType.Epic
-                    };
-
-                    StartConnectLoginWithOptions(connectLoginOptions, onConnectLoginCallback);
-                }
-                else if (authToken.Value.AccessToken != null)
-                {
-                    Log("Attempting to use access token to login with connect");
-
-                    connectLoginOptions.Credentials = new Epic.OnlineServices.Connect.Credentials
-                    {
-                        Token = authToken.Value.AccessToken,
-                        Type = ExternalCredentialType.Epic
-                    };
-
-                    StartConnectLoginWithOptions(connectLoginOptions, onConnectLoginCallback);
-                }
-                else
-                {
-                    Log("authToken has a value, but neither the refresh token nor the access token was provided. Cannot login.");
-
-                    var dummyLoginCallbackInfo = new Epic.OnlineServices.Connect.LoginCallbackInfo();
-                    dummyLoginCallbackInfo.ResultCode = Result.InvalidAuth;
-                    onConnectLoginCallback(dummyLoginCallbackInfo);
-                }
+                StartConnectLoginWithOptions(connectLoginOptions, onConnectLoginCallback);
             }
 
             //-------------------------------------------------------------------------

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -1074,7 +1074,7 @@ namespace PlayEveryWare.EpicOnlineServices
 
                 if (result != Result.Success || !idToken.HasValue)
                 {
-                    Debug.LogError("[EOS] CopyIdToken failed" + result);
+                    Debug.LogError($"{nameof(EOSManager)} {nameof(StartConnectLoginWithEpicAccount)}: CopyIdToken failed with result: {result}");
                     var dummy = new Epic.OnlineServices.Connect.LoginCallbackInfo
                     {
                         ResultCode = Result.InvalidAuth
@@ -1083,7 +1083,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     return;
                 }
 
-                Debug.Log("[EOS] Using ID Token for Connect Login");
+                Log($"{nameof(EOSManager)} {nameof(StartConnectLoginWithEpicAccount)}: Using ID Token for Connect Login");
 
                 var connectLoginOptions = new Epic.OnlineServices.Connect.LoginOptions
                 {


### PR DESCRIPTION
The plugin was using EOS_Auth_CopyUserAuthToken, which is unnecessary for ConnectLogin and can cause warnings. Updated the implementation to use EOS_Auth_CopyIdToken as recommended by the EOS API.