### PR TITLE
Fix: Retrieve Sandbox and Deployment IDs from CLI (EOSU-668)

### DIFF
--- a/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs
@@ -20,15 +20,15 @@ namespace PlayEveryWare.EpicOnlineServices
     /// </summary>
     public static class EOSCommandLineOverrides
     {
-        private const string DeploymentKey = "-epicdeploymentid";
-        private const string SandboxKey = "-epicsandboxid";
+        private const string DeploymentKey = "-epicdeploymentid=";
+        private const string SandboxKey = "-epicsandboxid=";
     
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void ApplyCliOverrides()
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void SaveCliOverrides()
         {
             try
             {
-                Debug.Log($"[{nameof(EOSCommandLineOverrides)}::{nameof(ApplyCliOverrides)}] Initializing CLI overrides");
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}::{nameof(SaveCliOverrides)}] Initializing CLI overrides");
     
                 // Get command line arguments
                 string[] args = Environment.GetCommandLineArgs();
@@ -56,28 +56,39 @@ namespace PlayEveryWare.EpicOnlineServices
                 // Save values globally for later access
                 EOSOverrideState.DeploymentIdOverride = deploymentArg;
                 EOSOverrideState.SandboxIdOverride = sandboxArg;
-    
-                var cfg = PlatformManager.GetPlatformConfig();
-    
-                // Apply overrides to PlatformConfig. Even though the values are applied here, they still need to be read globally for later access.
-                if (!string.IsNullOrEmpty(sandboxArg))
-                {
-                    cfg.deployment.SandboxId = SandboxId.FromString(sandboxArg);
-                    Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Sandbox configured: {sandboxArg}");
-                }
-    
-                if (!string.IsNullOrEmpty(deploymentArg) && Guid.TryParse(deploymentArg, out Guid dep))
-                {
-                    cfg.deployment.DeploymentId = dep;
-                    Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Deployment configured: {dep}");
-                }
-    
-                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Overrides applied successfully.");
+
+                // Apply values 
+                PlatformManager.GetPlatformConfig();
+
             }
             catch (Exception ex)
             {
                 Debug.LogError($"[{nameof(EOSCommandLineOverrides)}] ERROR applying overrides: {ex}");
             }
+        }
+        public static void ApplyOverrides(PlatformConfig config)
+        {
+            if (config == null)
+                return;
+
+            if (!string.IsNullOrEmpty(EOSOverrideState.DeploymentIdOverride))
+            { 
+                if(Guid.TryParse(EOSOverrideState.DeploymentIdOverride,out var dep))
+                {
+                    config.deployment.DeploymentId = dep;
+                    Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Deployment override applied: {config.deployment.DeploymentId}");
+                }
+            }
+
+            if (!string.IsNullOrEmpty(EOSOverrideState.SandboxIdOverride))
+            {
+                var sbx = SandboxId.FromString(EOSOverrideState.SandboxIdOverride);
+                config.deployment.SandboxId = sbx;
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Sandbox override applied: {config.deployment.SandboxId}");
+                
+            }
+
+            Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Overrides applied successfully.");
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PlayEveryWare.EpicOnlineServices;
+
+namespace PlayEveryWare.EpicOnlineServices
+{
+    /// <summary>
+    /// Holds override values for Deployment and Sandbox IDs.
+    /// </summary>
+    public static class EOSOverrideState
+    {
+        public static string DeploymentIdOverride { get; set; }
+        public static string SandboxIdOverride { get; set; }
+    }
+}
+/// <summary>
+/// Applies CLI overrides for Epic Online Services before any scene loads.
+/// </summary>
+public static class EOSCommandLineOverrides
+{
+    private const string DeploymentKey = "-epicdeploymentid";
+    private const string SandboxKey = "-epicsandboxid";
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    private static void ApplyCliOverrides()
+    {
+        try
+        {
+            Debug.Log($"[{nameof(EOSCommandLineOverrides)}::{nameof(ApplyCliOverrides)}] Initializing CLI overrides…");
+
+            // Get command line arguments
+            string[] args = Environment.GetCommandLineArgs();
+            string deploymentArg = null;
+            string sandboxArg = null;
+
+            // Parse CLI arguments for deployment and sandbox IDs
+            foreach (var arg in args)
+            {
+                if (arg.StartsWith(DeploymentKey, StringComparison.OrdinalIgnoreCase))
+                    deploymentArg = arg.Substring(DeploymentKey.Length);
+
+                if (arg.StartsWith(SandboxKey, StringComparison.OrdinalIgnoreCase))
+                    sandboxArg = arg.Substring(SandboxKey.Length);
+            }
+
+            // If no overrides found, exit early
+            if (deploymentArg == null && sandboxArg == null)
+            {
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] No CLI overrides found. argsCount={args.Length}");
+                return;
+            }
+
+            Debug.Log($"[EOSBuildBootstrapper] CLI Override detected: DEPLOYMENT={deploymentArg}, SANDBOX={sandboxArg}");
+
+            // --------------------------------------------------------------------
+            // Save values globally for later access
+            // --------------------------------------------------------------------
+            EOSOverrideState.DeploymentIdOverride = deploymentArg;
+            EOSOverrideState.SandboxIdOverride = sandboxArg;
+
+            // --------------------------------------------------------------------
+            // Regenerate a clean platform config
+            // --------------------------------------------------------------------
+            var cfg = PlatformManager.GetPlatformConfig();
+
+            // --------------------------------------------------------------------
+            // Apply overrides to PlatformConfig
+            // --------------------------------------------------------------------
+            if (!string.IsNullOrEmpty(sandboxArg))
+            {
+                cfg.deployment.SandboxId = SandboxId.FromString(sandboxArg);
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Sandbox configured: {sandboxArg}");
+            }
+
+            if (!string.IsNullOrEmpty(deploymentArg) && Guid.TryParse(deploymentArg, out Guid dep))
+            {
+                cfg.deployment.DeploymentId = dep;
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Deployment configured: {dep}");
+            }
+
+            Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Overrides applied successfully.");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[{nameof(EOSCommandLineOverrides)}] ERROR applying overrides: {ex}");
+        }
+    }
+}
+

