### PR TITLE
eosu-1026 Fix achievements failing after auth token expiration

### DIFF
--- a/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
+++ b/Assets/Scripts/StandardSamples/Services/AchievementsService.cs
@@ -130,11 +130,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </summary>
         protected async override Task InternalRefreshAsync()
         {
-            if (!TryGetProductUserId(out ProductUserId productUser)) 
+            if (!TryGetProductUserId(out ProductUserId productUserId))
             {
                 return;
             }
-            ProductUserId productUserId = EOSManager.Instance.GetProductUserId();
             _achievements = await QueryAchievementsAsync(productUserId);
 
             // If the user is not in the list, then add it.
@@ -176,14 +175,15 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// </param>
         private async Task RefreshPlayerAchievementsAsync(ProductUserId productUserId)
         {
-            var playerAchievements = await QueryPlayerAchievementsAsync(productUserId);
+            var (_, playerAchievements) = await ExecuteWithAuthRetryAsync(
+                userId => QueryPlayerAchievementsAsync(userId));
 
             // TODO: In the lambda function to update achievements, the
             //       achievements could be inspected for equality. If it is
             //       determined they have not changed, then NotifyUpdated()
             //       would not need to be called.
-            _playerAchievements.AddOrUpdate(productUserId, playerAchievements, 
-                (id, previousPlayerAchievements) => playerAchievements);
+            _playerAchievements.AddOrUpdate(productUserId, playerAchievements,
+                (id, _) => playerAchievements);
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <returns>
         /// List of PlayerAchievement objects.
         /// </returns>
-        private Task<List<PlayerAchievement>> QueryPlayerAchievementsAsync(ProductUserId productUserId)
+        private Task<(Result ResultCode, List<PlayerAchievement> Achievements)> QueryPlayerAchievementsAsync(ProductUserId productUserId)
         {
             Log($"Begin query player achievements for {ProductUserIdToString(productUserId)}");
 
@@ -295,18 +295,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 TargetUserId = productUserId
             };
 
-            TaskCompletionSource<List<PlayerAchievement>> tcs = new();
+            TaskCompletionSource<(Result ResultCode, List<PlayerAchievement> Achievements)> tcs = new();
 
             GetEOSAchievementInterface().QueryPlayerAchievements(ref options, null, (ref OnQueryPlayerAchievementsCompleteCallbackInfo data) =>
             {
                 if (data.ResultCode != Result.Success)
                 {
                     Log($"Error querying player achievements. Result code: {data.ResultCode}");
-                    tcs.SetResult(new List<PlayerAchievement>());
+                    tcs.SetResult((data.ResultCode, new List<PlayerAchievement>()));
                 }
                 else
                 {
-                    tcs.SetResult(GetCachedPlayerAchievements(productUserId));
+                    tcs.SetResult((Result.Success, GetCachedPlayerAchievements(productUserId)));
                 }
             });
 
@@ -500,7 +500,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         /// <param name="achievementId">
         /// The id of the achievement to unlock for the current player.
         /// </param>
-        public Task<PlayerAchievement> UnlockAchievementAsync(string achievementId)
+        public async Task<PlayerAchievement> UnlockAchievementAsync(string achievementId)
         {
             DefinitionV2? definition = null;
             for (int i = 0; i < _achievements.Count; i++)
@@ -514,58 +514,64 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
             }
 
             if (!definition.HasValue)
-            {
-                return Task.FromException<PlayerAchievement>(new Exception($"Achievement definition not found for ID: {achievementId}"));
-            }
+                throw new ArgumentException($"Achievement definition not found for ID: {achievementId}");
 
-            var localUserId = EOSManager.Instance.GetProductUserId();
-            var eosAchievementOption = new UnlockAchievementsOptions
+            var (resultCode, achievement) = await ExecuteWithAuthRetryAsync(
+                userId => DoUnlockAchievementAsync(userId, definition.Value));
+
+            if (resultCode != Result.Success)
+                throw new Exception($"Could not unlock achievement. Error code: {Enum.GetName(typeof(Result), resultCode)}");
+
+            return achievement;
+        }
+
+        private Task<(Result ResultCode, PlayerAchievement Achievement)> DoUnlockAchievementAsync(
+            ProductUserId userId, DefinitionV2 definition)
+        {
+            if (userId == null || !userId.IsValid())
+                return Task.FromResult((Result.InvalidUser, default(PlayerAchievement)));
+
+            var options = new UnlockAchievementsOptions
             {
-                UserId = localUserId,
-                AchievementIds = new Utf8String[] { definition.Value.AchievementId }
+                UserId = userId,
+                AchievementIds = new Utf8String[] { definition.AchievementId }
             };
 
-            var tcs = new TaskCompletionSource<PlayerAchievement>();
+            var tcs = new TaskCompletionSource<(Result, PlayerAchievement)>();
 
-            GetEOSAchievementInterface().UnlockAchievements(ref eosAchievementOption, null,
+            GetEOSAchievementInterface().UnlockAchievements(ref options, null,
                 (ref OnUnlockAchievementsCompleteCallbackInfo data) =>
                 {
                     if (data.ResultCode != Result.Success)
                     {
-                        tcs.SetException(new Exception($"Could not unlock achievement. Error code: {Enum.GetName(typeof(Result), data.ResultCode)}"));
+                        tcs.SetResult((data.ResultCode, default));
                     }
                     else
                     {
-                        var achievement = new PlayerAchievement()
+                        var achievement = new PlayerAchievement
                         {
-                            AchievementId = definition.Value.AchievementId,
-                            DisplayName = definition.Value.UnlockedDisplayName,
-                            Description = definition.Value.UnlockedDescription,
-                            Progress = 1.0,
-                            UnlockTime = DateTime.UtcNow,
-                            StatInfo = null
+                            AchievementId = definition.AchievementId,
+                            DisplayName   = definition.UnlockedDisplayName,
+                            Description   = definition.UnlockedDescription,
+                            Progress      = 1.0,
+                            UnlockTime    = DateTime.UtcNow,
+                            StatInfo      = null
                         };
 
-                        _playerAchievements.AddOrUpdate(localUserId,
+                        _playerAchievements.AddOrUpdate(userId,
                             new List<PlayerAchievement> { achievement },
                             (id, list) =>
                             {
                                 int index = list.FindIndex(a => a.AchievementId == achievement.AchievementId);
                                 if (index >= 0)
-                                {
                                     list[index] = achievement;
-                                }
                                 else
-                                {
                                     list.Add(achievement);
-                                }
                                 return list;
                             });
 
-                        NotifyUpdated(); 
-
-                        tcs.SetResult(achievement);
-
+                        NotifyUpdated();
+                        tcs.SetResult((Result.Success, achievement));
                     }
                 });
 

--- a/Assets/Scripts/StandardSamples/Services/EOSService.cs
+++ b/Assets/Scripts/StandardSamples/Services/EOSService.cs
@@ -25,6 +25,7 @@ namespace PlayEveryWare.EpicOnlineServices
 {
     using Epic.OnlineServices;
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -217,6 +218,80 @@ namespace PlayEveryWare.EpicOnlineServices
         protected void NotifyUpdated()
         {
             Updated?.Invoke();
+        }
+
+        /// <summary>
+        /// Returns true when the given EOS result code indicates a transient
+        /// auth connection failure that warrants a single retry after reconnect.
+        /// </summary>
+        protected static bool ShouldRetryAfterReconnect(Result resultCode)
+        {
+            return resultCode == Result.AuthExpired
+                || resultCode == Result.ConnectAuthExpired
+                || resultCode == Result.InvalidAuth
+                || resultCode == Result.InvalidUser;
+        }
+
+        /// <summary>
+        /// Executes the given EOS operation with a valid ProductUserId,
+        /// automatically waiting for re-authentication and retrying once if a
+        /// transient auth connection failure is detected.
+        /// </summary>
+        protected async Task<(Result ResultCode, T Value)> ExecuteWithAuthRetryAsync<T>(
+            Func<ProductUserId, Task<(Result ResultCode, T Value)>> operation)
+        {
+            var userId = EOSManager.Instance.GetProductUserId();
+            if (userId == null || !userId.IsValid())
+            {
+                await WhenAuthenticatedAsync();
+                userId = EOSManager.Instance.GetProductUserId();
+            }
+
+            var (resultCode, value) = await operation(userId);
+
+            if (ShouldRetryAfterReconnect(resultCode))
+            {
+                await WhenAuthenticatedAsync();
+                userId = EOSManager.Instance.GetProductUserId();
+                if (userId != null && userId.IsValid())
+                    (resultCode, value) = await operation(userId);
+            }
+
+            return (resultCode, value);
+        }
+
+        /// <summary>
+        /// Returns a Task that completes the next time a user successfully
+        /// authenticates. Useful for retrying EOS operations that failed due to
+        /// a transient auth connection failure while a proactive token refresh
+        /// was in progress.
+        /// </summary>
+        /// <param name="timeoutMs">
+        /// Maximum time to wait for re-authentication in milliseconds (default 30 s).
+        /// Throws <see cref="TimeoutException"/> if the deadline is exceeded.
+        /// </param>
+        protected async Task WhenAuthenticatedAsync(int timeoutMs = 30_000)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            void OnChanged(bool authenticated, AuthenticationListener.LoginChangeKind changeType)
+            {
+                if (!authenticated)
+                    return;
+
+                AuthenticationListener.Instance.AuthenticationChanged -= OnChanged;
+                tcs.TrySetResult(true);
+            }
+
+            using var cts = new CancellationTokenSource(timeoutMs);
+            cts.Token.Register(() =>
+            {
+                AuthenticationListener.Instance.AuthenticationChanged -= OnChanged;
+                tcs.TrySetException(new TimeoutException("Timed out waiting for re-authentication."));
+            });
+
+            AuthenticationListener.Instance.AuthenticationChanged += OnChanged;
+            await tcs.Task;
         }
     }
 }

--- a/Assets/Scripts/StandardSamples/UI/Achievements/UIAchievementsMenu.cs
+++ b/Assets/Scripts/StandardSamples/UI/Achievements/UIAchievementsMenu.cs
@@ -142,7 +142,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 }
 
                 var userId = EOSManager.Instance.GetProductUserId();
-                if (userId.IsValid())
+                if (userId != null && userId.IsValid())
                 {
                     foreach (var playerAch in AchievementsService.Instance.CachedPlayerAchievements(userId))
                     {
@@ -253,8 +253,17 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         //Show player-specific achievement data
         void DisplayPlayerAchievement(DefinitionV2 definition)
         {
+            var productUserId = EOSManager.Instance.GetProductUserId();
+            if (productUserId == null || !productUserId.IsValid())
+            {
+                definitionsDescription.text = "Player achievement data unavailable: user is not connected.";
+                definitionsDescription.gameObject.SetActive(true);
+                unlockAchievementButton.interactable = false;
+                return;
+            }
+
             PlayerAchievement? achievementNullable = null;
-            foreach (var ach in AchievementsService.Instance.CachedPlayerAchievements(EOSManager.Instance.GetProductUserId()))
+            foreach (var ach in AchievementsService.Instance.CachedPlayerAchievements(productUserId))
             {
                 if (ach.AchievementId == definition.AchievementId)
                 {


### PR DESCRIPTION
--Context--
The previous approach fixed the symptom inside the service by duplicating existing infrastructure and adding unnecessary cost. The new approach relies on what the SDK already provides, centralizes the logic in the base class, and lets each EOS method focus only on its own responsibility.

Add auth retry mechanism to EOSService base class so achievement operations automatically recover from transient authentication failures (AuthExpired, ConnectAuthExpired, InvalidAuth, InvalidUser).

- Add ExecuteWithAuthRetryAsync<T> to wrap EOS calls with a single retry after re-authentication
- Add WhenAuthenticatedAsync to await the next successful login event
- Refactor AchievementsService to use ExecuteWithAuthRetryAsync for QueryPlayerAchievementsAsync and unlock operations
- Fix null check on userId in UIAchievementsMenu before calling IsValid()