### PR TITLE
Fixes files copied by mistake in package generator configuration file

### DIFF
--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -36,7 +36,8 @@
       {"src": "Assets/Plugins/Windows/*",                           "dest": "Runtime/Windows/", "recursive": true },
       {"src": "Assets/Plugins/Linux/*",                             "dest": "Runtime/Linux/",   "recursive": true },
       {"src": "Assets/Plugins/macOS/*",                             "dest": "Runtime/macOS/",   "recursive": true },
-      {"src": "Assets/Plugins/Android/*",                           "dest": "Runtime/Android/", "recursive": true },
+      {"src": "Assets/Plugins/Android/*",                           "dest": "Runtime/Android/", "recursive": false },
+      {"src": "Assets/Plugins/Android/Core/*",                      "dest": "Runtime/Android/Core/", "recursive": true },
       {"src": "Assets/Plugins/iOS/*",                               "dest": "Runtime/iOS/",     "recursive": true },
                          
       {"src": "Assets/link.xml",                                    "dest": "Editor/"  },

--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -1,7 +1,8 @@
 {
   "source_to_dest": [
 
-      {"src": "etc/PlatformSpecificAssets/EOS/*",                   "dest": "PlatformSpecificAssets~/EOS/", "recursive": true },
+      {"ignore_regex": "gitignore"},
+      {"src": "etc/PlatformSpecificAssets/EOS/*",                   "dest": "PlatformSpecificAssets~/EOS/", "recursive": true},
       {"src": "tools/bin/EOSBootstrapperTool.exe",                  "dest": "bin~/"             },
       {"src": "tools/bin/EOSBootstrapper.exe",                      "dest": "bin~/"             },
       {"src": "tools/bin/EAC/Windows/anticheat_integritytool.exe",  "dest": "bin~/EAC/Windows/" },

--- a/etc/PackageConfigurations/eos_package_description.json
+++ b/etc/PackageConfigurations/eos_package_description.json
@@ -1,8 +1,8 @@
 {
   "source_to_dest": [
 
-      {"ignore_regex": "gitignore"},
-      {"src": "etc/PlatformSpecificAssets/EOS/*",                   "dest": "PlatformSpecificAssets~/EOS/", "recursive": true},
+      {"ignore_regex": "gitignore" },
+      {"src": "etc/PlatformSpecificAssets/EOS/*",                   "dest": "PlatformSpecificAssets~/EOS/", "recursive": true },
       {"src": "tools/bin/EOSBootstrapperTool.exe",                  "dest": "bin~/"             },
       {"src": "tools/bin/EOSBootstrapper.exe",                      "dest": "bin~/"             },
       {"src": "tools/bin/EAC/Windows/anticheat_integritytool.exe",  "dest": "bin~/EAC/Windows/" },


### PR DESCRIPTION
- Package generator copied .gitignore files in the project.
- Inside folder `Assets/Plugins/Android/` there are two additional folders that do not need to be copied in the package 