### PR TITLE
Fix: Apply correct RTCOptions conditional for macOS in Unity Editor

### DIFF
--- a/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Platform/PlatformInterface.cs
+++ b/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Platform/PlatformInterface.cs
@@ -92,7 +92,7 @@ namespace Epic.OnlineServices.Platform
 		/// <summary>
 		/// The most recent version of the <see cref="RTCOptions" /> API.
 		/// </summary>
-		#if UNITY_STANDALONE_OSX
+		#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
 			public const int RTCOPTIONS_API_LATEST = 2;
 		#else
 			public const int RTCOPTIONS_API_LATEST = 3;


### PR DESCRIPTION
When running the game in Unity Editor on macOS while targeting Android or any platform other than macOS or iOS, EOS_Platform_RTCOptions becomes incompatible due to incorrect API value assignment.

- Added conditional for UNITY_EDITOR_OSX
- Ensures RTCOPTIONS_API_LATEST = 2 for macOS in plugin (because this plugin version for macOS uses the EOS SDK library 1.17.3-4453235)