### PR TITLE
Eosu 853 il2cpp linker setup

### DIFF
--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -1,3 +1,10 @@
 <linker>
 <assembly fullname="Newtonsoft.Json" preserve="all" />
+<assembly fullname="com.playeveryware.eos.core">
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToPlatformFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToAuthScopeFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToIntegratedPlatformManagementFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToInputStateButtonFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.StringToTypeConverter`1" preserve="all"/>
+</assembly>
 </linker>

--- a/com.playeveryware.eos/Documentation~/IL2CPP Setup.md
+++ b/com.playeveryware.eos/Documentation~/IL2CPP Setup.md
@@ -5,6 +5,8 @@
 Some EOS samples and certain custom implementations may rely on **Newtonsoft.Json** for JSON serialization and deserialization.  
 When building with **IL2CPP** and **Managed Code Stripping** enabled, Unity may remove unused or reflection-referenced members from assemblies.  
 Because Newtonsoft.Json uses reflection heavily, this can lead to missing types at runtime (especially in **Android**, **iOS**, and **WebGL** builds).
+Some parts of the *EOS Unity Plugin (PlayEveryWare)* rely on **type converter classes** that IL2CPP may incorrectly remove.
+This affects several authentication flows, including **Exchange Code Auth** where the login callback may never complete and remain stuck in a state.
 
 This section describes how to **prevent code stripping** and ensure consistent runtime behavior.
 
@@ -29,7 +31,14 @@ You should perform this step if **any of the following are true**:
 
 ```xml
 <linker>
-  <assembly fullname="Newtonsoft.Json" preserve="all" />
+<assembly fullname="Newtonsoft.Json" preserve="all" />
+<assembly fullname="com.playeveryware.eos.core">
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToPlatformFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToAuthScopeFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToIntegratedPlatformManagementFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.ListOfStringsToInputStateButtonFlags" preserve="all"/>
+    <type fullname="PlayEveryWare.EpicOnlineServices.StringToTypeConverter`1" preserve="all"/>
+</assembly>
 </linker>
 ```
 


### PR DESCRIPTION
This change updates the IL2CPP setup documentation to cover an issue where Exchange Code authentication never completes when running on IL2CPP builds for Windows. The root cause is code stripping removing the PlayEveryWare converter types required by the EOS plugin.

- Document additional linker configuration required for IL2CPP builds
- Preserve ListOfStringsTo* converters to prevent code stripping from breaking ExchangeCode login
- Update IL2CPP Setup.md to include the new types under the com.playeveryware.eos.core assembly