### PR TITLE
Bug: Fix deployment selection when multiple deployments exist (EOSU-883)

### DIFF
--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -257,6 +257,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             if(!ProductConfig.Get<ProductConfig>().Environments.TryGetFirstDefinedNamedDeployment(out var namedDep))
             {
                 Debug.LogError($"{nameof(EOSSettingsWindow)} {nameof(Save)}: No named deployment found for current platform tab: {_platformConfigEditors[_selectedTab].GetPlatform()}");
+                return;
             }
             // Save each of the platform config editors.
             foreach (IConfigEditor editor in _platformConfigEditors)

--- a/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
+++ b/Assets/Plugins/Source/Editor/EditorWindows/EOSSettingsWindow.cs
@@ -254,11 +254,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             _productConfigEditor.Save();
 
             //Update deployment in current platform
-            if (ProductConfig.Get<ProductConfig>().Environments.TryGetFirstDefinedNamedDeployment(out var namedDep))
-            {
-                _platformConfigEditors[_selectedTab].SetDeployment(namedDep.Value);
-            }
-            else
+            if(!ProductConfig.Get<ProductConfig>().Environments.TryGetFirstDefinedNamedDeployment(out var namedDep))
             {
                 Debug.LogError($"{nameof(EOSSettingsWindow)} {nameof(Save)}: No named deployment found for current platform tab: {_platformConfigEditors[_selectedTab].GetPlatform()}");
             }
@@ -269,6 +265,8 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Windows
             }
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+            _platformTabs = BuildPlatformTabsDynamic();
+            Repaint();
         }
 
         /// <summary>

--- a/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
+++ b/Assets/Plugins/Source/Editor/Utility/GUIEditorUtility.cs
@@ -868,7 +868,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
                             nameRect,
                             string.IsNullOrEmpty,
                             item.Name,
-                            "Sandbox Name");
+                            "Deployment Name");
 
                         if (!item.TrySetName(newItemName))
                         {
@@ -926,6 +926,10 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
                             break;
                         }
                     }
+                    else
+                    {
+                        item.Value.SandboxId = productionEnvironmentsCopy.Sandboxes[0].Value;
+                    }
                 },
                 () => productionEnvironmentsCopy.Deployments.Add(),
                 (item) =>
@@ -934,6 +938,7 @@ namespace PlayEveryWare.EpicOnlineServices.Editor.Utility
                     {
                         // TODO: Tell user why deployment could not be removed
                         //       from the Production Environments.
+                        Debug.LogError($"{nameof(GUIEditorUtility)} {nameof(RenderDeploymentInputs)}: Failed to find deployment with name {item.Name} when trying to remove it.");
                     }
                 });
         }


### PR DESCRIPTION
- Corrected logic to properly resolve the selected deployment instead of always defaulting to the first entry.
- Added validation to handle missing named deployments in the current platform configuration.
- Improved debug logging for easier troubleshooting.
- When only one deployment exists and there is a single sandbox, automatically assign that sandbox to the deployment in the JSON so it appears correctly in the list.