### PR TITLE
Fix for ClientSessionTests FindByBucketIdAndJoin

### DIFF
--- a/Assets/Tests/Common/TestCommon.cs
+++ b/Assets/Tests/Common/TestCommon.cs
@@ -52,7 +52,7 @@ namespace PlayEveryWare.EpicOnlineServices.Tests
         public const string SearchBucketIdKey = "bucket";
         public const string LobbyBucketId = "TestServerLobbyBucket";
         public const string LobbyPrivateBucketId = "TestServerPrivateLobbyBucket";
-        public const string SessionBucketId = "TestServerSessionBucket";
+        public const string SessionBucketId = "SessionSample:Region";
         public const string SessionPrivateBucketId = "TestServerPrivateSessionBucket";
         public const string SessionName = "TestServerSession";
         public const string SessionPrivateName = "TestServerPrivateSession";


### PR DESCRIPTION
- Update SessionBucketId in TestCommon to match the default bucket ID used by the sample app (SessionSample:Region)
- UnitTest passed after creating a public session in a standalone client