### PR TITLE
Eosu 404 auth token reauth p2p disconnects v3

### DIFF
--- a/Assets/Scripts/EOSPeer2PeerManager.cs
+++ b/Assets/Scripts/EOSPeer2PeerManager.cs
@@ -85,6 +85,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         private P2PInterface P2PHandle;
 
         private ulong ConnectionNotificationId;
+        private ulong ConnectionEstablishedNotificationId;
+        private ulong ConnectionInterruptedNotificationId;
         private Dictionary<ProductUserId, ChatWithFriendData> ChatDataCache;
         private bool ChatDataCacheDirty;
 
@@ -144,12 +146,20 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         {
             SubscribeToConnectionRequest();
 
-            var options = new AddNotifyPeerConnectionEstablishedOptions
-            {
-                LocalUserId = EOSManager.Instance.GetProductUserId() 
-            };
+            var localUserId = EOSManager.Instance.GetProductUserId();
 
-            P2PHandle.AddNotifyPeerConnectionEstablished(ref options, null, OnPeerConnectionEstablished);
+            var establishedOptions = new AddNotifyPeerConnectionEstablishedOptions
+            {
+                LocalUserId = localUserId
+            };
+            ConnectionEstablishedNotificationId = P2PHandle.AddNotifyPeerConnectionEstablished(ref establishedOptions, null, OnPeerConnectionEstablished);
+
+            var interruptedOptions = new AddNotifyPeerConnectionInterruptedOptions
+            {
+                LocalUserId = localUserId,
+                SocketId = null
+            };
+            ConnectionInterruptedNotificationId = P2PHandle.AddNotifyPeerConnectionInterrupted(ref interruptedOptions, null, OnPeerConnectionInterrupted);
 
             Debug.Log("EOSPeer2PeerManager initialized: connection listeners registered.");
         }
@@ -188,6 +198,18 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         public void OnLoggedOut()
         {
             UnsubscribeFromConnectionRequests();
+
+            if (ConnectionEstablishedNotificationId != 0)
+            {
+                P2PHandle.RemoveNotifyPeerConnectionEstablished(ConnectionEstablishedNotificationId);
+                ConnectionEstablishedNotificationId = 0;
+            }
+
+            if (ConnectionInterruptedNotificationId != 0)
+            {
+                P2PHandle.RemoveNotifyPeerConnectionInterrupted(ConnectionInterruptedNotificationId);
+                ConnectionInterruptedNotificationId = 0;
+            }
         }
 
         private void OnRefreshNATTypeFinished(ref OnQueryNATTypeCompleteInfo data)