--- a/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs
@@ -14,77 +14,70 @@ namespace PlayEveryWare.EpicOnlineServices
         public static string DeploymentIdOverride { get; set; }
         public static string SandboxIdOverride { get; set; }
     }
-}
-/// <summary>
-/// Applies CLI overrides for Epic Online Services before any scene loads.
-/// </summary>
-public static class EOSCommandLineOverrides
-{
-    private const string DeploymentKey = "-epicdeploymentid";
-    private const string SandboxKey = "-epicsandboxid";
 
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    private static void ApplyCliOverrides()
+    /// <summary>
+    /// Applies CLI overrides for Epic Online Services before any scene loads.
+    /// </summary>
+    public static class EOSCommandLineOverrides
     {
-        try
+        private const string DeploymentKey = "-epicdeploymentid";
+        private const string SandboxKey = "-epicsandboxid";
+    
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ApplyCliOverrides()
         {
-            Debug.Log($"[{nameof(EOSCommandLineOverrides)}::{nameof(ApplyCliOverrides)}] Initializing CLI overrides…");
-
-            // Get command line arguments
-            string[] args = Environment.GetCommandLineArgs();
-            string deploymentArg = null;
-            string sandboxArg = null;
-
-            // Parse CLI arguments for deployment and sandbox IDs
-            foreach (var arg in args)
+            try
             {
-                if (arg.StartsWith(DeploymentKey, StringComparison.OrdinalIgnoreCase))
-                    deploymentArg = arg.Substring(DeploymentKey.Length);
-
-                if (arg.StartsWith(SandboxKey, StringComparison.OrdinalIgnoreCase))
-                    sandboxArg = arg.Substring(SandboxKey.Length);
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}::{nameof(ApplyCliOverrides)}] Initializing CLI overrides");
+    
+                // Get command line arguments
+                string[] args = Environment.GetCommandLineArgs();
+                string deploymentArg = null;
+                string sandboxArg = null;
+    
+                // Parse CLI arguments for deployment and sandbox IDs
+                foreach (var arg in args)
+                {
+                    if (arg.StartsWith(DeploymentKey, StringComparison.OrdinalIgnoreCase))
+                        deploymentArg = arg.Substring(DeploymentKey.Length);
+                    else if (arg.StartsWith(SandboxKey, StringComparison.OrdinalIgnoreCase))
+                        sandboxArg = arg.Substring(SandboxKey.Length);
+                }
+    
+                // If no overrides found, exit early
+                if (string.IsNullOrEmpty(deploymentArg) && string.IsNullOrEmpty(sandboxArg))
+                {
+                    Debug.Log($"[{nameof(EOSCommandLineOverrides)}] No CLI overrides found. argsCount={args.Length}");
+                    return;
+                }
+    
+                Debug.Log($"[EOSBuildBootstrapper] CLI Override detected: DEPLOYMENT={deploymentArg}, SANDBOX={sandboxArg}");
+    
+                // Save values globally for later access
+                EOSOverrideState.DeploymentIdOverride = deploymentArg;
+                EOSOverrideState.SandboxIdOverride = sandboxArg;
+    
+                var cfg = PlatformManager.GetPlatformConfig();
+    
+                // Apply overrides to PlatformConfig. Even though the values are applied here, they still need to be read globally for later access.
+                if (!string.IsNullOrEmpty(sandboxArg))
+                {
+                    cfg.deployment.SandboxId = SandboxId.FromString(sandboxArg);
+                    Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Sandbox configured: {sandboxArg}");
+                }
+    
+                if (!string.IsNullOrEmpty(deploymentArg) && Guid.TryParse(deploymentArg, out Guid dep))
+                {
+                    cfg.deployment.DeploymentId = dep;
+                    Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Deployment configured: {dep}");
+                }
+    
+                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Overrides applied successfully.");
             }
-
-            // If no overrides found, exit early
-            if (deploymentArg == null && sandboxArg == null)
+            catch (Exception ex)
             {
-                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] No CLI overrides found. argsCount={args.Length}");
-                return;
+                Debug.LogError($"[{nameof(EOSCommandLineOverrides)}] ERROR applying overrides: {ex}");
             }
