### PR TITLE
Fix/EOSU 854 add checker on friends manager --> 6.0.0

### DIFF
--- a/Assets/Scripts/EOSFriendsManager.cs
+++ b/Assets/Scripts/EOSFriendsManager.cs
@@ -748,13 +748,13 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <summary>Display Social Overlay</summary>
         public void ShowFriendsOverlay(OnFriendsCallback ShowFriendsOverlayCompleted)
         {
-            ShowFriendsOverlayCallback = ShowFriendsOverlayCompleted;
-            var showFriendsOptions = new ShowFriendsOptions() { LocalUserId = EOSManager.Instance.GetLocalUserId() };
-            if (EOSManager.Instance.GetEOSPlatformInterface().GetUIInterface() == null)
+            if (EOSManager.Instance.GetEOSPlatformInterface() == null)
             {
                 Debug.Log("EOS platform interface is not ready. Attempted to access platform interface before loading finished.");
                 return;
             }
+            ShowFriendsOverlayCallback = ShowFriendsOverlayCompleted;
+            var showFriendsOptions = new ShowFriendsOptions() { LocalUserId = EOSManager.Instance.GetLocalUserId() };
             EOSManager.Instance.GetEOSPlatformInterface().GetUIInterface().ShowFriends(ref showFriendsOptions, null, OnShowFriendsCallback);
         }
 

--- a/Assets/Scripts/EOSFriendsManager.cs
+++ b/Assets/Scripts/EOSFriendsManager.cs
@@ -750,6 +750,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             ShowFriendsOverlayCallback = ShowFriendsOverlayCompleted;
             var showFriendsOptions = new ShowFriendsOptions() { LocalUserId = EOSManager.Instance.GetLocalUserId() };
+            if (EOSManager.Instance.GetEOSPlatformInterface().GetUIInterface() == null)
+            {
+                Debug.Log("EOS platform interface is not ready. Attempted to access platform interface before loading finished.");
+                return;
+            }
             EOSManager.Instance.GetEOSPlatformInterface().GetUIInterface().ShowFriends(ref showFriendsOptions, null, OnShowFriendsCallback);
         }
 

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -105,10 +105,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void SearchFriendsEndEdit(string searchString)
         {
-            if (FriendsManager == null)
-            {
-                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
-            }
             if (string.IsNullOrEmpty(searchString))
             {
                 isSearching = false;

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -105,6 +105,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void SearchFriendsEndEdit(string searchString)
         {
+            if (FriendsManager == null)
+            {
+                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
+            }
             if (string.IsNullOrEmpty(searchString))
             {
                 isSearching = false;
@@ -154,6 +158,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void RenderFriendsList(bool forceUpdate)
         {
+            if (FriendsManager == null)
+            {
+                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
+            }
             if (FriendsManager.GetCachedFriends(out Dictionary<EpicAccountId, FriendData> friendList) || forceUpdate)
             {
                 RefreshUIList(friendList.Values);
@@ -162,6 +170,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void RenderSearchResults()
         {
+            if (FriendsManager == null)
+            {
+                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
+            }
             if (FriendsManager.GetCachedSearchResults(out Dictionary<EpicAccountId, FriendData> searchResults))
             {
                 RefreshUIList(searchResults.Values);
@@ -292,12 +304,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         // Friends
         public void FriendsOverlayOnClick()
         {
+            if(FriendsManager == null) 
+            {
+                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
+            }
             Debug.Log("FriendsOverlayOnClick: IsValid=" + EOSManager.Instance.GetLocalUserId().IsValid() + ", accountId" + EOSManager.Instance.GetLocalUserId().ToString());
             FriendsManager.ShowFriendsOverlay(null);
         }
 
         public void RefreshFriendsOnClick()
         {
+            if (FriendsManager == null)
+            {
+                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
+            }
             FriendsManager.QueryFriends(null);
         }
 

--- a/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Friends/UIFriendsMenu.cs
@@ -158,10 +158,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void RenderFriendsList(bool forceUpdate)
         {
-            if (FriendsManager == null)
-            {
-                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
-            }
             if (FriendsManager.GetCachedFriends(out Dictionary<EpicAccountId, FriendData> friendList) || forceUpdate)
             {
                 RefreshUIList(friendList.Values);
@@ -170,10 +166,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         private void RenderSearchResults()
         {
-            if (FriendsManager == null)
-            {
-                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
-            }
             if (FriendsManager.GetCachedSearchResults(out Dictionary<EpicAccountId, FriendData> searchResults))
             {
                 RefreshUIList(searchResults.Values);
@@ -304,20 +296,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         // Friends
         public void FriendsOverlayOnClick()
         {
-            if(FriendsManager == null) 
-            {
-                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
-            }
             Debug.Log("FriendsOverlayOnClick: IsValid=" + EOSManager.Instance.GetLocalUserId().IsValid() + ", accountId" + EOSManager.Instance.GetLocalUserId().ToString());
             FriendsManager.ShowFriendsOverlay(null);
         }
 
         public void RefreshFriendsOnClick()
         {
-            if (FriendsManager == null)
-            {
-                Debug.Log("Friends Manager is not ready. Attempted to access friend data before loading finished.");
-            }
             FriendsManager.QueryFriends(null);
         }
 


### PR DESCRIPTION
[EOSU-850](https://epicgames.atlassian.net/browse/EOSU-854)
<img width="1305" height="711" alt="image" src="https://github.com/user-attachments/assets/f981ec9a-473f-45ec-8aef-efb902b306b4" />
Image confirm that overlay works with good conection
If the internet is very slow,[ EOS Manager ](https://github.com/EOS-Contrib/eos_plugin_for_unity/blob/820cb7e435054f11fc57318881dbb19816a61dfe/com.playeveryware.eos/Runtime/Core/EOSManager.cs#L678) may not finish starting up before attempting to use its resources, so a checker was added to the platform interface that displays a message if the platform interface is not yet linked.