### PR TITLE
Chore/eos sdk 1.19.1.2 build arm64 native libs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,7 +27,6 @@ etc\PlatformSpecificAssets\EOS\Mac\eac_launcher.app\Contents\_CodeSignature\Code
 *.gif   binary
 *.icns	binary
 *.jpg   binary
-*.lib   binary
 *.png   binary
 *.so    binary
 *.ttf   binary
@@ -40,7 +39,6 @@ etc\PlatformSpecificAssets\EOS\Mac\eac_launcher.app\Contents\_CodeSignature\Code
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.icns filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.lib filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.so filter=lfs diff=lfs merge=lfs -text
 *.ttf filter=lfs diff=lfs merge=lfs -text

--- a/Assets/Plugins/Windows/ARM64/DynamicLibraryLoaderHelper-ARM64.dll
+++ b/Assets/Plugins/Windows/ARM64/DynamicLibraryLoaderHelper-ARM64.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:975d1725c1b82d61747abbf10a98b3cc32e9fa475e28a6f53d28cf95a59b238b
+oid sha256:d8b8b5b5e0c78a48ad25ad1645846b2881fd59d22695000cc7048d281ddfb971
 size 116736

--- a/Assets/Plugins/Windows/ARM64/EOSSDK-Win64-Shippingarm64.lib
+++ b/Assets/Plugins/Windows/ARM64/EOSSDK-Win64-Shippingarm64.lib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b77b3dbdfe5148eba7a325804c9193a54a0908aa568efc57ce1cc9f72a349fa
-size 217088

--- a/Assets/Plugins/Windows/ARM64/EOSSDK-Win64-Shippingarm64.lib.meta
+++ b/Assets/Plugins/Windows/ARM64/EOSSDK-Win64-Shippingarm64.lib.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: cc7b4ea769b94a92abacaedd36005f35
-DefaultImporter:
-  externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:

--- a/Assets/Plugins/Windows/ARM64/GfxPluginNativeRender-ARM64.dll
+++ b/Assets/Plugins/Windows/ARM64/GfxPluginNativeRender-ARM64.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c23af8b5033562892bbb9c91e6b095a153b49ec0ec60e23d6ffa573969ba96fc
+oid sha256:71f47c21a7a0e2564abf33ecbf1e679f00137339840e768239a8c8c700983993
 size 614912

--- a/Assets/Plugins/Windows/x64/DynamicLibraryLoaderHelper-x64.dll
+++ b/Assets/Plugins/Windows/x64/DynamicLibraryLoaderHelper-x64.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5b052459dc14cbf7bc173f49e2a2409b560938cd2e5853289f32e15e8be6cb0
+oid sha256:fa0f6de63dea13bbeba84ef593fdf761f903a24d3eabd32537bff450df97be9e
 size 137216

--- a/Assets/Plugins/Windows/x64/GfxPluginNativeRender-x64.dll
+++ b/Assets/Plugins/Windows/x64/GfxPluginNativeRender-x64.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8866bb7a6497247784d29cb12dc4f25cacba89aca9fea9880a46ef7b1be1969a
+oid sha256:69ab51e92b3c4f028a2dc4ed7e88170f5cdd4e579a47ea1e2c24ec1d73a61399
 size 589824


### PR DESCRIPTION
- Builds Windows native libs for x64 and the new ARM64
- Removes ARM64 lib