### PR TITLE
Update EOSHighFrequencyP2P.cs

### DIFF
--- a/Assets/Scripts/EOSHighFrequencyP2P.cs
+++ b/Assets/Scripts/EOSHighFrequencyP2P.cs
@@ -49,30 +49,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public bool sendActive = false;
         private List<float> dataDump;
         private const string CoordinateMessagePrefix = "m";
-
-        public static string SerializeCoordinatePacket(float x, float y)
-        {
-            // Coordinate packets are serialized as: "m<x>,<y>".
-            // The leading "m" identifies a coordinate message.
-            return string.Format(CultureInfo.InvariantCulture, "{0}{1},{2}", CoordinateMessagePrefix, x, y);
-        }
-
-        public static bool TryDeserializeCoordinatePacket(string packet, out float x, out float y)
-        {
-            x = 0f;
-            y = 0f;
-
-            if (string.IsNullOrEmpty(packet) || !packet.StartsWith(CoordinateMessagePrefix, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            // Remove the CoordinateMessagePrefix via Substring(1) before splitting "<x>,<y>".
-            string[] parts = packet.Substring(1).Split(',');
-            return parts.Length == 2
-                && float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out x)
-                && float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out y);
-        }
         
 #if UNITY_EDITOR
         void OnPlayModeChanged(UnityEditor.PlayModeStateChange modeChange)
@@ -421,6 +397,30 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             {
                 Debug.LogErrorFormat("P2p (OnIncomingConnectionRequest): error while accepting connection, code: {0}", result);
             }
+        }
+
+        public static string SerializeCoordinatePacket(float x, float y)
+        {
+            // Coordinate packets are serialized as: "m<x>,<y>".
+            // The leading "m" identifies a coordinate message.
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1},{2}", CoordinateMessagePrefix, x, y);
+        }
+
+        public static bool TryDeserializeCoordinatePacket(string packet, out float x, out float y)
+        {
+            x = 0f;
+            y = 0f;
+
+            if (string.IsNullOrEmpty(packet) || !packet.StartsWith(CoordinateMessagePrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // Remove the CoordinateMessagePrefix via Substring(1) before splitting "<x>,<y>".
+            string[] parts = packet.Substring(1).Split(',');
+            return parts.Length == 2
+                && float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out x)
+                && float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out y);
         }
     }
 }

--- a/Assets/Scripts/EOSHighFrequencyP2P.cs
+++ b/Assets/Scripts/EOSHighFrequencyP2P.cs
@@ -24,6 +24,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Text;
     using UnityEngine;
     using Epic.OnlineServices;
@@ -47,11 +48,31 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public bool sendActive = false;
         private List<float> dataDump;
-        // Coordinate packets are serialized as: "m<x>,<y>".
-        // The leading "m" identifies a coordinate message.
-        // The payload parser intentionally removes this prefix via Substring(1)
-        // before splitting the remaining "<x>,<y>" values.
-        public const string CoordinateMessagePrefix = "m";
+        private const string CoordinateMessagePrefix = "m";
+
+        public static string SerializeCoordinatePacket(float x, float y)
+        {
+            // Coordinate packets are serialized as: "m<x>,<y>".
+            // The leading "m" identifies a coordinate message.
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1},{2}", CoordinateMessagePrefix, x, y);
+        }
+
+        public static bool TryDeserializeCoordinatePacket(string packet, out float x, out float y)
+        {
+            x = 0f;
+            y = 0f;
+
+            if (string.IsNullOrEmpty(packet) || !packet.StartsWith(CoordinateMessagePrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // Remove the CoordinateMessagePrefix via Substring(1) before splitting "<x>,<y>".
+            string[] parts = packet.Substring(1).Split(',');
+            return parts.Length == 2
+                && float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out x)
+                && float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out y);
+        }
         
 #if UNITY_EDITOR
         void OnPlayModeChanged(UnityEditor.PlayModeStateChange modeChange)
@@ -313,34 +334,24 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                     Debug.LogWarning($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: Received an empty message.");
                     return null;
                 }
-                // Expected message format: <CoordinateMessagePrefix><x>,<y>
-                // The first character is a prefix used to identify coordinate update messages.
-                // We intentionally skip the prefix (Substring(1)) before splitting the payload
-                // so only the numeric coordinate data is parsed.
-                else if (message.StartsWith(CoordinateMessagePrefix))
+                else if (TryDeserializeCoordinatePacket(message, out float xPos, out float yPos))
                 {
-                    string[] parts = message.Substring(1).Split(',');
-                    if (parts.Length == 2 &&
-                        int.TryParse(parts[0], out int xPos) &&
-                        int.TryParse(parts[1], out int yPos))
+                    Debug.Log($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: Particle coordinates received: x={xPos}, y={yPos}");
+
+                    if (owner != null && owner.ParticleManager != null)
                     {
-                        Debug.Log($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: Particle coordinates received: x={xPos}, y={yPos}");
-
-                        if (owner != null && owner.ParticleManager != null)
-                        {
-                            owner.ParticleManager.SpawnParticles(xPos, yPos);
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: ParticleManager or owner reference is missing.");
-                        }
-
-                        return peerId;
+                        owner.ParticleManager.SpawnParticles(xPos, yPos);
                     }
                     else
                     {
-                        Debug.LogWarning($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: Malformed coordinate message received.");
+                        Debug.LogWarning($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: ParticleManager or owner reference is missing.");
                     }
+
+                    return peerId;
+                }
+                else if (message.StartsWith(CoordinateMessagePrefix, StringComparison.Ordinal))
+                {
+                    Debug.LogWarning($"{nameof(EOSHighFrequencyPeer2PeerManager)} {nameof(HandleReceivedMessages)}: Malformed coordinate message received.");
                 }
             }
             return null;

--- a/Assets/Scripts/EOSHighFrequencyP2P.cs
+++ b/Assets/Scripts/EOSHighFrequencyP2P.cs
@@ -47,6 +47,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public bool sendActive = false;
         private List<float> dataDump;
+        // Coordinate packets are serialized as: "m<x>,<y>".
+        // The leading "m" identifies a coordinate message.
+        // The payload parser intentionally removes this prefix via Substring(1)
+        // before splitting the remaining "<x>,<y>" values.
         public const string CoordinateMessagePrefix = "m";
         
 #if UNITY_EDITOR

--- a/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
@@ -324,12 +324,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             Debug.Log($"{nameof(UIHighFrequencyPeer2PeerMenu)} {nameof(ParticlesOnClick)} Mouse click received");
             Vector3 mousePos = Input.mousePosition;
             Vector3 viewportPos = uiCamera.ScreenToViewportPoint(mousePos);
-            messageData message;
-            message.type = messageType.coordinatesMessage;
-            message.xPos = viewportPos.x;
-            message.yPos = viewportPos.y;
-            message.textData = null;
-            string coordinatePayload = EOSHighFrequencyPeer2PeerManager.CoordinateMessagePrefix + message.xPos + "," + message.yPos;
+            string coordinatePayload = EOSHighFrequencyPeer2PeerManager.SerializeCoordinatePacket(viewportPos.x, viewportPos.y);
             Peer2PeerManager.SendMessage(currentChatProductUserId, coordinatePayload);
         }
         private bool HasValidCurrentProductId()


### PR DESCRIPTION
- Documents why the first character is stripped before parsing
- Reduces ambiguity for future maintainers
- Improves clarity around HighFrequency P2P coordinate message format