### PR TITLE
Implement EOS_DISABLE for non-Windows platforms to fix build issues

### DIFF
--- a/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
+++ b/Assets/Plugins/Source/Editor/com.playeveryware.eos-Editor.asmdef
@@ -17,7 +17,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "!EOS_DISABLE"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.inputsystem",

--- a/Assets/Scripts/FacePunch/com.playeveryware.eos.samples.facepunch-steamworks.asmdef
+++ b/Assets/Scripts/FacePunch/com.playeveryware.eos.samples.facepunch-steamworks.asmdef
@@ -11,7 +11,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "!EOS_DISABLE"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Assets/Scripts/PerformanceStressTestSample/PostProcessing/com.playeveryware.eos.samples.postprocessing.asmdef
+++ b/Assets/Scripts/PerformanceStressTestSample/PostProcessing/com.playeveryware.eos.samples.postprocessing.asmdef
@@ -8,7 +8,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "!EOS_DISABLE"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.postprocessing",

--- a/Assets/Tests/EditMode/com.playeveryware.eos.tests.editmode.asmdef
+++ b/Assets/Tests/EditMode/com.playeveryware.eos.tests.editmode.asmdef
@@ -16,7 +16,8 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
+        "UNITY_INCLUDE_TESTS",
+        "!EOS_DISABLE"
     ],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Tests/Editor/UnitTestResultsWindow.cs
+++ b/Assets/Tests/Editor/UnitTestResultsWindow.cs
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 {
     using System;
@@ -267,3 +267,4 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         }
     }
 }
+#endif

--- a/Assets/Tests/Editor/UnitTestResultsWindow.cs
+++ b/Assets/Tests/Editor/UnitTestResultsWindow.cs
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#if !EOS_DISABLE
+
 namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
 {
     using System;
@@ -267,4 +267,3 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
         }
     }
 }
-#endif

--- a/Assets/Tests/Editor/com.playeveryware.eos.test.asmdef
+++ b/Assets/Tests/Editor/com.playeveryware.eos.test.asmdef
@@ -1,13 +1,12 @@
 {
-    "name": "com.playeveryware.eos.samples.appleauth.editor",
+    "name": "com.playeveryware.eos.test",
     "rootNamespace": "",
     "references": [
-        "GUID:09ef5922e2d77498aa246abd9073d05f",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:cc11d9857b82d9b458fca637d5cb33fb"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
@@ -16,12 +15,6 @@
     "defineConstraints": [
         "!EOS_DISABLE"
     ],
-    "versionDefines": [
-        {
-            "name": "com.lupidan.apple-signin-unity",
-            "expression": "",
-            "define": "APPLEAUTH_MODULE_EDITOR"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Assets/Tests/Editor/com.playeveryware.eos.test.asmdef.meta
+++ b/Assets/Tests/Editor/com.playeveryware.eos.test.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6da2d779522f5f94d970bd848aac271f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.playeveryware.eos/Runtime/Core/SystemMemory.cs
+++ b/com.playeveryware.eos/Runtime/Core/SystemMemory.cs
@@ -32,6 +32,7 @@
 #define DYNAMIC_MEMORY_ALLOCATION_AVAILABLE
 #endif
 
+#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices
 {
     using System.Runtime.InteropServices;
@@ -132,3 +133,4 @@ namespace PlayEveryWare.EpicOnlineServices
 
     }
 }
+#endif

--- a/com.playeveryware.eos/Runtime/Core/SystemMemory.cs
+++ b/com.playeveryware.eos/Runtime/Core/SystemMemory.cs
@@ -32,7 +32,6 @@
 #define DYNAMIC_MEMORY_ALLOCATION_AVAILABLE
 #endif
 
-#if !EOS_DISABLE
 namespace PlayEveryWare.EpicOnlineServices
 {
     using System.Runtime.InteropServices;
@@ -133,4 +132,3 @@ namespace PlayEveryWare.EpicOnlineServices
 
     }
 }
-#endif

--- a/com.playeveryware.eos/Runtime/Core/Utility/PluginVersionInterface.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/PluginVersionInterface.cs
@@ -1,3 +1,4 @@
+#if !EOS_DISABLE
 using Epic.OnlineServices;
 using System;
 
@@ -40,3 +41,4 @@ namespace ApexSystems.Utility
         }
     }
 }
+#endif

--- a/com.playeveryware.eos/Runtime/Core/Utility/PluginVersionInterface.cs
+++ b/com.playeveryware.eos/Runtime/Core/Utility/PluginVersionInterface.cs
@@ -1,4 +1,3 @@
-#if !EOS_DISABLE
 using Epic.OnlineServices;
 using System;
 
@@ -41,4 +40,3 @@ namespace ApexSystems.Utility
         }
     }
 }
-#endif

--- a/com.playeveryware.eos/Runtime/Core/com.playeveryware.eos.core.asmdef
+++ b/com.playeveryware.eos/Runtime/Core/com.playeveryware.eos.core.asmdef
@@ -10,7 +10,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "!EOS_DISABLE"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Builds for iOS were failing due to EOS Plugin dependencies, even though EOS was not required on these platforms.
- Implemented conditional compilation using EOS_DISABLE for non-Windows platforms (Mac, iOS, Android)
- Fixed build failures on iOS caused by EOS Plugin when EOS_DISABLE
- Verified successful builds on Mac, Android, iOS, and Linux
- Ensured Windows integration remains unaffected