### PR TITLE
eosu 1130 Fix(high-frequency-p2p): avoid toggle send without selected peer

### DIFF
--- a/Assets/Scripts/EOSHighFrequencyP2P.cs
+++ b/Assets/Scripts/EOSHighFrequencyP2P.cs
@@ -166,7 +166,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
 
         public void SendMessage(ProductUserId friendId, string message)
         {
-            if (!friendId.IsValid())
+            if (friendId == null || !friendId.IsValid())
             {
                 Debug.LogError("EOS P2PNAT SendMessage: bad input data: account id is wrong.");
                 return;

--- a/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Peer2Peer/HighFrequency/UIHighFrequencyPeer2PeerMenu.cs
@@ -79,6 +79,12 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             if (Peer2PeerManager != null)
             {
+                if (!Peer2PeerManager.sendActive &&
+                    (currentChatProductUserId == null || !currentChatProductUserId.IsValid()))
+                {
+                    Debug.LogWarning($"{nameof(UIHighFrequencyPeer2PeerMenu)} {nameof(ToggleHighFrequencySending)}: Select a valid peer before enabling high-frequency sending.");
+                    return;
+                }
                 Peer2PeerManager.sendActive = !Peer2PeerManager.sendActive;
             }
         }


### PR DESCRIPTION
- Block enabling high-frequency sending when no valid peer is selected
- Add null-safe guard in SendMessage for missing ProductUserId
- Prevent runtime errors when toggling send without an active connection