### PR TITLE
Release 5.1.3

### DIFF
--- a/Assets/Scripts/StandardSamples/UI/Common/UINativeLibVersion.cs
+++ b/Assets/Scripts/StandardSamples/UI/Common/UINativeLibVersion.cs
@@ -10,7 +10,7 @@
             var textComp = GetComponent<Text>();
             if (textComp != null)
             {
-                textComp.text = $"v-{EOSPackageInfo.NativeLibVersion}";
+                textComp.text = $"v-{EOSPackageInfo.NativeLibSDKVersion}";
             }
         }
     }

--- a/com.playeveryware.eos/CHANGELOG.md
+++ b/com.playeveryware.eos/CHANGELOG.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.3] - 2026-01-09
+
+### Fixed
+- Fix: UINativeLibVersion.cs compile error
+
 ## [5.1.2] - 2025-11-25
 
 ### Added

--- a/com.playeveryware.eos/CHANGELOG.md
+++ b/com.playeveryware.eos/CHANGELOG.md
@@ -2,10 +2,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.3] - 2026-01-09
+## [5.1.3] - 2026-01-13
 
 ### Fixed
 - Fix: UINativeLibVersion.cs compile error
+- Fix: RTC initialization error in the Unity editor on Mac.
 
 ## [5.1.2] - 2025-11-25
 

--- a/com.playeveryware.eos/Runtime/Core/EOSPackageInfo.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSPackageInfo.cs
@@ -33,7 +33,7 @@ namespace PlayEveryWare.EpicOnlineServices
          * not involve editing source code files.
          */
       
-        public const string Version = "5.1.2";
+        public const string Version = "5.1.3";
         // Define a string to be used with a future version of Native Libraries
         public const string NativeLibSDKVersion = "todo value";
         public const string PackageName = "com.playeveryware.eos";

--- a/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Platform/PlatformInterface.cs
+++ b/com.playeveryware.eos/Runtime/EOS_SDK/Generated/Platform/PlatformInterface.cs
@@ -92,7 +92,7 @@ namespace Epic.OnlineServices.Platform
 		/// <summary>
 		/// The most recent version of the <see cref="RTCOptions" /> API.
 		/// </summary>
-		#if UNITY_STANDALONE_OSX
+		#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
 			public const int RTCOPTIONS_API_LATEST = 2;
 		#else
 			public const int RTCOPTIONS_API_LATEST = 3;

--- a/com.playeveryware.eos/package.json
+++ b/com.playeveryware.eos/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.playeveryware.eos",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "unity": "2021.3",
     "unityRelease": "16f1",
     "author": {


### PR DESCRIPTION
- Fixes UINativeLibVersion.cs compile error.
- Fixes RTC initialization error in the Unity editor on Mac.