### PR TITLE
Stop `EOSConfigBuildValidator` running when `EOS_DISABLE` is defined.

### DIFF
--- a/Assets/Plugins/Source/Editor/Build/EOSConfigBuildValidator.cs
+++ b/Assets/Plugins/Source/Editor/Build/EOSConfigBuildValidator.cs
@@ -1,4 +1,5 @@
 using PlayEveryWare.EpicOnlineServices;
+using PlayEveryWare.EpicOnlineServices.Editor.Utility;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -110,6 +111,11 @@ public class EOSConfigBuildValidator : IPreprocessBuildWithReport
     /// <exception cref="BuildFailedException">An exception class that represents a failed build.</exception>
     public void OnPreprocessBuild(BuildReport report)
     {
+        if (ScriptingDefineUtility.IsEOSDisabled(report))
+        {
+            return;
+        }
+
         errorCode = ErrorCode.None;
         BuildTarget target = report.summary.platform;
         if (!PlatformManager.TryGetConfigFilePath(target, out string configFilePath))


### PR DESCRIPTION
This change stops `EOSConfigBuildValidator` from running when `EOS_DISABLE` is defined, for consistency with other pre-process scripts.