### PR TITLE
Bug: Fix Windows build error caused by asmdef changes (EOSU-797)

### DIFF
--- a/Assets/Tests/Editor/com.playeveryware.eos.test.asmdef
+++ b/Assets/Tests/Editor/com.playeveryware.eos.test.asmdef
@@ -13,6 +13,7 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "!EOS_DISABLE"
     ],
     "versionDefines": [],


### PR DESCRIPTION
- Updated .asmdef to build only when UNITY_INCLUDE_TESTS is defined
- Ensured test assemblies are excluded from production builds