@@ -533,7 +555,7 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
         }
         private void OnPeerConnectionEstablished(ref OnPeerConnectionEstablishedInfo info)
         {
-            Debug.Log($"[P2P] Connection established with {LoggingUtils.Redact(info.RemoteUserId)}");
+            Debug.Log($"[P2P] Connection established with {LoggingUtils.Redact(info.RemoteUserId)} | type={info.ConnectionType} network={info.NetworkType}");
 
             if (!connectionStates.ContainsKey(info.RemoteUserId))
             {
@@ -541,6 +563,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples
                 SendHandshakeRequest(info.RemoteUserId);
                 connectionStates[info.RemoteUserId] = PeerConnectionAppState.HandshakePending;
             }
+        }
+
+        private void OnPeerConnectionInterrupted(ref OnPeerConnectionInterruptedInfo info)
+        {
+            Debug.LogWarning($"[P2P] Connection interrupted with {LoggingUtils.Redact(info.RemoteUserId)} on socket '{info.SocketId?.SocketName}' - EOS will attempt auto-recovery");
         }
         public void SendTrigger(ProductUserId peerId)
         {

--- a/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
+++ b/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
@@ -254,6 +254,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
         private const byte ConnectionConfirmationChannel = byte.MaxValue;
 
+        private ulong ConnectionEstablishedNotificationsId = 0;
+        
+        private ulong ConnectionInterruptedNotificationsId = 0;
+
         [System.Diagnostics.Conditional("EOS_TRANSPORTMANAGER_DEBUG")]
         private void Log(string msg)
         {
@@ -445,10 +449,10 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             Log($"EOSTransportManager.Shutdown: Shutting down EOSTransportManager... | EOSTransportManager={GetDebugString()}");
             CloseAllConnections();
+            UnsubscribeFromConnectionInterruptedNotifications();
+            UnsubscribeFromConnectionEstablishedNotifications();
             UnsubscribeFromConnectionClosedNotifications();
             UnsubscribeFromConnectionRequestNotifications();
-            UnsubscribeFromConnectionEstablishedNotifications();
-            UnsubscribeFromConnectionInterruptedNotifications();
             Clear();
 
 #if UNITY_EDITOR
@@ -1354,8 +1358,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             CloseConnection(remoteUserId, socketName, true);
         }
 
-        private ulong ConnectionEstablishedNotificationsId = 0;
-
         private void SubscribeToConnectionEstablishedNotifications()
         {
             var options = new AddNotifyPeerConnectionEstablishedOptions()
@@ -1369,7 +1371,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
         private void UnsubscribeFromConnectionEstablishedNotifications()
         {
-            P2PHandle?.RemoveNotifyPeerConnectionEstablished(ConnectionEstablishedNotificationsId);
+            if (ConnectionEstablishedNotificationsId != 0)
+            {
+                P2PHandle?.RemoveNotifyPeerConnectionEstablished(ConnectionEstablishedNotificationsId);
+                ConnectionEstablishedNotificationsId = 0;
+            }
         }
 
         private void OnConnectionEstablishedNotification(ref OnPeerConnectionEstablishedInfo data)
@@ -1378,8 +1384,6 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             Log($"EOSTransportManager.OnConnectionEstablishedNotification: Connection established with remote peer '{LoggingUtils.Redact(data.RemoteUserId)}' " +
                 $"on socket '{data.SocketId?.SocketName}' | type={data.ConnectionType} network={data.NetworkType}");
         }
-
-        private ulong ConnectionInterruptedNotificationsId = 0;
 
         private void SubscribeToConnectionInterruptedNotifications()
         {
@@ -1394,7 +1398,11 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
         private void UnsubscribeFromConnectionInterruptedNotifications()
         {
-            P2PHandle?.RemoveNotifyPeerConnectionInterrupted(ConnectionInterruptedNotificationsId);
+            if (ConnectionInterruptedNotificationsId != 0)
+            {
+                P2PHandle?.RemoveNotifyPeerConnectionInterrupted(ConnectionInterruptedNotificationsId);
+                ConnectionInterruptedNotificationsId = 0;
+            }
         }
 
         private void OnConnectionInterruptedNotification(ref OnPeerConnectionInterruptedInfo data)

--- a/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
+++ b/Assets/Scripts/P2PNetcodeSample/Networking/EOSTransportManager.cs
@@ -424,6 +424,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
                 IsInitialized = true;
                 SubscribeToConnectionRequestNotifications();
                 SubscribeToConnectionClosedNotifications();
+                SubscribeToConnectionEstablishedNotifications();
+                SubscribeToConnectionInterruptedNotifications();
                 QueryNATType();
             }
 
@@ -445,6 +447,8 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
             CloseAllConnections();
             UnsubscribeFromConnectionClosedNotifications();
             UnsubscribeFromConnectionRequestNotifications();
+            UnsubscribeFromConnectionEstablishedNotifications();
+            UnsubscribeFromConnectionInterruptedNotifications();
             Clear();
 
 #if UNITY_EDITOR
@@ -1348,6 +1352,56 @@ namespace PlayEveryWare.EpicOnlineServices.Samples.Network
 
             // Force close (from incoming direction)
             CloseConnection(remoteUserId, socketName, true);
+        }
+
+        private ulong ConnectionEstablishedNotificationsId = 0;
+
+        private void SubscribeToConnectionEstablishedNotifications()
+        {
+            var options = new AddNotifyPeerConnectionEstablishedOptions()
+            {
+                LocalUserId = LocalUserId,
+                SocketId = null,
+            };
+
+            ConnectionEstablishedNotificationsId = P2PHandle.AddNotifyPeerConnectionEstablished(ref options, null, OnConnectionEstablishedNotification);
+        }
+
+        private void UnsubscribeFromConnectionEstablishedNotifications()
+        {
+            P2PHandle?.RemoveNotifyPeerConnectionEstablished(ConnectionEstablishedNotificationsId);
+        }
+
+        private void OnConnectionEstablishedNotification(ref OnPeerConnectionEstablishedInfo data)
+        {
+            Debug.Assert(data.LocalUserId == LocalUserId);
+            Log($"EOSTransportManager.OnConnectionEstablishedNotification: Connection established with remote peer '{LoggingUtils.Redact(data.RemoteUserId)}' " +
+                $"on socket '{data.SocketId?.SocketName}' | type={data.ConnectionType} network={data.NetworkType}");
+        }
+
+        private ulong ConnectionInterruptedNotificationsId = 0;
+
+        private void SubscribeToConnectionInterruptedNotifications()
+        {
+            var options = new AddNotifyPeerConnectionInterruptedOptions()
+            {
+                LocalUserId = LocalUserId,
+                SocketId = null,
+            };
+
+            ConnectionInterruptedNotificationsId = P2PHandle.AddNotifyPeerConnectionInterrupted(ref options, null, OnConnectionInterruptedNotification);
+        }
+
+        private void UnsubscribeFromConnectionInterruptedNotifications()
+        {
+            P2PHandle?.RemoveNotifyPeerConnectionInterrupted(ConnectionInterruptedNotificationsId);
+        }
+
+        private void OnConnectionInterruptedNotification(ref OnPeerConnectionInterruptedInfo data)
+        {
+            Debug.Assert(data.LocalUserId == LocalUserId);
+            LogWarning($"EOSTransportManager.OnConnectionInterruptedNotification: Connection interrupted with remote peer '{LoggingUtils.Redact(data.RemoteUserId)}' " +
+                       $"on socket '{data.SocketId?.SocketName}' - EOS will attempt auto-recovery");
         }
 
         public bool StartHost()

