### PR TITLE
eosu-679-build-native-libraries-mac

### DIFF
--- a/Assets/Plugins/macOS/MicrophoneUtility_macos.dylib
+++ b/Assets/Plugins/macOS/MicrophoneUtility_macos.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43dad3f281f36c6f219ec6444df1bdd978a6e146fca994b2e25891e4e8c45775
+oid sha256:bfbaed5a018f23ffcbe92b77fa6e901e7fdf75622ccf5ab7464226f5f3e462c0
 size 83336

--- a/Assets/Plugins/macOS/libDynamicLibraryLoaderHelper.dylib
+++ b/Assets/Plugins/macOS/libDynamicLibraryLoaderHelper.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:505d8ca3192f85055a2803f5b16811c2a7c7f70ab1c31d037220add21254da58
+oid sha256:54d18e0ee51af4ac0f1fd0d0d5ed1f4f2325d9b84f4f94944c70851092e6cbf7
 size 171632


### PR DESCRIPTION
-Update native libraries for Mac with version EOS-1.19.0.0-Pre-RC