-
-            Debug.Log($"[EOSBuildBootstrapper] CLI Override detected: DEPLOYMENT={deploymentArg}, SANDBOX={sandboxArg}");
-
-            // --------------------------------------------------------------------
-            // Save values globally for later access
-            // --------------------------------------------------------------------
-            EOSOverrideState.DeploymentIdOverride = deploymentArg;
-            EOSOverrideState.SandboxIdOverride = sandboxArg;
-
-            // --------------------------------------------------------------------
-            // Regenerate a clean platform config
-            // --------------------------------------------------------------------
-            var cfg = PlatformManager.GetPlatformConfig();
-
-            // --------------------------------------------------------------------
-            // Apply overrides to PlatformConfig
-            // --------------------------------------------------------------------
-            if (!string.IsNullOrEmpty(sandboxArg))
-            {
-                cfg.deployment.SandboxId = SandboxId.FromString(sandboxArg);
-                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Sandbox configured: {sandboxArg}");
-            }
-
-            if (!string.IsNullOrEmpty(deploymentArg) && Guid.TryParse(deploymentArg, out Guid dep))
-            {
-                cfg.deployment.DeploymentId = dep;
-                Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Deployment configured: {dep}");
-            }
-
-            Debug.Log($"[{nameof(EOSCommandLineOverrides)}] Overrides applied successfully.");
-        }
-        catch (Exception ex)
-        {
-            Debug.LogError($"[{nameof(EOSCommandLineOverrides)}] ERROR applying overrides: {ex}");
         }
     }
 }

--- a/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs.meta
+++ b/com.playeveryware.eos/Runtime/Core/EOSCommandLineOverrides.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6e597dd4cdcae9468e622341936f556
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -288,10 +288,6 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetSandboxId()
             {
-                if (!string.IsNullOrEmpty(EOSOverrideState.SandboxIdOverride))
-                {
-                    return EOSOverrideState.SandboxIdOverride;
-                }
                 return PlatformManager.GetPlatformConfig().deployment.SandboxId.ToString();
             }
 
@@ -302,10 +298,6 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetDeploymentID()
             {
-                if (!string.IsNullOrEmpty(EOSOverrideState.DeploymentIdOverride))
-                {
-                    return EOSOverrideState.DeploymentIdOverride;
-                }
                 return PlatformManager.GetPlatformConfig().deployment.DeploymentId.ToString("N").ToLowerInvariant();
             }
 

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -288,6 +288,10 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetSandboxId()
             {
+                if (!string.IsNullOrEmpty(EOSOverrideState.SandboxIdOverride))
+                {
+                    return EOSOverrideState.SandboxIdOverride;
+                }
                 return PlatformManager.GetPlatformConfig().deployment.SandboxId.ToString();
             }
 
@@ -298,6 +302,10 @@ namespace PlayEveryWare.EpicOnlineServices
             /// <returns></returns>
             public string GetDeploymentID()
             {
+                if (!string.IsNullOrEmpty(EOSOverrideState.DeploymentIdOverride))
+                {
+                    return EOSOverrideState.DeploymentIdOverride;
+                }
                 return PlatformManager.GetPlatformConfig().deployment.DeploymentId.ToString("N").ToLowerInvariant();
             }
 
@@ -492,101 +500,6 @@ namespace PlayEveryWare.EpicOnlineServices
                     });
             }
 
