### PR TITLE
Eosu 678 build native libs windows

### DIFF
--- a/Assets/Plugins/Windows/x64/DynamicLibraryLoaderHelper-x64.dll
+++ b/Assets/Plugins/Windows/x64/DynamicLibraryLoaderHelper-x64.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:361f15de31925baa632cd3af1ea7c3ba6529b8c2c8be69c6cede4f2d0716140d
-size 125440
+oid sha256:81de0db1bf924c0f914f89d358b00b9dfa6428884d3bf70454e804f79c47d634
+size 137216

--- a/Assets/Plugins/Windows/x64/GfxPluginNativeRender-x64.dll
+++ b/Assets/Plugins/Windows/x64/GfxPluginNativeRender-x64.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec31c5f8e7066a5a94358afd2fdacd831ae2060fff3d03fde7dd4dc6889e3429
-size 637952
+oid sha256:dc801ec2843d3ec46678d97b0d07ae6c3a68a5fa23d34c532ced7f501ddf495a
+size 589312

--- a/Assets/Plugins/Windows/x86/DynamicLibraryLoaderHelper-x86.dll
+++ b/Assets/Plugins/Windows/x86/DynamicLibraryLoaderHelper-x86.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0642f924bc7174bfee262f2104abe1408d6720532de6f7ca5d57c030eb439d70
-size 110592
+oid sha256:914b7ba5e4fe3164d589ee08bd67b43014d5eff0e6ca7234487f223bf5986c10
+size 105472

--- a/Assets/Plugins/Windows/x86/GfxPluginNativeRender-x86.dll
+++ b/Assets/Plugins/Windows/x86/GfxPluginNativeRender-x86.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5063010506411d9949451eb01e5c6cfe19285302b7ecaad4747300e56db6f36
-size 484864
+oid sha256:eec6c73c0fdc8c79f0cdaf74ecb2d43a1ffed38ddce1c64aae6d2837257549f2
+size 478208

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.vcxproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper/DynamicLibraryLoaderHelper.vcxproj
@@ -37,7 +37,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32' Or '$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>false</LinkIncremental>

--- a/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/NativeRender.vcxproj
+++ b/lib/NativeCode/DynamicLibraryLoaderHelper/NativeRender/NativeRender.vcxproj
@@ -38,7 +38,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32' Or '$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>


### PR DESCRIPTION
This PR updates the solution to use the Visual Studio 2022 toolset (v143) and refreshes native libraries. In collaboration with @DanF-ApexSystems , we reviewed and promoted the migration to Visual Studio 2022, given that VS2019 will soon be deprecated

Changes included:
- Updated .vcxproj files for DynamicLibraryLoaderHelper and NativeRender to use toolset v143
- Rebuilt native DLLs (DynamicLibraryLoaderHelper and GfxPluginNativeRender) for x86 and x64
- Replaced old binaries in Assets\Plugins\Windows directories
- Verified compatibility with VS2022 build environment