--- a/com.playeveryware.eos/Runtime/Core/EOSManager.cs
+++ b/com.playeveryware.eos/Runtime/Core/EOSManager.cs
@@ -1378,6 +1378,18 @@ namespace PlayEveryWare.EpicOnlineServices
                     ulong callbackHandle = EOSConnectInterface.AddNotifyAuthExpiration(
                         ref addNotifyAuthExpirationOptions, null, (ref AuthExpirationCallbackInfo callbackInfo) =>
                         {
+                            if (connectLoginOptions.Credentials.HasValue &&
+                                connectLoginOptions.Credentials.Value.Type == ExternalCredentialType.EpicIdToken)
+                            {
+                                var epicAccountId = GetLocalUserId();
+                                if (epicAccountId != null && epicAccountId.IsValid())
+                                {
+                                    // connectLoginOptions captures the JWT string from initial login; by expiration
+                                    // time that JWT is also stale. Fetch a fresh one from the Auth interface instead.
+                                    StartConnectLoginWithEpicAccount(epicAccountId, null);
+                                    return;
+                                }
+                            }
                             StartConnectLoginWithOptions(connectLoginOptions, null);
                         });
 


### PR DESCRIPTION
Fix auth token re-auth and add P2P connection state callbacks

--Context--
The issue that motivated this PR is related to token re-authentication during the session. The logs show many EOS_InvalidAuth errors, followed by a successful UpdateUserAuthToken and then Login complete: EOS_Success.
The root cause was that the refresh flow is not calling EOS_Connect_Login with the renewed token before it expires. This suggests that the SDK is refreshing too late, or that the AddNotifyAuthExpiration callback is not being handled correctly to anticipate the expiration.
However, based on the latest comment, this seems to be a different issue. I ran tests using a VPN but could not reproduce it. In this case, the TURN/relay server assigned by EOS for the GE <> NL region could not be reached by both peers. The server reporting a NAT type of “Unknown” is a red flag, as it may be behind a symmetric NAT or have firewall restrictions that prevent TURN from working correctly.
For this second scenario, I only added extra code in EOSTransportManager. The Initialize() method was not registering AddNotifyPeerConnectionEstablished or AddNotifyPeerConnectionInterrupted. Without these callbacks, failures happen silently, with no diagnostics or recovery.

- Fix Connect re-authentication using a stale JWT when the EOS Connect token expires mid-session. The expiration callback was reusing the JWT string captured at login time, which is also expired by the time the callback fires. Now fetches a fresh JWT via CopyIdToken for EpicIdToken credentials.

- Add AddNotifyPeerConnectionEstablished and AddNotifyPeerConnectionInterrupted callbacks to EOSTransportManager and EOSPeer2PeerManager. Both managers were missing the interrupted callback entirely, and EOSPeer2PeerManager was discarding the established callback handle (preventing cleanup on logout). Connection logs now include network type (direct vs relay) to aid diagnosis of P2P connectivity issues between specific player pairs.