-            /// <summary>
-            /// This function applies any command line arguments that may have
-            /// been provided to the application from the Epic Games Launcher.
-            /// </summary>
-            private void ApplyCommandLineArguments()
-            {
-                EpicLauncherArgs epicArgs = GetCommandLineArgsFromEpicLauncher();
-
-                // If neither the sandbox id nor the deployment id have been specified on the command line, the application of the arguments can stop here.
-                if (string.IsNullOrEmpty(epicArgs.epicSandboxID) && string.IsNullOrEmpty(epicArgs.epicDeploymentID))
-                {
-                    return;
-                }
-
-                ProductConfig productConfig = Config.Get<ProductConfig>();
-
-                if (!string.IsNullOrEmpty(epicArgs.epicSandboxID))
-                {
-                    bool sandboxDefined = false;
-                    SandboxId sandboxFromCommandLine = SandboxId.FromString(epicArgs.epicSandboxID);
-                    foreach (var namedSandbox in productConfig.Environments.Sandboxes)
-                    {
-                        if (namedSandbox.Value.Equals(sandboxFromCommandLine))
-                        {
-                            Debug.Log($"{namedSandbox} selected as sandbox.");
-                            sandboxDefined = true;
-                            break;
-                        }
-                    }
-
-                    PlatformManager.GetPlatformConfig().deployment.SandboxId = sandboxFromCommandLine;
-
-                    if (!sandboxDefined)
-                    {
-                        Debug.LogWarning(
-                            $"Sandbox Id \"{sandboxFromCommandLine}\" was " +
-                            $"provided on the command line, but was not " +
-                            $"found in the product config. Attempting to use " +
-                            $"it regardless.");
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(epicArgs.epicDeploymentID))
-                {
-                    bool deploymentDefined = false;
-
-                    foreach (var namedDeployment in productConfig.Environments.Deployments)
-                    {
-                        // Check for equality regardless of case - and
-                        // regardless of whether the dashes are included in the
-                        // Guid for the purposes of comparison.
-                        if (namedDeployment.Value.DeploymentId.ToString().Equals(epicArgs.epicDeploymentID,
-                                StringComparison.OrdinalIgnoreCase) ||
-                            namedDeployment.Value.DeploymentId.ToString("N").Equals(epicArgs.epicDeploymentID,
-                                StringComparison.OrdinalIgnoreCase))
-                        {
-                            Debug.Log($"{namedDeployment} selected as deployment.");
-                            deploymentDefined = true;
-                            break;
-                        }
-                    }
-
-                    // NOTE: An empty guid is known to cause the EOS SDK to fail
-                    //       to initialize - however in the native code when
-                    //       this same operation is done, no check is performed
-                    //       on whether the Guid is a valid Guid. This
-                    //       implementation has been written to provide
-                    //       verisimilitude with the native implementation on
-                    //       Windows. Regardless - a warning is logged here -
-                    //       despite the fact that it could be arguably be
-                    //       logged as an error.
-                    if (!Guid.TryParse(epicArgs.epicDeploymentID, out Guid deploymentFromCommandLine))
-                    {
-                        Debug.LogWarning(
-                            $"ERROR: Invalid Guid " +
-                            $"\"{epicArgs.epicDeploymentID}\" for Deployment " +
-                            $"Id was provided on the command line. EOS SDK " +
-                            $"will almost certainly fail to initialize.");
-
-                        deploymentFromCommandLine = Guid.Empty;
-                    }
-
-                    PlatformManager.GetPlatformConfig().deployment.DeploymentId = deploymentFromCommandLine;
-
-                    if (!deploymentFromCommandLine.Equals(Guid.Empty) && !deploymentDefined)
-                    {
-                        Debug.LogWarning(
-                            $"Deployment \"{deploymentFromCommandLine}\" was " +
-                            $"provided on the command line, but was not " +
-                            $"found in the product config. Attempting to use " +
-                            $"it regardless.");
-                    }
-                }
-            }
-
             public void Init(IEOSCoroutineOwner coroutineOwner, string configFileName = null)
             {
                 if (GetEOSPlatformInterface() != null)
@@ -618,8 +531,6 @@ namespace PlayEveryWare.EpicOnlineServices
 #else
                 InitializeLogLevels();
 #endif
-
-                ApplyCommandLineArguments();
 
                 Result initResult = InitializePlatformInterface();
 

--- a/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/PlatformManager.cs
@@ -264,6 +264,8 @@ namespace PlayEveryWare.EpicOnlineServices
 
             s_platformConfig = platformInfo.GetConfigFunction();
 
+            EOSCommandLineOverrides.ApplyOverrides(s_platformConfig);
+
             return s_platformConfig;
         }
 


### PR DESCRIPTION
- Added new class to fetch Sandbox ID and Deployment ID from CLI arguments
- Replaced previous logic that only read values from JSON after initialization
- Ensures correct IDs are used when running builds in different environments