### PR TITLE
Force Windows plugin path to X64 to avoid missing XAudio29 DLL (EOSU-961)

### DIFF
--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -128,7 +128,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <param name="createOptions"></param>
         public override void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions)
         {
-            const pluginPlatformPath ="x64";
+            const string pluginPlatformPath ="x64";
 
                 List<string> pluginPaths = DLLHandle.GetPathsToPlugins();
                 var rtcPlatformSpecificOptions = new WindowsRTCOptionsPlatformSpecificOptions();

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -128,12 +128,7 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <param name="createOptions"></param>
         public override void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions)
         {
-            string pluginPlatformPath =
-#if UNITY_64
-            "x64";
-#else
-            "x86";
-#endif
+            string pluginPlatformPath ="x64";
 
             if (pluginPlatformPath.Length > 0)
             {

--- a/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
+++ b/Assets/Plugins/Windows/Core/WindowsPlatformSpecifics.cs
@@ -128,10 +128,8 @@ namespace PlayEveryWare.EpicOnlineServices
         /// <param name="createOptions"></param>
         public override void ConfigureSystemPlatformCreateOptions(ref EOSCreateOptions createOptions)
         {
-            string pluginPlatformPath ="x64";
+            const pluginPlatformPath ="x64";
 
-            if (pluginPlatformPath.Length > 0)
-            {
                 List<string> pluginPaths = DLLHandle.GetPathsToPlugins();
                 var rtcPlatformSpecificOptions = new WindowsRTCOptionsPlatformSpecificOptions();
                 foreach (string pluginPath in pluginPaths)
@@ -201,7 +199,6 @@ namespace PlayEveryWare.EpicOnlineServices
                     }
                 }
 #endif
-            }
         }
 
 #endif


### PR DESCRIPTION
- Replaced conditional UNITY_64 logic with a fixed X64 plugin path.
- Prevents editor-side errors when running Android builds after x86 removal.
- Does not affect runtime on device; editor-only impact.