### PR TITLE
Update mobile overlay status

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -71,7 +71,7 @@ There are many EOS features that do not require your player to have an Epic Game
 
 Efforts will be made to add corresponding support to features as they are added to the Epic Online Services SDK. The table above reflects the features as of December 2025.
 
-[^2]: As of EOS SDK 1.18.1.2, only the Store Overlay is supported on mobile. The Social Overlay isn't supported. 
+[^2]: As of EOS Unity Plugin 4.1.0, only the Ecom Overlay is supported on mobile. The Social Overlay isn't supported on mobile.
 
 The mobile Epic Games Store is currently in closed beta. We’re excited to launch our self-publishing tools in the near future.
 Interested in joining our mobile store? Submit your game through our [Leads Intake form](https://e.acct.epicgames.com/click?EZWdzdG9yZS10ZWFtQGVwaWNnYW1lcy5jb20/CeyJtaWQiOiIxNzYzNTcxOTU3NDUzMTk2NTk2OGRjNzFiIiwiY3QiOiJlcGljLXR4LXByb2QtODI0ODA2ZmU0NDUwYjQ4ZTQ3MDVhODM3Y2Q4MzAwNGItMSIsInJkIjoiZXBpY2dhbWVzLmNvbSJ9/VaHR0cHM6Ly9mb3Jtcy51bnJlYWxlbmdpbmUuY29tL3MvZWdzLWxlYWQtaW50YWtlLWZvcm0/SWkhfYWNjdF9OTlRBTjExMTkyMDI1YzE4NjM3NjJiMQ/LYWUx/qP2xhbmd1YWdlPWVuX1VT/gaR35mw/JMTExOTIwMjVDMTg2Mzc2MkIx/s1v93de8f7c)

--- a/com.playeveryware.eos/Documentation~/android/README_Android.md
+++ b/com.playeveryware.eos/Documentation~/android/README_Android.md
@@ -22,7 +22,7 @@ You can follow the standard <a href="/com.playeveryware.eos/README.md#samples">S
 Please note the details in the <a href="#running-the-samples">Running the samples</a> section when running the samples from a build for Android.  
 
 > [!WARNING] 
-> The EOS Overlay is not implemented yet. When it is (due to the limitations of phones) the EOS Overlay will not be set to be openable by a physical button.
+> The Social Overlay is not implemented yet. However, the Ecom Overlay is supported on mobile as of EOS Unity Plugin 4.1.0.
 
 ## Running the samples
 

--- a/com.playeveryware.eos/Documentation~/eos_features.md
+++ b/com.playeveryware.eos/Documentation~/eos_features.md
@@ -38,5 +38,7 @@ There are many EOS features that do not require your player to have an Epic Game
 
 Efforts will be made to add corresponding support to features as they are added to the Epic Online Services SDK. The table above reflects the features as of December 2025.
 
-[^2]: As of EOS SDK 1.18.1.2, only the Store Overlay is supported on mobile. The Social Overlay isn't supported. The mobile Epic Games Store is currently in closed beta. We’re excited to launch our self-publishing tools in the near future.
+The mobile Epic Games Store is currently in closed beta. We’re excited to launch our self-publishing tools in the near future.
 Interested in joining our mobile store? Submit your game through our [Leads Intake form](https://e.acct.epicgames.com/click?EZWdzdG9yZS10ZWFtQGVwaWNnYW1lcy5jb20/CeyJtaWQiOiIxNzYzNTcxOTU3NDUzMTk2NTk2OGRjNzFiIiwiY3QiOiJlcGljLXR4LXByb2QtODI0ODA2ZmU0NDUwYjQ4ZTQ3MDVhODM3Y2Q4MzAwNGItMSIsInJkIjoiZXBpY2dhbWVzLmNvbSJ9/VaHR0cHM6Ly9mb3Jtcy51bnJlYWxlbmdpbmUuY29tL3MvZWdzLWxlYWQtaW50YWtlLWZvcm0/SWkhfYWNjdF9OTlRBTjExMTkyMDI1YzE4NjM3NjJiMQ/LYWUx/qP2xhbmd1YWdlPWVuX1VT/gaR35mw/JMTExOTIwMjVDMTg2Mzc2MkIx/s1v93de8f7c)
+
+[^2]: As of EOS Unity Plugin 4.1.0, only the Ecom Overlay is supported on mobile. The Social Overlay isn't supported on mobile.

--- a/com.playeveryware.eos/Documentation~/iOS/README_iOS.md
+++ b/com.playeveryware.eos/Documentation~/iOS/README_iOS.md
@@ -20,7 +20,7 @@ You can follow the standard <a href="/com.playeveryware.eos/README.md#importing-
 You can follow the standard <a href="/com.playeveryware.eos/README.md#samples">Samples</a> process. Please note the details in the <a href="#running-the-samples">Running the samples</a> section when running the samples from a build for iOS.
 
 > [!WARNING]
-> The EOS Overlay is not yet implemented for iOS.
+> The Social Overlay is not implemented yet. However, the Ecom Overlay is supported on mobile as of EOS Unity Plugin 4.1.0.
 
 ## Running the samples
 

--- a/com.playeveryware.eos/README.md
+++ b/com.playeveryware.eos/README.md
@@ -71,7 +71,7 @@ There are many EOS features that do not require your player to have an Epic Game
 
 Efforts will be made to add corresponding support to features as they are added to the Epic Online Services SDK. The table above reflects the features as of December 2025.
 
-[^2]: As of EOS SDK 1.18.1.2, only the Store Overlay is supported on mobile. The Social Overlay isn't supported. 
+[^2]: As of EOS Unity Plugin 4.1.0, only the Ecom Overlay is supported on mobile. The Social Overlay isn't supported on mobile.
 
 The mobile Epic Games Store is currently in closed beta. We’re excited to launch our self-publishing tools in the near future.
 Interested in joining our mobile store? Submit your game through our [Leads Intake form](https://e.acct.epicgames.com/click?EZWdzdG9yZS10ZWFtQGVwaWNnYW1lcy5jb20/CeyJtaWQiOiIxNzYzNTcxOTU3NDUzMTk2NTk2OGRjNzFiIiwiY3QiOiJlcGljLXR4LXByb2QtODI0ODA2ZmU0NDUwYjQ4ZTQ3MDVhODM3Y2Q4MzAwNGItMSIsInJkIjoiZXBpY2dhbWVzLmNvbSJ9/VaHR0cHM6Ly9mb3Jtcy51bnJlYWxlbmdpbmUuY29tL3MvZWdzLWxlYWQtaW50YWtlLWZvcm0/SWkhfYWNjdF9OTlRBTjExMTkyMDI1YzE4NjM3NjJiMQ/LYWUx/qP2xhbmd1YWdlPWVuX1VT/gaR35mw/JMTExOTIwMjVDMTg2Mzc2MkIx/s1v93de8f7c)


### PR DESCRIPTION
Updated docs to reflect Social Overlay not being available on mobile, but Ecom Overlay being available as of 4.1.0 (EOS SDK 1.17.1.3).